### PR TITLE
Reactify the insides of the content component

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "color-space": "^2.0.0",
         "eslint": "^8.14.0",
         "eslint-config-react-app": "^7.0.1",
+        "html-react-parser": "^1.4.12",
         "js-cookie": "^3.0.1",
         "moment": "^2.29.3",
         "node-sass": "^7.0.1",
@@ -8350,6 +8351,44 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.2.0.tgz",
+      "integrity": "sha512-2HIpFMvvffsXHFUFjso0M9LqM+1Lm22BF+Df2ba+7QHJXjk63pWChEnI6YG27eaWqUdfnh5/Vy+OXrNTtepRsg==",
+      "dependencies": {
+        "domhandler": "4.3.1",
+        "htmlparser2": "7.2.0"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -8389,6 +8428,20 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.12.tgz",
+      "integrity": "sha512-nqYQzr4uXh67G9ejAG7djupTHmQvSTgjY83zbXLRfKHJ0F06751jXx6WKSFARDdXxCngo2/7H4Rwtfeowql4gQ==",
+      "dependencies": {
+        "domhandler": "4.3.1",
+        "html-dom-parser": "1.2.0",
+        "react-property": "2.0.0",
+        "style-to-js": "1.1.0"
+      },
+      "peerDependencies": {
+        "react": "0.14 || 15 || 16 || 17 || 18"
       }
     },
     "node_modules/html-webpack-plugin": {
@@ -8687,6 +8740,11 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -14112,6 +14170,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
+      "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -15660,6 +15723,22 @@
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.0.tgz",
+      "integrity": "sha512-1OqefPDxGrlMwcbfpsTVRyzwdhr4W0uxYQzeA2F1CBc8WG04udg2+ybRnvh3XYL4TdHQrCahLtax2jc8xaE6rA==",
+      "dependencies": {
+        "style-to-object": "0.3.0"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+      "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
       }
     },
     "node_modules/stylehacks": {
@@ -23875,6 +23954,33 @@
         }
       }
     },
+    "html-dom-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.2.0.tgz",
+      "integrity": "sha512-2HIpFMvvffsXHFUFjso0M9LqM+1Lm22BF+Df2ba+7QHJXjk63pWChEnI6YG27eaWqUdfnh5/Vy+OXrNTtepRsg==",
+      "requires": {
+        "domhandler": "4.3.1",
+        "htmlparser2": "7.2.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+        },
+        "htmlparser2": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+          "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.2",
+            "domutils": "^2.8.0",
+            "entities": "^3.0.1"
+          }
+        }
+      }
+    },
     "html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -23905,6 +24011,17 @@
         "param-case": "^3.0.4",
         "relateurl": "^0.2.7",
         "terser": "^5.10.0"
