### PR TITLE
Fixes an issue when right top menu is shifted when navigating

### DIFF
--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -2,6 +2,10 @@
 
 // TODO add css reset
 
+html {
+  overflow-y: overlay;
+}
+
 html,body {
   height: 100%;
   margin: 0;


### PR DESCRIPTION
Fixes an issue when right top menu is shifted when navigating between pages with scroll and pages with no scroll

Before:

https://user-images.githubusercontent.com/57953386/177014210-f3c07dd3-bd3c-4c55-a486-abb367bc25ce.mov

After:

https://user-images.githubusercontent.com/57953386/177014216-5bf9e824-094f-4978-ba2b-4ab437564858.mov


The shift actually happens because of [this CSS rule](https://github.com/spaceshelter/orbitar/blob/d4bd77cf67aee9f3f29aeeb5f7782a4e64793948/frontend/src/index.scss#L141), if you remove it the effect would be the same, but I'm not sure why it was defined