### PR TITLE
Attempt to fix broken notifications on ipad

### DIFF
--- a/frontend/src/Components/NotificationsPopup.tsx
+++ b/frontend/src/Components/NotificationsPopup.tsx
@@ -21,8 +21,13 @@ export default function NotificationsPopup(props: NotificationsPopupProps) {
 
     const fetchNotifications = useMemo(() => {
         return async () => {
-            const auth = siteName === 'main' ? await pushService.getAuth() : undefined;
-            console.log('have auth:', auth);
+            let auth = undefined;
+            try {
+                auth = siteName === 'main' ? await pushService.getAuth() : undefined;
+                console.log('have auth:', auth);
+            } catch (e) {
+                console.error('failed to get auth', e);
+            }
             return await api.notifications.list(auth);
         };
     }, [api, pushService, siteName]);

--- a/frontend/src/Services/PushService.ts
+++ b/frontend/src/Services/PushService.ts
@@ -28,7 +28,7 @@ export class PushService {
         }
 
         const registration = await this.getRegistration();
-        if (!registration) {
+        if (!registration || !registration.pushManager || !registration.pushManager.getSubscription) {
             return;
         }
 


### PR DESCRIPTION
The log message that I managed to collect on ipad:
```LOGnotifications error TypeError: undefined is not an object (evaluating 't.pushManager.getSubscription')```

<img width="464" alt="image" src="https://user-images.githubusercontent.com/2865203/170896582-3d8f0d15-96c6-4b2b-80cd-e0bf4172f091.png">

The seeming culprit is this place:
```
const subscription = await registration.pushManager.getSubscription();
```

I added more safeguards around the suspects (unfortunately, I cannot test it locally).