+      }
+    },
+    "html-react-parser": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.12.tgz",
+      "integrity": "sha512-nqYQzr4uXh67G9ejAG7djupTHmQvSTgjY83zbXLRfKHJ0F06751jXx6WKSFARDdXxCngo2/7H4Rwtfeowql4gQ==",
+      "requires": {
+        "domhandler": "4.3.1",
+        "html-dom-parser": "1.2.0",
+        "react-property": "2.0.0",
+        "style-to-js": "1.1.0"
       }
     },
     "html-webpack-plugin": {
@@ -24116,6 +24233,11 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -27906,6 +28028,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
+      "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -29074,6 +29201,22 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
       "requires": {}
+    },
+    "style-to-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.0.tgz",
+      "integrity": "sha512-1OqefPDxGrlMwcbfpsTVRyzwdhr4W0uxYQzeA2F1CBc8WG04udg2+ybRnvh3XYL4TdHQrCahLtax2jc8xaE6rA==",
+      "requires": {
+        "style-to-object": "0.3.0"
+      }
+    },
+    "style-to-object": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+      "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+      "requires": {
+        "inline-style-parser": "0.1.1"
+      }
     },
     "stylehacks": {
       "version": "5.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,8 @@
     "react-scripts": "5.0.0",
     "react-toastify": "^8.2.0",
     "typescript": "^4.6.3",
-    "webfonts-loader": "^7.5.2"
+    "webfonts-loader": "^7.5.2",
+    "html-react-parser": "^1.4.12"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -1,47 +1,47 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import classNames from 'classnames';
 import styles from './ContentComponent.module.scss';
+import htmlParser, {Element } from 'html-react-parser';
 
 interface ContentComponentProps extends React.ComponentPropsWithRef<'div'> {
     content: string;
     autoCut?: boolean;
 }
 
-function updateContent(div: HTMLDivElement) {
-    div.querySelectorAll('img').forEach(img => {
-        if (img.complete) {
-            updateImg(img);
-            return;
-        }
+function ScalableImage(props: { src: string }) {
+    const ref = useRef<HTMLImageElement>(null);
+    const [scaled, setScaled] = useState(false);
+    const [scalable, setScalable] = useState<boolean | undefined>(undefined);
 
-        img.onload = () => {
-            updateImg(img);
-        };
-    });
+    const onLoad = () => {
+        if (scalable === undefined) {
+            setScalable(ref.current!.naturalWidth > 500 || ref.current!.naturalHeight > 500);
+        }
+    };
+    const onClick = () => {
+        if (scalable) {
+            setScaled(!scaled);
+        }
+    };
+    return <img src={props.src} className={classNames({ 'image-scalable' : scalable,  'image-preview' : scaled } )}
+                onLoad={onLoad} ref={ref} onClick={onClick} />;
 }
 
-function updateImg(img: HTMLImageElement) {
-    let el: HTMLElement | null = img;
-    while (el) {
-        if (el.tagName.toUpperCase() === 'A') {
-            return;
-        }
-        el = el.parentElement;
-    }
-
-    let imageLarge = false;
-    img.classList.add('image-scalable');
-    if (img.naturalWidth > 500 || img.naturalHeight > 500) {
-        img.onclick = () => {
-            if (imageLarge) {
-                imageLarge = false;
-                img.classList.remove('image-preview');
-                return;
+function parseContent(content: string) {
+    return htmlParser(content, {
+        replace: domNode => {
+            if (domNode instanceof Element && domNode.tagName.toUpperCase() === 'IMG') {
+                let el: Element | null = domNode;
+                while (el) {
+                    if (el.tagName.toUpperCase() === 'A') {
+                        return;
+                    }
+                    el = (el.parent instanceof Element) ? el.parent : null;
+                }
+                return <ScalableImage src={domNode.attribs['src']} />;
             }
-            imageLarge = true;
-            img.classList.add('image-preview');
-        };
-    }
+        }
+    });
 }
 
 export default function ContentComponent(props: ContentComponentProps) {
@@ -53,8 +53,6 @@ export default function ContentComponent(props: ContentComponentProps) {
         if (!content) {
             return;
         }
-
-        updateContent(content);
 
         if (props.autoCut) {
             const rect = content.getBoundingClientRect();
@@ -68,9 +66,13 @@ export default function ContentComponent(props: ContentComponentProps) {
         setCut(false);
     };
 
+    const content = useMemo(() => parseContent(props.content), [props.content]);
+
     return (
         <>
-            <div className={classNames(styles.content, props.className, cut && styles.cut)} dangerouslySetInnerHTML={{__html: props.content}} ref={contentDiv} />
+            <div className={classNames(styles.content, props.className, cut && styles.cut)} ref={contentDiv}>
+                {content}
+            </div>
             {cut && <div className={styles.cutCover}><button className={styles.cutButton} onClick={handleCut}>Читать дальше</button></div>}
         </>
     );


### PR DESCRIPTION
### Changes:
* use `html-react-parser` to parse string content into react components before adding it as a child of the `ContentComponent`
* refactor scalable image preview as a react component

### Goal:
* pave the road to add more interactive components inside the `ContentComponent`, e.g:
   * `@mentions` with popups on hover
   * `Link`s
   * embeds
