### PR TITLE
Refactor and fix DB manager

### DIFF
--- a/backend/src/api/VoteController.ts
+++ b/backend/src/api/VoteController.ts
@@ -60,11 +60,10 @@ export default class VoteController {
                 vote = 0;
             }
 
-            let currentVoteResult = await this.db.execute('select * from post_votes where post_id=:post_id and voter_id=:voter_id', {
+            const currentVote:RawPostVote = await this.db.fetchOne('select * from post_votes where post_id=:post_id and voter_id=:voter_id', {
                 post_id: id,
                 voter_id: userId
             });
-            let currentVote = (<RawPostVote[]> currentVoteResult)[0];
             if (!currentVote) {
                 await this.db.execute('insert into post_votes (post_id, voter_id, vote) values (:post_id, :voter_id, :vote)', {
                     post_id: id,
@@ -79,10 +78,9 @@ export default class VoteController {
                 });
             }
 
-            let ratingResult = await this.db.execute('select sum(vote) rating from post_votes where post_id = :post_id', {
+            let rating = (await this.db.fetchOne('select sum(vote) rating from post_votes where post_id = :post_id', {
                 post_id: id
-            });
-            let rating = ratingResult[0].rating || 0;
+            })).rating || 0;
 
             await this.db.execute('update posts set rating=:rating where post_id=:post_id', {
                 rating: rating,

--- a/backend/src/db/DB.ts
+++ b/backend/src/db/DB.ts
@@ -1,4 +1,5 @@
-import {createPool, Pool, PoolConnection, RowDataPacket} from 'mysql2';
+import {createPool, OkPacket, ResultSetHeader, RowDataPacket} from 'mysql2'
+import {Pool, PoolConnection} from 'mysql2/promise'
 
 interface DBOptions {
     host: string;
@@ -19,81 +20,51 @@ export default class DB {
                 password: options.password,
                 database: options.database,
                 namedPlaceholders: true
-            });
+            }).promise()
 
-            console.log('Mysql pool is up');
-        }
-        catch (e) {
-            console.error('DB', e);
+            console.log('Mysql pool is up')
+        } catch (e) {
+            console.error('DB', e)
             throw new Error('Failed to initialize database pool')
         }
     }
 
-    async execute(query: string, params: string[] | Object, connection?: PoolConnection) {
-        let conn: Pool | PoolConnection = connection || this.pool;
+    async execute<T = RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
+        query: string, params: string[] | Object, connection?: PoolConnection): Promise<T> {
+        const conn: Pool | PoolConnection = connection || this.pool
 
         if (!this.pool) {
-            throw new Error('Database pool was not created');
+            throw new Error('Database pool was not created')
         }
-
         try {
-            return new Promise((resolve, reject) => {
-                conn.query(query, params, (error, results) => {
-                    if (error) {
-                        console.error('DB', error);
-                        reject(error);
-                    }
-                    else {
-                        const rows = (<RowDataPacket[]> results)
-                        resolve(rows);
-                    }
-                });
-            })
-        }
-        catch (e) {
-            console.error('DB', e);
-            throw new Error('Failed to execute database query');
+            return (await conn.query(query, params))[0] as undefined as T
+        } catch (e) {
+            console.error('DB', e)
+            throw new Error('Failed to execute database query')
         }
     }
 
-    beginTransaction(): Promise<PoolConnection> {
-        return new Promise((resolve, reject) => {
-            this.pool.getConnection((err, connection) => {
-                if (err) {
-                    reject(err);
-                    return;
-                }
-
-                connection.beginTransaction((err) => {
-                    if (err) {
-                        reject(err);
-                        return;
-                    }
-
-                    resolve(connection);
-                })
-            })
-        })
+    async fetchOne<T = any>(query: string, params: string[] | Object, connection?: PoolConnection): Promise<T | undefined> {
+        return (await this.execute<T[]>(query, params, connection))[0];
     }
 
-    commit(connection: PoolConnection): Promise<void> {
-        return new Promise((resolve, reject) => {
-            connection.commit((err) => {
-                if (err) {
-                    reject(err);
-                    return;
-                }
-
-                resolve();
-            })
-        })
-    }
-
-    rollback(connection: PoolConnection): Promise<void> {
-        return new Promise((resolve) => {
-            connection.rollback(() => {
-                resolve();
-            })
-        })
+    /**
+     * Usage:
+     * await beginTransaction(async (conn) => {
+     *   await conn.query('...')
+     *   await conn.query('...')
+     * })
+     * //connection will be released automatically
+     * @param transactionFunc
+     *
+     *  Note: never hold onto the connection fetched from the pool
+     */
+    async beginTransaction<T>(transactionFunc: (conn: PoolConnection) => Promise<T>): Promise<T> {
+        const conn = await this.pool.getConnection()
+        try {
+            return await transactionFunc(conn)
+        } finally {
+            conn.release()
+        }
     }
 }

--- a/backend/src/db/managers/InviteManager.ts
+++ b/backend/src/db/managers/InviteManager.ts
@@ -14,72 +14,64 @@ export default class InviteManager {
     }
 
     async get(code: string): Promise<InviteRawWithIssuer | undefined> {
-        let result = await this.db.execute('select i.*, u.username issuer from invites i join users u on (i.issued_by = u.user_id) where code=:code', {code: code});
-
-        let row = (<InviteRawWithIssuer> result)[0];
-        if (!row) {
-            return;
-        }
-
-        return row;
+        return await this.db.fetchOne('select i.*, u.username issuer from invites i join users u on (i.issued_by = u.user_id) where code=:code', {code: code})
     }
 
     async use(code: string, username: string, name: string, email: string, passwordHash: string, gender: UserGender): Promise<UserRaw> {
-        let connection = await this.db.beginTransaction();
+        return await this.db.beginTransaction(async (connection) => {
 
-        try {
-            let inviteResult = await this.db.execute('select i.* from invites i where code=:code and left_count > 0', {code: code}, connection);
-            let inviteRow = (<InviteRaw>inviteResult)[0];
-            if (!inviteRow) {
-                console.error('Invite not found');
-                throw new CodeError('invite-not-found', 'Invite not found');
+            try {
+                let inviteRow: InviteRaw =
+                    await this.db.fetchOne('select i.* from invites i where code=:code and left_count > 0', {code: code}, connection);
+                if (!inviteRow) {
+                    console.error('Invite not found');
+                    throw new CodeError('invite-not-found', 'Invite not found');
+                }
+
+                const userCountResult: any[] = await this.db.execute('select count(*) cnt from users where username=:username', {username: username}, connection);
+                if (!userCountResult || userCountResult[0].cnt > 0) {
+                    console.error('Username exists');
+                    throw new CodeError('username-exists', 'Username exists');
+                }
+
+                await this.db.execute('update invites set left_count=left_count-1 where code=:code', {code: code}, connection);
+                let userInsertResult: OkPacket = await this.db.execute('insert into users (username, password, gender, name, email) values(:username, :password, :gender, :name, :email)', {
+                    username: username,
+                    password: passwordHash,
+                    gender: gender,
+                    name: name,
+                    email: email
+                }, connection);
+
+                let userInsertId = userInsertResult.insertId;
+                if (!userInsertId) {
+                    throw new CodeError('unknown', 'Could not insert user');
+                }
+
+                await this.db.execute('insert into user_invites (parent_id, child_id, invited, invite_id) values(:parent_id, :child_id, now(), :invite_id)', {
+                    parent_id: inviteRow.issued_by,
+                    invite_id: inviteRow.invite_id,
+                    child_id: userInsertId
+                }, connection);
+
+                await connection.commit();
+
+                let userRow:UserRaw | undefined = await this.db.fetchOne('select * from users where user_id=:user_id', {user_id: userInsertId}, connection);
+                if (!userRow) {
+                    throw new CodeError('unknown', 'Could not select user')
+                }
+
+                return userRow;
+            } catch (err) {
+                console.error(err);
+                await connection.rollback();
+
+                if (err instanceof CodeError) {
+                    throw err;
+                }
+
+                throw new CodeError('unknown', err instanceof Error ? err.message : 'Unknown error');
             }
-
-            let userCountResult = await this.db.execute('select count(*) cnt from users where username=:username', {username: username}, connection);
-            if (!userCountResult || userCountResult[0].cnt > 0) {
-                console.error('Username exists');
-                throw new CodeError('username-exists', 'Username exists');
-            }
-
-            await this.db.execute('update invites set left_count=left_count-1 where code=:code', {code: code}, connection);
-            let userInsertResult = await this.db.execute('insert into users (username, password, gender, name, email) values(:username, :password, :gender, :name, :email)', {
-                username: username,
-                password: passwordHash,
-                gender: gender,
-                name: name,
-                email: email
-            }, connection);
-
-            let userInsertId = (<OkPacket> userInsertResult).insertId;
-            if (!userInsertId) {
-                throw new CodeError('unknown', 'Could not insert user');
-            }
-
-            await this.db.execute('insert into user_invites (parent_id, child_id, invited, invite_id) values(:parent_id, :child_id, now(), :invite_id)', {
-                parent_id: inviteRow.issued_by,
-                invite_id: inviteRow.invite_id,
-                child_id: userInsertId
-            }, connection);
-
-            await this.db.commit(connection);
-
-            let userResult = await this.db.execute('select * from users where user_id=:user_id', {user_id: userInsertId});
-            let userRow = (<UserRaw> userResult)[0];
-            if (!userRow) {
-                throw new CodeError('unknown', 'Could not select user')
-            }
-
-            return userRow;
-        }
-        catch (err) {
-            console.error(err);
-            await this.db.rollback(connection);
-
-            if (err instanceof CodeError) {
-                throw err;
-            }
-
-            throw new CodeError('unknown', err instanceof Error ? err.message : 'Unknown error');
-        }
+        });
     }
 }

--- a/backend/src/db/managers/SiteManager.ts
+++ b/backend/src/db/managers/SiteManager.ts
@@ -15,25 +15,11 @@ export default class SiteManager {
     }
 
     async getSiteRaw(siteId: number): Promise<SiteRaw | undefined> {
-        let result = await this.db.execute('select * from sites where site_id=:site_id', {site_id: siteId});
-
-        let row = (<SiteRaw> result)[0];
-        if (!row) {
-            return;
-        }
-
-        return row;
+        return await this.db.fetchOne('select * from sites where site_id=:site_id', {site_id: siteId});
     }
 
     async getSiteByNameRaw(subdomain: string): Promise<SiteRaw | undefined> {
-        let result = await this.db.execute('select * from sites where subdomain=:subdomain', {subdomain: subdomain});
-
-        let row = (<SiteRaw> result)[0];
-        if (!row) {
-            return;
-        }
-
-        return row;
+        return await this.db.fetchOne('select * from sites where subdomain=:subdomain', {subdomain: subdomain});
     }
 
     async getSiteByName(subdomain: string): Promise<Site | undefined> {

--- a/backend/src/db/managers/UserManager.ts
+++ b/backend/src/db/managers/UserManager.ts
@@ -10,25 +10,11 @@ export default class UserManager {
     }
 
     async getRaw(username: string): Promise<UserRaw | undefined> {
-        let result = await this.db.execute('select * from users where username=:username', {username: username});
-
-        let row = (<UserRaw> result)[0];
-        if (!row) {
-            return;
-        }
-
-        return row;
+        return await this.db.fetchOne('select * from users where username=:username', {username: username});
     }
 
     async getRawById(userId: number): Promise<UserRaw | undefined> {
-        let result = await this.db.execute('select * from users where user_id=:user_id', {user_id: userId});
-
-        let row = (<UserRaw> result)[0];
-        if (!row) {
-            return;
-        }
-
-        return row;
+        return await this.db.fetchOne('select * from users where user_id=:user_id', {user_id: userId});
     }
 
     async get(userId: number): Promise<User | undefined> {


### PR DESCRIPTION
### Changes:

* simplified DB manager API:
  - reused existing [mysql2 promise API](https://www.npmjs.com/package/mysql2#using-promise-wrapper)
  - introduced [`fetchOne` method](https://github.com/mugabe/orbitar/compare/refactor-db-manager?expand=1#diff-77ee94ccac27e12ed4966f0c0a48747f7a0ab381ee2a998cf1e879e26e077a80R47) for queries returning a single row (common pattern)
  - parameterized [`execute` with result type](https://github.com/mugabe/orbitar/compare/refactor-db-manager?expand=1#diff-77ee94ccac27e12ed4966f0c0a48747f7a0ab381ee2a998cf1e879e26e077a80R32)
* fixed a [bug with beginTransaction not releasing connection](https://github.com/mugabe/orbitar/compare/refactor-db-manager?expand=1#diff-77ee94ccac27e12ed4966f0c0a48747f7a0ab381ee2a998cf1e879e26e077a80R62)

### Testing:

manually checked the following:
* invites
* login
* posting
* commenting
* post and comment upvoting