### PR TITLE
Fix styles for post and comment preview

### DIFF
--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -8,7 +8,6 @@ import CreateCommentComponent from './CreateCommentComponent';
 import DateComponent from './DateComponent';
 import ContentComponent from './ContentComponent';
 import PostLink from './PostLink';
-import {useAppState} from '../AppState/AppState';
 
 interface CommentProps {
     comment: CommentInfo;

--- a/frontend/src/Components/CreateCommentComponent.module.css
+++ b/frontend/src/Components/CreateCommentComponent.module.css
@@ -7,13 +7,7 @@
     min-height: 100px;
     font-size: 16px;
     padding: 10px;
-}
-
-.answer .preview {
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    overflow: visible;
+    line-height: 1.5em;
 }
 
 .controls {

--- a/frontend/src/Components/CreateCommentComponent.tsx
+++ b/frontend/src/Components/CreateCommentComponent.tsx
@@ -2,6 +2,7 @@ import {CommentInfo, PostInfo, PostLinkInfo} from '../Types/PostInfo';
 import React, {useEffect, useRef, useState} from 'react';
 import styles from './CreateCommentComponent.module.css';
 import postStyles from '../Pages/CreatePostPage.module.css';
+import commentStyles from './CommentComponent.module.css';
 import {ReactComponent as IronyIcon} from '../Assets/irony.svg';
 import {ReactComponent as ImageIcon} from '../Assets/image.svg';
 import {ReactComponent as LinkIcon} from '../Assets/link.svg';
@@ -200,7 +201,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
             {(previewing === null ) ?
                 <div className={styles.editor}><textarea ref={answerRef} disabled={isPosting} value={answerText} onChange={handleAnswerChange} onKeyDown={handleKeyDown} /></div>
                     :
-                <div className={styles.body}><ContentComponent className={classNames(styles.commentContent, styles.preview, postStyles.preview)} content={previewing} /></div>}
+                <div className={classNames(commentStyles.content, styles.preview, postStyles.preview)}><ContentComponent content={previewing} /></div>}
             <div className={styles.final}>
                 <button disabled={isPosting || !answerText} className={styles.buttonPreview} onClick={handlePreview}>{(previewing === null) ? "Превью" : "Редактор"}</button>
                 <button disabled={isPosting || !answerText} onClick={handleAnswer}>Пыщь</button>

--- a/frontend/src/Pages/CreatePostPage.module.css
+++ b/frontend/src/Pages/CreatePostPage.module.css
@@ -15,13 +15,7 @@
 .createpost textarea, .createpost .preview  {
     min-height: 250px;
     font-size: 16px;
-}
-
-.preview {
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    overflow: visible;
+    line-height: 1.5em;
 }
 
 .createpost input.title {

--- a/frontend/src/Pages/CreatePostPage.tsx
+++ b/frontend/src/Pages/CreatePostPage.tsx
@@ -1,10 +1,12 @@
 import React, {useState} from 'react';
 import styles from './CreatePostPage.module.css';
+import createCommentStyles from '../Components/CommentComponent.module.css';
 import {useAPI, useSiteName} from '../AppState/AppState';
 import {useNavigate} from 'react-router-dom';
 import CreateCommentComponent from '../Components/CreateCommentComponent';
 import {CommentInfo} from '../Types/PostInfo';
 import {toast} from 'react-toastify';
+import classNames from "classnames";
 
 export function CreatePostPage() {
     const api = useAPI();
@@ -38,7 +40,7 @@ export function CreatePostPage() {
 
     return (
         <div className={styles.container}>
-            <div className={styles.createpost}>
+            <div className={classNames(styles.createpost, createCommentStyles.content)}>
                 <div className={styles.form}>
                     <input className={styles.title} type="text" placeholder="Без названия" value={title} onChange={handleTitleChange} />
                     <CreateCommentComponent open={true} onAnswer={handleAnswer} onPreview={handlePreview} />


### PR DESCRIPTION
Preview now looks exactly like the real content. In addition, textarea text style is also adjusted to match the result.

Post:
![orbitar-user-posts-demo5](https://user-images.githubusercontent.com/2865203/167986174-659cf4c4-7ddc-4c98-ae1c-e8a0c5158235.gif)

Comment:
![orbitar-user-posts-demo6](https://user-images.githubusercontent.com/2865203/167986196-94ba3c67-c8de-48b7-995f-b02339d7c0c2.gif)
