### PR TITLE
Show parent comment arrow and username for all comments

### DIFF
--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -82,7 +82,7 @@ export default function CommentComponent(props: CommentProps) {
     return (
         <div className={styles.comment + (props.comment.isNew ? ' isNew': '') + (isFlat?' isFlat':'')} data-comment-id={props.comment.id}>
             <div className='commentBody'>
-                <SignatureComponent showSite={props.showSite} site={site} author={author} onHistoryClick={toggleHistory} parentCommentId={isFlat?props.parent?.id:undefined} postLink={postLink} commentId={props.comment.id} date={created} editFlag={editFlag} />
+                <SignatureComponent showSite={props.showSite} site={site} author={author} onHistoryClick={toggleHistory} parentCommentId={props.parent?.id} parentCommentAuthor={props.parent?.author?.username} postLink={postLink} commentId={props.comment.id} date={created} editFlag={editFlag} />
                 {editingText === false ?
                     (showHistory
                         ?

--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -18,6 +18,8 @@ interface CommentProps {
     onEdit?: (text: string, comment: CommentInfo) => Promise<CommentInfo | undefined>;
     depth?: number
     maxTreeDepth?: number
+    idx?: number
+    unreadOnly?: boolean
 }
 
 export default function CommentComponent(props: CommentProps) {
@@ -82,7 +84,9 @@ export default function CommentComponent(props: CommentProps) {
     return (
         <div className={styles.comment + (props.comment.isNew ? ' isNew': '') + (isFlat?' isFlat':'')} data-comment-id={props.comment.id}>
             <div className='commentBody'>
-                <SignatureComponent showSite={props.showSite} site={site} author={author} onHistoryClick={toggleHistory} parentCommentId={props.parent?.id} parentCommentAuthor={props.parent?.author?.username} postLink={postLink} commentId={props.comment.id} date={created} editFlag={editFlag} />
+                <SignatureComponent showSite={props.showSite} site={site} author={author} onHistoryClick={toggleHistory}
+                                    parentCommentId={props.idx && props.parent?.id} parentCommentAuthor={props.parent?.author?.username}
+                                    postLink={postLink} commentId={props.comment.id} postLinkIsNew={props.unreadOnly} date={created} editFlag={editFlag} />
                 {editingText === false ?
                     (showHistory
                         ?
@@ -107,8 +111,9 @@ export default function CommentComponent(props: CommentProps) {
             {(props.comment.answers || answerOpen) ?
                 <div className={styles.answers + (isFlat?' isFlat':'')}>
                     {props.onAnswer && <CreateCommentComponentRestricted open={answerOpen} post={props.comment.postLink} comment={props.comment} onAnswer={handleAnswer} />}
-                    {props.comment.answers && props.onAnswer ? props.comment.answers.map(comment =>
-                        <CommentComponent maxTreeDepth={maxDepth} depth={depth+1} parent={props.comment} key={comment.id} comment={comment} onAnswer={props.onAnswer} onEdit={props.onEdit} />) : <></>}
+                    {props.comment.answers && props.onAnswer ? props.comment.answers.map( (comment, idx) =>
+                        <CommentComponent maxTreeDepth={maxDepth} depth={depth+1} parent={props.comment} key={comment.id}
+                                          comment={comment} onAnswer={props.onAnswer} onEdit={props.onEdit} unreadOnly={props.unreadOnly} idx={idx} />) : <></>}
                 </div>
                 : <></>}
 

--- a/frontend/src/Components/SignatureComponent.tsx
+++ b/frontend/src/Components/SignatureComponent.tsx
@@ -15,6 +15,7 @@ interface SignatureComponentProps {
     editFlag?: EditFlag;
     onHistoryClick: () => void;
     postLink: PostLinkInfo;
+    postLinkIsNew?: boolean
     parentCommentId?: number;
     parentCommentAuthor?: string;
     date: Date;
@@ -26,7 +27,7 @@ export const SignatureComponent = (props: SignatureComponentProps) => {
         <div className={styles.signature}>
             {(props.showSite && props.site && props.site !== 'main') ? <><Link to={`/s/${props.site}`}>{props.site}</Link> • </> : ''}
             <Username className={styles.username} user={props.author} /> • <PostLink post={props.postLink} commentId={props.commentId}><DateComponent date={props.date} /></PostLink>
-            {props.parentCommentId && <> • <PostLink className={'arrow i i-arrow'} post={props.postLink} commentId={props.parentCommentId}> {props.parentCommentAuthor}</PostLink></>}
+            {props.parentCommentId && <> • <PostLink className={'arrow i i-arrow'} post={props.postLink} onlyNew={props.postLinkIsNew} commentId={props.parentCommentId}> @{props.parentCommentAuthor}</PostLink></>}
             {props.editFlag && <> • <button className={styles.toggleHistory} onClick={props.onHistoryClick}>изменён</button></>}
         </div>
     );

--- a/frontend/src/Components/SignatureComponent.tsx
+++ b/frontend/src/Components/SignatureComponent.tsx
@@ -16,6 +16,7 @@ interface SignatureComponentProps {
     onHistoryClick: () => void;
     postLink: PostLinkInfo;
     parentCommentId?: number;
+    parentCommentAuthor?: string;
     date: Date;
     commentId?: number;
 }
@@ -25,7 +26,7 @@ export const SignatureComponent = (props: SignatureComponentProps) => {
         <div className={styles.signature}>
             {(props.showSite && props.site && props.site !== 'main') ? <><Link to={`/s/${props.site}`}>{props.site}</Link> • </> : ''}
             <Username className={styles.username} user={props.author} /> • <PostLink post={props.postLink} commentId={props.commentId}><DateComponent date={props.date} /></PostLink>
-            {props.parentCommentId && <> • <PostLink className={'arrow i i-arrow'} post={props.postLink} commentId={props.parentCommentId}></PostLink></>}
+            {props.parentCommentId && <> • <PostLink className={'arrow i i-arrow'} post={props.postLink} commentId={props.parentCommentId}> {props.parentCommentAuthor}</PostLink></>}
             {props.editFlag && <> • <button className={styles.toggleHistory} onClick={props.onHistoryClick}>изменён</button></>}
         </div>
     );

--- a/frontend/src/Pages/PostPage.tsx
+++ b/frontend/src/Pages/PostPage.tsx
@@ -112,7 +112,7 @@ export default function PostPage() {
                         <div className={styles.postButtons}><Link to={`${baseRoute}p${post.id}`} className={unreadOnly ? '' : 'bold'}>все комментарии</Link> • <Link to={`${baseRoute}p${post.id}?new`} className={unreadOnly ? 'bold' : ''}>только новые</Link></div>
                         <div className={styles.comments + (unreadOnly ? ' unreadOnly' : '')}>
                             {comments ?
-                                comments.map(comment => <CommentComponent maxTreeDepth={12} key={comment.id} comment={comment} onAnswer={handleAnswer} onEdit={handleCommentEdit} />)
+                                comments.map(comment => <CommentComponent maxTreeDepth={12} key={comment.id} comment={comment} onAnswer={handleAnswer} unreadOnly={unreadOnly} onEdit={handleCommentEdit} />)
                                 :
                                 (
                                     error ? <div className={styles.error}>{error}<div><button onClick={() => reload(unreadOnly)}>Повторить</button></div></div>


### PR DESCRIPTION
<img width="610" alt="image" src="https://user-images.githubusercontent.com/2865203/183319456-7a4fef89-15f3-4775-891d-219c9950a72a.png">

* shows arrows only when necessary: when parent is not located immediately above
* fixed: clicking arrow preserves the "new comments" post view mode