### PR TITLE
Log user visit activity

### DIFF
--- a/backend/migrations/20220526092700-user-activity.js
+++ b/backend/migrations/20220526092700-user-activity.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function(db) {
+  await db.runSql(`
+      create table user_activity
+      (
+          user_id    int      not null,
+          visited_at datetime not null,
+          constraint user_activity_pk
+              primary key (user_id, visited_at)
+      );
+  `);
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/backend/migrations/20220526092700-user-activity.js
+++ b/backend/migrations/20220526092700-user-activity.js
@@ -16,15 +16,22 @@ exports.setup = function(options, seedLink) {
 
 exports.up = async function(db) {
   await db.runSql(`
-      create table user_activity
+      create database activity_db;
+      grant insert,update,delete,select on activity_db.* to 'orbitar'@'%';
+      
+      create table activity_db.user_activity
       (
           user_id    int      not null,
           visited_at datetime not null,
           constraint user_activity_pk
               primary key (user_id, visited_at)
-      );
+      ) engine=myisam;
   `);
   return null;
+};
+
+exports.down = async function(db) {
+  await db.runSql('drop database activity_db');
 };
 
 exports._meta = {

--- a/backend/src/api/FeedController.ts
+++ b/backend/src/api/FeedController.ts
@@ -58,6 +58,7 @@ export default class FeedController {
         }
 
         const userId = request.session.data.userId;
+        this.userManager.logVisit(userId);
         const { format, page, perpage: perPage } = request.body;
 
         try {
@@ -84,6 +85,7 @@ export default class FeedController {
         }
 
         const userId = request.session.data.userId;
+        this.userManager.logVisit(userId);
         const { format, page, perpage: perPage } = request.body;
 
         try {
@@ -110,6 +112,7 @@ export default class FeedController {
         }
 
         const userId = request.session.data.userId;
+        this.userManager.logVisit(userId);
         const { site: subdomain, format, page, perpage: perPage } = request.body;
 
         try {
@@ -142,6 +145,7 @@ export default class FeedController {
         }
 
         const userId = request.session.data.userId;
+        this.userManager.logVisit(userId);
         const { filter, format, page, perpage: perPage } = request.body;
 
         try {

--- a/backend/src/db/repositories/UserRepository.ts
+++ b/backend/src/db/repositories/UserRepository.ts
@@ -115,7 +115,7 @@ export default class UserRepository {
             '.' + date.getMilliseconds();
 
         return this.db.query(`
-            insert ignore into user_activity (user_id, visited_at) values (:user_id, :visited_at)
+            insert ignore into activity_db.user_activity (user_id, visited_at) values (:user_id, :visited_at)
         `, {user_id: userId, visited_at: dateToInsert});
     }
 }

--- a/backend/src/db/repositories/UserRepository.ts
+++ b/backend/src/db/repositories/UserRepository.ts
@@ -108,4 +108,14 @@ export default class UserRepository {
 
         return parseInt(res.cnt);
     }
+
+    logVisit(userId: number, date: Date): Promise<void> {
+        // insert format: 2022-05-26 12:00:00.000
+        const dateToInsert = date.toISOString().replace(/T/, ' ').substring(0, 19) +
+            '.' + date.getMilliseconds();
+
+        return this.db.query(`
+            insert ignore into user_activity (user_id, visited_at) values (:user_id, :visited_at)
+        `, {user_id: userId, visited_at: dateToInsert});
+    }
 }


### PR DESCRIPTION
As an important prerequisite for the senate elections and activity based rating/karma models, we need to track user activity.

This is the simplest possible implementation that records if user visited the site (feeds) in a particular 12 hour period.

### Implementation:

Table:
```
 create table user_activity
      (
          user_id    int      not null,
          visited_at datetime not null,
          constraint user_activity_pk
              primary key (user_id, visited_at)
      );
```
`visited_at` is truncated to a period (currently 12h) on the server before insertion. No additional indexes and foreign keys are added for insertion performance.

Insertion is performed in `FeedController` in async fire-and-forget manner. There is an in-memory cache on the server that limits the number of insertions.

