### PR TITLE
Video and url parsing enhancements

### DIFF
--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -163,7 +163,7 @@ export default class TheParser {
 
     processVideo(url: Url<string>) {
         if (url.pathname.match(/\.(mp4|webm)$/)) {
-            return `<video loop="" preload="metadata" controls="" width="500"><source src="${encodeURI(url.toString())}" type="video/mp4"></video>`;
+            return this.renderVideoTag(url.toString(), false);
         }
 
         return false;
@@ -272,10 +272,14 @@ export default class TheParser {
         if (!this.validUrl(url)) {
             return this.parseDisallowedTag(node);
         }
-
-        const text = `<video loop="" preload="metadata" controls="" width="500"><source src="${encodeURI(url)}" type="video/mp4"></video>`;
-
+        const text = this.renderVideoTag(url, node.attribs['loop'] !== undefined);
         return { text, mentions: [], urls: [], images: [url] };
+    }
+
+    renderVideoTag(url: string, loop: boolean) {
+        const match = url.match(/https?:\/\/i.imgur.com\/([^.]+).mp4$/);
+        const poster = match ? `poster="https://i.imgur.com/${encodeURI(match[1])}.jpg"` : '';
+        return `<video ${loop ? 'loop=""' : ''} preload="metadata" ${poster} controls="" width="500"><source src="${encodeURI(url)}" type="video/mp4"></video>`;
     }
 
     parseIrony(node: Element): ParseResult {

--- a/backend/src/parser/urlregex.ts
+++ b/backend/src/parser/urlregex.ts
@@ -95,5 +95,5 @@ function getRegex(path = '\\S*') {
         `(?:[/?#]${path})?`;
 }
 
-export const urlRegex = new RegExp('\\b' + getRegex('[^\\s,.:;!()\\[\\]{}]*'), 'gi');
+export const urlRegex = new RegExp('\\b' + getRegex('(?:[^\\s.,:;!()\\[\\]{}]|[.,:;!]+\\b)*'), 'gi');
 export const urlRegexExact = new RegExp('^' + getRegex() + '$', 'i');

--- a/backend/test/parser/urlregex.test.ts
+++ b/backend/test/parser/urlregex.test.ts
@@ -107,11 +107,18 @@ test('URL extraction', () => {
     urlRegex.lastIndex = 0;
     expect(urlRegex.exec("a http://test.com?q=123 as")[0]).toEqual("http://test.com?q=123");
 
-    // some symbols are explicitly excluded from the resource part of the url (like .,! brackets, etc):
+    // some symbols are explicitly excluded from the resource part of the url (like .,! brackets, etc)
+    // but only when they are not at the end of the url
     urlRegex.lastIndex = 0;
     expect(urlRegex.exec("(http://test.com?q=123)")[0]).toEqual("http://test.com?q=123");
     urlRegex.lastIndex = 0;
     expect(urlRegex.exec("[http://test.com?q=123]")[0]).toEqual("http://test.com?q=123");
     urlRegex.lastIndex = 0;
     expect(urlRegex.exec("http://test.com?q=123,")[0]).toEqual("http://test.com?q=123");
+
+    // when punctuation symbols are in the middle of the url, they are not considered as part of the url:
+    urlRegex.lastIndex = 0;
+    expect(urlRegex.exec("http://test.com?q=123,blabla")[0]).toEqual("http://test.com?q=123,blabla");
+    urlRegex.lastIndex = 0;
+    expect(urlRegex.exec("https://i.imgur.com/LEv7f25.mp4")[0]).toEqual("https://i.imgur.com/LEv7f25.mp4");
 });


### PR DESCRIPTION
### Changes:
* improve URL parser (allow punctuation symbols in the middle of the url)
  * "https://i.imgur.com/LEv7f25.mp4" is parsed as one url
  * "https://i.imgur.com/LEv7f25. mp4" is parsed as "https://i.imgur.com/LEv7f25"
* control `loop` attribute of the video tag (don't loop by default)
* generate `poster` attribute for imgur mp4 videos (preload alone doesn't work on ipad)