### PR TITLE
Hide media content in posts and comments with low rating

### DIFF
--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -88,7 +88,7 @@ export default function CommentComponent(props: CommentProps) {
                             <HistoryComponent initial={{ content, date: created }} history={{ id: props.comment.id, type: 'comment' }} onClose={toggleHistory} />
                         :
                             <div className={styles.content}>
-                                <ContentComponent className={styles.commentContent} content={content} />
+                                <ContentComponent className={styles.commentContent} content={content} lowRating={props.comment.rating <= -3} autoCut={props.comment.rating <= -3} />
                             </div>
                     )
                 :

--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -8,6 +8,7 @@ import {useAPI} from '../AppState/AppState';
 import {toast} from 'react-toastify';
 import {SignatureComponent} from './SignatureComponent';
 import {HistoryComponent} from './HistoryComponent';
+import Conf from '../Conf';
 
 interface CommentProps {
     comment: CommentInfo;
@@ -88,7 +89,7 @@ export default function CommentComponent(props: CommentProps) {
                             <HistoryComponent initial={{ content, date: created }} history={{ id: props.comment.id, type: 'comment' }} onClose={toggleHistory} />
                         :
                             <div className={styles.content}>
-                                <ContentComponent className={styles.commentContent} content={content} lowRating={props.comment.rating <= -3} autoCut={props.comment.rating <= -3} />
+                                <ContentComponent className={styles.commentContent} content={content} lowRating={props.comment.rating <= Conf.COMMENT_LOW_RATING_THRESHOLD} autoCut={props.comment.rating <= Conf.COMMENT_LOW_RATING_THRESHOLD} />
                             </div>
                     )
                 :

--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -5,6 +5,7 @@ import styles from './ContentComponent.module.scss';
 interface ContentComponentProps extends React.ComponentPropsWithRef<'div'> {
     content: string;
     autoCut?: boolean;
+    lowRating?: boolean;
 }
 
 function updateContent(div: HTMLDivElement) {
@@ -62,6 +63,18 @@ export default function ContentComponent(props: ContentComponentProps) {
                 setCut(true);
             }
         }
+
+        if (props.lowRating) {
+            content.querySelectorAll('img, video, iframe').forEach(el => el.classList.add('low-rating'));
+
+            content.addEventListener('click', (evt) => {
+                evt.preventDefault();
+                evt.stopPropagation();
+                content.querySelectorAll('img, iframe, video').forEach(el => el.classList.remove('low-rating'));
+                return false;
+            }, {once: true});
+        }
+
     }, [contentDiv, props.autoCut]);
 
     const handleCut = () => {

--- a/frontend/src/Components/PostComponent.tsx
+++ b/frontend/src/Components/PostComponent.tsx
@@ -132,7 +132,7 @@ export default function PostComponent(props: PostComponentProps) {
                             : <>
                                     {title && <div className={styles.title}><PostLink post={props.post}>{title}</PostLink></div>}
                                     <div className={styles.content}>
-                                        <ContentComponent className={styles.content} content={content} autoCut={props.autoCut} />
+                                        <ContentComponent className={styles.content} content={content} autoCut={props.autoCut} lowRating={rating <= -3} />
                                     </div>
                                 </>
                         )

--- a/frontend/src/Components/PostComponent.tsx
+++ b/frontend/src/Components/PostComponent.tsx
@@ -15,6 +15,7 @@ import {toast} from 'react-toastify';
 import CreateCommentComponent from './CreateCommentComponent';
 import { HistoryComponent } from './HistoryComponent';
 import {SignatureComponent} from './SignatureComponent';
+import Conf from '../Conf';
 
 interface PostComponentProps {
     post: PostInfo;
@@ -132,7 +133,7 @@ export default function PostComponent(props: PostComponentProps) {
                             : <>
                                     {title && <div className={styles.title}><PostLink post={props.post}>{title}</PostLink></div>}
                                     <div className={styles.content}>
-                                        <ContentComponent className={styles.content} content={content} autoCut={props.autoCut} lowRating={rating <= -3} />
+                                        <ContentComponent className={styles.content} content={content} autoCut={props.autoCut} lowRating={rating <= Conf.POST_LOW_RATING_THRESHOLD} />
                                     </div>
                                 </>
                         )

--- a/frontend/src/Conf.ts
+++ b/frontend/src/Conf.ts
@@ -1,0 +1,9 @@
+/* Frontend-specific app configuration */
+//TODO - move into the module shared with the backend
+
+const Conf = {
+    POST_LOW_RATING_THRESHOLD: -3,
+    COMMENT_LOW_RATING_THRESHOLD: -3,
+};
+
+export default Conf;

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -103,10 +103,10 @@ img.image-preview {
 img.low-rating, video.low-rating, iframe.low-rating {
   opacity: 0.5;
   /*blur*/
-  filter: blur(5px);
-  -webkit-filter: blur(5px);
-  max-height: 36px;
-  max-width: 36px;
+  filter: blur(2px);
+  -webkit-filter: blur(2px);
+  max-height: 48px;
+  max-width: 48px;
 }
 
 /*br {*/

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -100,6 +100,14 @@ img.image-preview {
   max-height: none;
   cursor: zoom-out;
 }
+img.low-rating, video.low-rating, iframe.low-rating {
+  opacity: 0.5;
+  /*blur*/
+  filter: blur(5px);
+  -webkit-filter: blur(5px);
+  max-height: 36px;
+  max-width: 36px;
+}
 
 /*br {*/
 /*  content: "";*/


### PR DESCRIPTION
Current threshold for "low rating" status is set to "less than -3".

Demo:
![orb-hidden](https://user-images.githubusercontent.com/2865203/177897840-01b54c39-a92d-4a7d-82fc-45765b6c761a.gif)

Height autocut in comment with low rating:
<img width="624" alt="image" src="https://user-images.githubusercontent.com/2865203/177897913-b2727f4a-fc28-437d-a60e-62e5cbc60c5c.png">
