### PR TITLE
User restrictions based on karma

### DIFF
--- a/backend/migrations/20220705333837-user-site-rating.js
+++ b/backend/migrations/20220705333837-user-site-rating.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = async function(db) {
+  await db.runSql(`
+      drop table if exists user_site_rating;
+      create table user_site_rating
+      (
+          user_id        int           not null,
+          site_id        int           not null,
+          comment_rating int default 0 not null,
+          post_rating    int default 0 not null,
+          primary key (user_id, site_id),
+          constraint fk_user_site_rating_user_id foreign key (user_id) references users (user_id) on delete cascade on update cascade,
+          constraint fk_user_site_rating_site_id foreign key (site_id) references sites (site_id) on delete cascade on update cascade
+      ) engine=InnoDB;
+  `);
+
+  // populate from post_votes and comment_votes
+    await db.runSql(`
+        insert into user_site_rating (user_id, site_id, comment_rating, post_rating)
+        select user_id,
+               site_id,
+               sum(cr),
+               sum(pr)
+        from (select author_id as user_id, site_id, sum(vote) as cr, 0 as pr
+              from comment_votes
+                       left join comments on comment_votes.comment_id = comments.comment_id
+              group by user_id, site_id
+              union all
+              select author_id as user_id, site_id, 0, sum(vote) as pr
+              from post_votes
+                       left join posts on post_votes.post_id = posts.post_id
+              group by user_id, site_id
+        ) votes
+        group by user_id, site_id;
+    `);
+
+  return null;
+};
+
+exports.down = async function(db) {
+  await db.runSql('drop table user_site_rating;');
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/backend/src/api/types/entities/UserEntity.ts
+++ b/backend/src/api/types/entities/UserEntity.ts
@@ -18,4 +18,5 @@ export type UserEntity = UserBaseEntity & {
 
 export type UserProfileEntity = UserEntity & {
     registered: string;
+    active: boolean;
 };

--- a/backend/src/api/types/requests/UserProfile.ts
+++ b/backend/src/api/types/requests/UserProfile.ts
@@ -15,3 +15,11 @@ export type UserKarmaResponse = {
     postRatingBySubsite: Record<string, number>;
     commentRatingBySubsite: Record<string, number>;
 };
+
+/* see UserRestrictions */
+export type UserRestrictionsResponse = {
+    effectiveKarma: number;
+    postSlowModeWaitSec: number;
+    commentSlowModeWaitSec: number;
+    restrictedToPostId: number | true | false;
+};

--- a/backend/src/api/types/requests/UserProfile.ts
+++ b/backend/src/api/types/requests/UserProfile.ts
@@ -9,3 +9,9 @@ export type UserProfileResponse = {
     invitedBy?: UserBaseEntity;
     invites: UserBaseEntity[];
 };
+
+export type UserKarmaResponse = {
+    activeKarmaVotes: Record<string, number>;
+    postRatingBySubsite: Record<string, number>;
+    commentRatingBySubsite: Record<string, number>;
+};

--- a/backend/src/api/types/requests/UserProfile.ts
+++ b/backend/src/api/types/requests/UserProfile.ts
@@ -22,4 +22,5 @@ export type UserRestrictionsResponse = {
     postSlowModeWaitSec: number;
     commentSlowModeWaitSec: number;
     restrictedToPostId: number | true | false;
+    canVote: boolean;
 };

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -100,11 +100,11 @@ const webPushRepository = new WebPushRepository(db);
 
 const inviteManager = new InviteManager(inviteRepository);
 const notificationManager = new NotificationManager(commentRepository, notificationsRepository, postRepository, siteRepository, userRepository, webPushRepository, config.vapid, config.site);
-const userManager = new UserManager(credentialsRepository, userRepository, voteRepository, webPushRepository, notificationManager, redis.client);
+const userManager = new UserManager(credentialsRepository, userRepository, voteRepository, commentRepository, postRepository, webPushRepository, notificationManager, redis.client);
 const siteManager = new SiteManager(siteRepository, userManager);
 const feedManager = new FeedManager(bookmarkRepository, postRepository, userRepository, siteManager, redis.client);
 const postManager = new PostManager(bookmarkRepository, commentRepository, postRepository, feedManager, notificationManager, siteManager, userManager, theParser);
-const voteManager = new VoteManager(voteRepository, postManager);
+const voteManager = new VoteManager(voteRepository, postManager, redis.client);
 
 const apiEnricher = new Enricher(siteManager, userManager);
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -113,7 +113,7 @@ const requests = [
     new InviteController(inviteManager, userManager, logger.child({ service: 'INVITE' })),
     new PostController(apiEnricher, postManager, feedManager, siteManager, userManager, logger.child({ service: 'POST' })),
     new StatusController(apiEnricher, siteManager, userManager, logger.child({ service: 'STATUS' })),
-    new VoteController(voteManager, logger.child({ service: 'VOTE' })),
+    new VoteController(voteManager, userManager, logger.child({ service: 'VOTE' })),
     new UserController(apiEnricher, userManager, postManager, voteManager, logger.child({ service: 'USER' })),
     new FeedController(apiEnricher, feedManager, siteManager, userManager, postManager, logger.child({ service: 'FEED' })),
     new SiteController(apiEnricher, feedManager, siteManager, logger.child( { service: 'SITE' })),

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -100,7 +100,7 @@ const webPushRepository = new WebPushRepository(db);
 
 const inviteManager = new InviteManager(inviteRepository);
 const notificationManager = new NotificationManager(commentRepository, notificationsRepository, postRepository, siteRepository, userRepository, webPushRepository, config.vapid, config.site);
-const userManager = new UserManager(credentialsRepository, userRepository, voteRepository, webPushRepository, notificationManager);
+const userManager = new UserManager(credentialsRepository, userRepository, voteRepository, webPushRepository, notificationManager, redis.client);
 const siteManager = new SiteManager(siteRepository, userManager);
 const feedManager = new FeedManager(bookmarkRepository, postRepository, userRepository, siteManager, redis.client);
 const postManager = new PostManager(bookmarkRepository, commentRepository, postRepository, feedManager, notificationManager, siteManager, userManager, theParser);
@@ -114,7 +114,7 @@ const requests = [
     new PostController(apiEnricher, postManager, feedManager, siteManager, userManager, logger.child({ service: 'POST' })),
     new StatusController(apiEnricher, siteManager, userManager, logger.child({ service: 'STATUS' })),
     new VoteController(voteManager, logger.child({ service: 'VOTE' })),
-    new UserController(apiEnricher, userManager, postManager, logger.child({ service: 'USER' })),
+    new UserController(apiEnricher, userManager, postManager, voteManager, logger.child({ service: 'USER' })),
     new FeedController(apiEnricher, feedManager, siteManager, userManager, postManager, logger.child({ service: 'FEED' })),
     new SiteController(apiEnricher, feedManager, siteManager, logger.child( { service: 'SITE' })),
     new NotificationsController(notificationManager, userManager, logger.child({ service: 'NOTIFY' })),

--- a/backend/src/db/DB.ts
+++ b/backend/src/db/DB.ts
@@ -20,7 +20,7 @@ export class DBConnection {
     }
 
     async query<T = RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-        query: string, params: string[] | object): Promise<T> {
+        query: string, params: string[] | object = {}): Promise<T> {
         this.logger.verbose('Query', { query: query.replace(/[\s\n]+/g, ' '), params: params });
 
         try {
@@ -32,11 +32,11 @@ export class DBConnection {
         }
     }
 
-    async fetchAll<T = object>(query: string, params: string[] | object): Promise<T[]> {
+    async fetchAll<T = object>(query: string, params: string[] | object = {}): Promise<T[]> {
         return (await this.query<T[]>(query, params));
     }
 
-    async fetchOne<T = object>(query: string, params: string[] | object): Promise<T | undefined> {
+    async fetchOne<T = object>(query: string, params: string[] | object = {}): Promise<T | undefined> {
         return (await this.query<T[]>(query, params))[0];
     }
 

--- a/backend/src/db/repositories/CommentRepository.ts
+++ b/backend/src/db/repositories/CommentRepository.ts
@@ -58,6 +58,12 @@ export default class CommentRepository {
             });
     }
 
+    async getLastUserComment(userId: number): Promise<CommentRaw | undefined> {
+        return await this.db.fetchOne<CommentRaw>('select * from comments where author_id=:user_id order by created_at desc limit 1', {
+            user_id: userId
+        });
+    }
+
     async getUserCommentsTotal(userId: number): Promise<number> {
         return this.db.fetchOne<{ cnt: string }>('select count(*) cnt from comments where author_id = :user_id and deleted = 0', {
             user_id: userId

--- a/backend/src/db/repositories/PostRepository.ts
+++ b/backend/src/db/repositories/PostRepository.ts
@@ -116,6 +116,10 @@ export default class PostRepository {
             });
     }
 
+    getLastUserPost(userId: number): Promise<PostRaw | undefined> {
+        return this.db.fetchOne<PostRawWithUserData>('select * from posts where author_id=:user_id order by created_at desc limit 1', {user_id: userId});
+    }
+
     async getWatchPostsTotal(forUserId: number, all = false): Promise<number> {
         const result = await this.db.fetchOne<{ cnt: string }>(`
             select count(*) cnt from (

--- a/backend/src/db/repositories/VoteRepository.ts
+++ b/backend/src/db/repositories/VoteRepository.ts
@@ -5,6 +5,14 @@ export type VoteWithUsername = {
     username: string;
 };
 
+export type UserRatingOnSubsite = {
+    site_id: number;
+    site_name: string;
+    subdomain: string;
+    comment_rating: number;
+    post_rating: number;
+};
+
 export default class VoteRepository {
     private db: DB;
 
@@ -13,56 +21,118 @@ export default class VoteRepository {
     }
 
     async getUserVote(userId: number, byUserId: number): Promise<number> {
-        const voteResult = await this.db.fetchOne<{vote: number}>('select vote from user_karma where user_id=:user_id and voter_id=:voter_id', {
-            user_id: userId,
-            voter_id: byUserId
-        });
+        const voteResult = await this.db.fetchOne<{ vote: number }>(
+            'select vote from user_karma where user_id=:user_id and voter_id=:voter_id', {
+                user_id: userId,
+                voter_id: byUserId
+            });
 
         return voteResult?.vote || 0;
     }
 
-    async postSetVote(postId: number, vote: number, userId: number): Promise<number> {
+    private async setVotes(entityId: number, vote: number, userId: number,
+                           comments: boolean): Promise<number> {
+
+        const entityField = comments ? 'comment_id' : 'post_id';
+        const entityVotesTable = comments ? 'comment_votes' : 'post_votes';
+        const entityTable = comments ? 'comments' : 'posts';
+        const userSiteRatingField = comments ? 'comment_rating' : 'post_rating';
+
+
+        const [entitySite, authorId] = await this.db.fetchOne<{
+            site_id: string, author_id: string
+        }>(`select site_id, author_id
+                from ${entityTable}
+                where ${entityField} = :entity_id`, {
+            entity_id: entityId
+        }).then(res => [parseInt(res.site_id), parseInt(res.author_id)]);
+
+        await this.db.query(`insert ignore into ${entityVotesTable} ( ${entityField}, voter_id, vote ) values ( :entity_id, :voter_id, 0 )`, {
+            entity_id: entityId,
+            voter_id: userId,
+        });
+
+        await this.db.query(`insert ignore into user_site_rating (user_id, site_id, ${userSiteRatingField} ) values ( :user_id, :site_id, 0 )`, {
+            user_id: authorId,
+            site_id: entitySite,
+        });
+
         return await this.db.inTransaction(async conn => {
-            await conn.query('insert into post_votes (post_id, voter_id, vote) values (:post_id, :voter_id, :vote) on duplicate key update vote=:vote', {
-                post_id: postId,
-                voter_id: userId,
-                vote: vote
-            });
+            // Important! transaction must start with locking the most "coarse" table first (entity table)
+            // to prevent deadlocks
+            // tricky: related tables (entity_votes), are implicitly locking records in the entity table
+            const prevRating = await conn.fetchOne<{ rating: string; }>(
+                `select rating
+                 from ${entityTable}
+                 where ${entityField} = :entity_id
+                     FOR UPDATE /* locks the row */`, {
+                    entity_id: entityId
+                }).then(res => Number(res.rating || 0));
 
-            const ratingResult = await conn.fetchOne<{ rating: string }>('select sum(vote) rating from post_votes where post_id=:post_id', {
-                post_id: postId
-            });
-            const rating = Number(ratingResult.rating || 0);
+            const prevVote = await conn.fetchOne<{ vote: string; }>(
+                `select vote
+                 from ${entityVotesTable}
+                 where ${entityField} = :entity_id
+                   and voter_id = :voter_id
+                     FOR UPDATE` /* Locks the row, or waits for the lock */, {
+                    entity_id: entityId,
+                    voter_id: userId
+                }).then(res => Number(res.vote || 0));
 
-            await conn.query('update posts set rating=:rating where post_id=:post_id', {
-                rating: rating,
-                post_id: postId
-            });
+            if (prevVote === vote) {
+                return prevRating;
+            }
 
-            return rating;
+            await conn.query(
+                `update ${entityVotesTable}
+                 set vote=:vote
+                 where ${entityField} = :entity_id
+                   and voter_id = :voter_id
+                   and vote = :prev_vote`, {
+                    entity_id: entityId,
+                    voter_id: userId,
+                    vote: vote,
+                    prev_vote: prevVote
+                });
+
+            await conn.query(
+                `update ${entityTable}
+                 set rating=rating + :delta
+                 where ${entityField} = :entity_id`, {
+                    entity_id: entityId,
+                    delta: vote - prevVote
+                });
+
+            // lock the row to prevent concurrent updates
+            await conn.query(
+                `select ${userSiteRatingField}
+                 from user_site_rating
+                 where user_id = :user_id
+                   and site_id = :site_id
+                     FOR UPDATE` /*locks the row*/, {
+                    user_id: authorId,
+                    site_id: entitySite
+                });
+
+            await conn.query(`update user_site_rating
+                    set ${userSiteRatingField}=${userSiteRatingField} + :delta
+                    where user_id = :user_id
+                        and site_id = :site_id`, {
+                    user_id: authorId,
+                    site_id: entitySite,
+                    delta: vote - prevVote
+                });
+
+            return prevRating + vote - prevVote;
         });
     }
 
+    async postSetVote(postId: number, vote: number, userId: number): Promise<number> {
+        return this.setVotes(postId, vote, userId, false);
+    }
+
     async commentSetVote(commentId: number, vote: number, userId: number): Promise<number> {
-        return await this.db.inTransaction(async conn => {
-            await conn.query('insert into comment_votes (comment_id, voter_id, vote) values (:comment_id, :voter_id, :vote) on duplicate key update vote=:vote', {
-                comment_id: commentId,
-                voter_id: userId,
-                vote: vote
-            });
-
-            const ratingResult = await conn.fetchOne<{ rating: number }>('select sum(vote) rating from comment_votes where comment_id=:comment_id', {
-                comment_id: commentId
-            });
-            const rating = Number(ratingResult.rating || 0);
-
-            await conn.query('update comments set rating=:rating where comment_id=:comment_id', {
-                rating: rating,
-                comment_id: commentId
-            });
-
-            return rating;
-        });
+        return this.setVotes(commentId, vote, userId, true);
     }
 
     async userSetVote(toUserId: number, vote: number, voterId: number): Promise<number> {
@@ -103,5 +173,15 @@ export default class VoteRepository {
         return await this.db.fetchAll('select u.username, v.vote from user_karma v join users u on (v.voter_id = u.user_id) where v.user_id=:user_id order by voted_at desc', {
             user_id: userId
         });
+    }
+
+    async getUserRatingOnSubsites(userId: number): Promise<UserRatingOnSubsite[]> {
+        return await this.db.fetchAll(
+            `select usr.site_id as site_id, comment_rating, post_rating, s.name as site_name, subdomain
+             from user_site_rating usr
+                      left join sites s on (usr.site_id = s.site_id)
+             where user_id = :user_id`, {
+                user_id: userId
+            });
     }
 }

--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -296,13 +296,12 @@ export default class UserManager {
 
         return {
             effectiveKarma,
-
             postSlowModeWaitSec: lastOwnPost ?
                 Math.max(lastOwnPost.created_at.getTime() / 1000 - Date.now() / 1000 + postSlowModeDelay, 0)  : 0,
             commentSlowModeWaitSec: lastCommentTime ?
                 Math.max(lastCommentTime.getTime() / 1000 - Date.now() / 1000 + commentSlowModeDelay, 0) : 0,
-
-            restrictedToPostId: (effectiveKarma <= -1000 ? (lastOwnPost?.post_id || true) : false)
+            restrictedToPostId: (effectiveKarma <= -1000 ? (lastOwnPost?.post_id || true) : false),
+            canVote: effectiveKarma >= -10,
         };
     }
 

--- a/backend/src/managers/VoteManager.ts
+++ b/backend/src/managers/VoteManager.ts
@@ -1,13 +1,16 @@
 import PostManager from './PostManager';
 import VoteRepository, {VoteWithUsername} from '../db/repositories/VoteRepository';
+import {RedisClientType} from 'redis';
 
 export default class VoteManager {
     private voteRepository: VoteRepository;
     private postManager: PostManager;
+    private redis: RedisClientType;
 
-    constructor(voteRepository: VoteRepository, postManager: PostManager) {
+    constructor(voteRepository: VoteRepository, postManager: PostManager, redis: RedisClientType) {
         this.voteRepository = voteRepository;
         this.postManager = postManager;
+        this.redis = redis;
     }
 
     async postVote(postId: number, vote: number, userId: number): Promise<number> {
@@ -19,7 +22,9 @@ export default class VoteManager {
     }
 
     async userVote(toUserId: number, vote: number, voterId: number): Promise<number> {
-        return await this.voteRepository.userSetVote(toUserId, vote, voterId);
+        const res = await this.voteRepository.userSetVote(toUserId, vote, voterId);
+        this.redis.del(`active_karma_votes_${toUserId}`).catch();
+        return res;
     }
 
     async getPostVotes(postId: number): Promise<VoteWithUsername[]> {

--- a/backend/src/managers/types/UserInfo.ts
+++ b/backend/src/managers/types/UserInfo.ts
@@ -32,3 +32,13 @@ export type UserRatingBySubsite = {
     postRatingBySubsite: Record<string, number>;
     commentRatingBySubsite: Record<string, number>;
 };
+
+export type UserRestrictions = {
+    effectiveKarma: number;
+
+    postSlowModeWaitSec: number; /* time to wait until can post */
+    commentSlowModeWaitSec: number; /* time to wait until can comment */
+    restrictedToPostId: number | true | false; /* if number: post id to restrict commenting to,
+                                                  if true - restriction active, but no posts,
+                                                  if false - no restriction */
+};

--- a/backend/src/managers/types/UserInfo.ts
+++ b/backend/src/managers/types/UserInfo.ts
@@ -27,3 +27,8 @@ export type UserStats = {
         comments: number;
     }
 };
+
+export type UserRatingBySubsite = {
+    postRatingBySubsite: Record<string, number>;
+    commentRatingBySubsite: Record<string, number>;
+};

--- a/backend/src/managers/types/UserInfo.ts
+++ b/backend/src/managers/types/UserInfo.ts
@@ -41,4 +41,5 @@ export type UserRestrictions = {
     restrictedToPostId: number | true | false; /* if number: post id to restrict commenting to,
                                                   if true - restriction active, but no posts,
                                                   if false - no restriction */
+    canVote: boolean; /* if user can vote for posts, comments and karma */
 };

--- a/frontend/src/API/UserAPI.ts
+++ b/frontend/src/API/UserAPI.ts
@@ -7,6 +7,7 @@ import {CommentInfo, PostInfo} from '../Types/PostInfo';
 
 export type UserProfileEntity = UserInfo & {
     registered: string;
+    active: boolean;
 };
 type UseProfileRequest = {
     username: string;
@@ -49,6 +50,12 @@ type UserProfileCommentsResult = {
     total: number;
 };
 
+export type UserKarmaResponse = {
+    activeKarmaVotes: Record<string, number>;
+    postRatingBySubsite: Record<string, number>;
+    commentRatingBySubsite: Record<string, number>;
+};
+
 export default class UserAPI {
     api: APIBase;
     postAPIHelper: PostAPIHelper;
@@ -80,6 +87,10 @@ export default class UserAPI {
             comments: this.postAPIHelper.fixComments(result.comments, result.users),
             total: result.total,
         };
+    }
+
+    async userKarma(username: string): Promise<UserKarmaResponse> {
+        return await this.api.request<{username: string}, UserKarmaResponse>('/user/karma', {username});
     }
 
 }

--- a/frontend/src/API/UserAPI.ts
+++ b/frontend/src/API/UserAPI.ts
@@ -62,6 +62,7 @@ export type UserRestrictionsResponse = {
     postSlowModeWaitSec: number;
     commentSlowModeWaitSec: number;
     restrictedToPostId: number | true | false;
+    canVote: boolean;
 };
 
 export default class UserAPI {

--- a/frontend/src/API/UserAPI.ts
+++ b/frontend/src/API/UserAPI.ts
@@ -56,6 +56,14 @@ export type UserKarmaResponse = {
     commentRatingBySubsite: Record<string, number>;
 };
 
+/* see UserRestrictions */
+export type UserRestrictionsResponse = {
+    effectiveKarma: number;
+    postSlowModeWaitSec: number;
+    commentSlowModeWaitSec: number;
+    restrictedToPostId: number | true | false;
+};
+
 export default class UserAPI {
     api: APIBase;
     postAPIHelper: PostAPIHelper;
@@ -91,6 +99,10 @@ export default class UserAPI {
 
     async userKarma(username: string): Promise<UserKarmaResponse> {
         return await this.api.request<{username: string}, UserKarmaResponse>('/user/karma', {username});
+    }
+
+    userRestrictions(username: string): Promise<UserRestrictionsResponse> {
+        return this.api.request<{username: string}, UserRestrictionsResponse>('/user/restrictions', {username});
     }
 
 }

--- a/frontend/src/API/UserAPIHelper.ts
+++ b/frontend/src/API/UserAPIHelper.ts
@@ -11,6 +11,7 @@ export type UserProfileResult = {
 export default class UserAPIHelper {
     private api: UserAPI;
     private appState: AppState;
+    private restrictionRefreshInProgress = false; // avoid duplicate requests
 
     constructor(api: UserAPI, appState: AppState) {
         this.api = api;
@@ -29,5 +30,16 @@ export default class UserAPIHelper {
             invitedBy,
             invites
         };
+    }
+
+    refreshUserRestrictions() {
+        if (this.appState.userInfo && !this.restrictionRefreshInProgress) {
+            this.restrictionRefreshInProgress = true;
+            this.api.userRestrictions(this.appState.userInfo.username).then(restrictions => {
+                this.appState.setUserRestrictions(restrictions);
+            }).finally(() => {
+                this.restrictionRefreshInProgress = false;
+            });
+        }
     }
 }

--- a/frontend/src/AppState/AppState.tsx
+++ b/frontend/src/AppState/AppState.tsx
@@ -7,6 +7,7 @@ import {observable, makeObservable, autorun, action, computed, makeAutoObservabl
 import APICache from '../API/APICache';
 import {createBrowserHistory} from 'history';
 import {RouterStore} from '@superwf/mobx-react-router';
+import {UserRestrictionsResponse} from '../API/UserAPI';
 
 export enum AppLoadingState {
     loading,
@@ -33,6 +34,9 @@ export class AppState {
 
     @observable.struct
     userInfo: UserInfo | undefined = undefined; // undefined means not authorized
+
+    @observable.struct
+    userRestrictions: UserRestrictionsResponse | undefined;
 
     @observable
     notificationsCount = 0;
@@ -80,6 +84,11 @@ export class AppState {
     @action
     setUserInfo(value: UserInfo | undefined) {
         this.userInfo = value;
+    }
+
+    @action
+    setUserRestrictions(value: UserRestrictionsResponse) {
+        this.userRestrictions = value;
     }
 
     @action

--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -2,7 +2,7 @@ import {CommentInfo, PostLinkInfo} from '../Types/PostInfo';
 import styles from './CommentComponent.module.scss';
 import RatingSwitch from './RatingSwitch';
 import React, {useMemo, useState} from 'react';
-import CreateCommentComponent from './CreateCommentComponent';
+import {CreateCommentComponentRestricted} from './CreateCommentComponent';
 import ContentComponent from './ContentComponent';
 import {useAPI} from '../AppState/AppState';
 import {toast} from 'react-toastify';
@@ -92,7 +92,7 @@ export default function CommentComponent(props: CommentProps) {
                             </div>
                     )
                 :
-                    <CreateCommentComponent open={true} text={editingText} onAnswer={handleEditComplete} />
+                    <CreateCommentComponentRestricted open={true} text={editingText} onAnswer={handleEditComplete} />
                 }
 
                 <div className={styles.controls}>
@@ -105,7 +105,7 @@ export default function CommentComponent(props: CommentProps) {
             </div>
             {(props.comment.answers || answerOpen) ?
                 <div className={styles.answers + (isFlat?' isFlat':'')}>
-                    {props.onAnswer && <CreateCommentComponent open={answerOpen} post={props.comment.postLink} comment={props.comment} onAnswer={handleAnswer} />}
+                    {props.onAnswer && <CreateCommentComponentRestricted open={answerOpen} post={props.comment.postLink} comment={props.comment} onAnswer={handleAnswer} />}
                     {props.comment.answers && props.onAnswer ? props.comment.answers.map(comment =>
                         <CommentComponent maxTreeDepth={maxDepth} depth={depth+1} parent={props.comment} key={comment.id} comment={comment} onAnswer={props.onAnswer} onEdit={props.onEdit} />) : <></>}
                 </div>

--- a/frontend/src/Components/CreateCommentComponent.tsx
+++ b/frontend/src/Components/CreateCommentComponent.tsx
@@ -12,7 +12,9 @@ import ContentComponent from './ContentComponent';
 import classNames from 'classnames';
 import MediaUploader from './MediaUploader';
 import {UserGender} from '../Types/UserInfo';
-import {useAPI} from '../AppState/AppState';
+import {useAPI, useAppState} from '../AppState/AppState';
+import SlowMode from './SlowMode';
+import {observer} from 'mobx-react-lite';
 
 interface CreateCommentProps {
     open: boolean;
@@ -22,6 +24,38 @@ interface CreateCommentProps {
 
     onAnswer: (text: string, post?: PostLinkInfo, comment?: CommentInfo) => Promise<CommentInfo | undefined>;
 }
+
+// same as CreateCommentComponent, but with slow mode and other restrictions
+export const CreateCommentComponentRestricted = observer((props: CreateCommentProps) => {
+    const api = useAPI();
+    const {userRestrictions} = useAppState();
+
+    useEffect(() => {
+        if (props.open) {
+            api.user.refreshUserRestrictions();
+        }
+    }, [api, props.open]);
+
+    if (!props.open) {
+        return null;
+    }
+
+    if (userRestrictions?.restrictedToPostId && userRestrictions.restrictedToPostId !== props.post?.id) {
+        return <div className={styles.answer}><RestrictedToPostIdMessage postId={userRestrictions.restrictedToPostId}/></div>;
+    }
+
+    if (userRestrictions?.commentSlowModeWaitSec) {
+        return <div className={styles.answer}><RestrictedSlowMode
+            endTime={new Date(Date.now() + userRestrictions.commentSlowModeWaitSec * 1000)}
+            endCallback={() => api.user.refreshUserRestrictions()}/></div>;
+    }
+
+    return <CreateCommentComponent {...props} onAnswer={(text, post, comment) => {
+        return props.onAnswer(text, post, comment).finally(() => {
+            api.user.refreshUserRestrictions();
+        });
+    }}/>;
+});
 
 export default function CreateCommentComponent(props: CreateCommentProps) {
     const answerRef = useRef<HTMLTextAreaElement>(null);
@@ -219,3 +253,23 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
         </div>
     );
 }
+
+const RestrictedToPostIdMessage = (props: { postId: number | true }) => {
+    return props.postId === true ?
+        <div className={styles.restrictedToPostIdMessage}>
+            Возможность комментировать в чужих постах заблокирована из-за низкой кармы.
+            <a href={'/create'}>Создать свой пост.</a>
+        </div>
+        : <div className={styles.restrictedToPostIdMessage}>
+        Возможность комментировать заблокирована из-за низкой кармы.
+        Можно комментировать только в <a href={`/p${props.postId}`}>этом посте</a>.
+    </div>;
+};
+
+const RestrictedSlowMode = (props: { endTime: Date; endCallback: () => void }) => {
+    return <SlowMode endTime={props.endTime} endCallback={props.endCallback}>
+        <div className={styles.restrictedSlowMode}>
+            Возможность комментировать ограничена из-за низкой кармы. До конца ожидания осталось:
+        </div>
+    </SlowMode>;
+};

--- a/frontend/src/Components/Karma.tsx
+++ b/frontend/src/Components/Karma.tsx
@@ -1,14 +1,22 @@
 import React, {useEffect, useState} from 'react';
 import './KarmaCalculator.scss';
-export function Karma() {
-    const [allPostsValue, setP] = useState(0); // sum of votes for all posts
-    const [allCommentsValue, setC] = useState(0); // sum of votes for all comments
-    const [profileVotesCount, setUCount] = useState(0); //count of votes in profile
-    const [profileVotingResult, setU] = useState(0); // sum of votes in profile
+
+type KarmaCalculatorProps = {
+    postsSumRating?: number;
+    commentsSumRating?: number;
+    profileVotesCount?: number;
+    profileVotesSum?: number;
+};
+
+export function Karma(props: KarmaCalculatorProps) {
+    const [allPostsValue, setP] = useState(props.postsSumRating || 0); // sum of votes for all posts
+    const [allCommentsValue, setC] = useState(props.commentsSumRating || 0); // sum of votes for all comments
+    const [profileVotesCount, setUCount] = useState(props.profileVotesCount || 0); //count of votes in profile
+    const [profileVotingResult, setU] = useState(props.profileVotesSum || 0); // sum of votes in profile
     const [punishment, setPunishment] = useState(0); // penalty set by moderator
 
     useEffect(() => {
-         setU( clamp(profileVotingResult, -profileVotesCount, profileVotesCount));
+         setU( clamp(profileVotingResult, -profileVotesCount * 2, profileVotesCount * 2));
     },[profileVotesCount, profileVotingResult]);
 
     //TODO extract the rest of coefficients to constants and comment them
@@ -44,7 +52,7 @@ export function Karma() {
                         <input type="range" min="0" max="250" value={profileVotesCount.toString()} step="1" onChange={e => setUCount( +e.target.value) } />
                 </label>
                 <label className="slider">Сумма всех голосов в профиле: {profileVotingResult}<br/>
-                        <input type="range" min={-profileVotesCount} max={profileVotesCount} value={profileVotingResult} step="1" onChange={e => setU( +e.target.value) } />
+                        <input type="range" min={-profileVotesCount * 2} max={profileVotesCount * 2} value={profileVotingResult} step="1" onChange={e => setU( +e.target.value) } />
                 </label>
                 <label className="slider">Кармический штраф наложенный сенатом: {punishment}<br/>
                         <input type="range" min="0" max="2000" value={punishment} step="100" onChange={e => setPunishment( +e.target.value) } />

--- a/frontend/src/Components/SlowMode.module.scss
+++ b/frontend/src/Components/SlowMode.module.scss
@@ -1,0 +1,8 @@
+
+.slowmode .message {
+  font-size: 20px;
+}
+
+.slowmode .timeleft {
+  font-size: 40px;
+}

--- a/frontend/src/Components/SlowMode.tsx
+++ b/frontend/src/Components/SlowMode.tsx
@@ -1,0 +1,50 @@
+import React, {FC, useEffect, useState} from 'react';
+import styles from './SlowMode.module.scss';
+
+export type SlowModeProps = {
+    endTime: Date;
+    endCallback?: () => void; // called when slow mode ends
+};
+
+/**
+ * Displays a message with a countdown to the end of the slow mode.
+ * @param props
+ */
+const SlowMode: FC<SlowModeProps> = (props) => {
+    const {endTime, endCallback} = props;
+    const [timeLeft, setTimeLeft] = useState(endTime.getTime() - Date.now());
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            const newTimeLeft = endTime.getTime() - Date.now();
+            if (newTimeLeft <= 0) {
+                if (endCallback) {
+                    endCallback();
+                }
+                clearInterval(interval);
+            } else {
+                setTimeLeft(endTime.getTime() - Date.now());
+            }
+        }, 1000);
+
+        return () => {
+            clearInterval(interval);
+        };
+    }, [endTime]);
+
+    return <div className={styles.slowmode}>
+        {props.children}
+        <div className={styles.timeleft}>{formatTimeLeft(timeLeft)}</div>
+    </div>;
+};
+export default SlowMode;
+
+/*
+* Formats time (in ms) to the format  hh:mm:ss
+* */
+const formatTimeLeft = (timeLeft: number) => {
+    const hours = Math.floor(timeLeft / 1000 / 60 / 60);
+    const minutes = Math.floor(timeLeft / 1000 / 60 % 60);
+    const seconds = Math.floor(timeLeft / 1000 % 60);
+    return `${hours}:${minutes < 10 ? '0' : ''}${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
+};

--- a/frontend/src/Components/UserProfileKarma.module.scss
+++ b/frontend/src/Components/UserProfileKarma.module.scss
@@ -1,0 +1,5 @@
+
+.container {
+  display: flex;
+  flex-direction: row;
+}

--- a/frontend/src/Components/UserProfileKarma.tsx
+++ b/frontend/src/Components/UserProfileKarma.tsx
@@ -1,0 +1,105 @@
+import {useAPI} from '../AppState/AppState';
+import React, {useEffect, useState} from 'react';
+import Username from './Username';
+import {Karma} from './Karma';
+import {UserKarmaResponse} from '../API/UserAPI';
+import ratingSwitchStyles from './RatingSwitch.module.scss';
+import styles from './UserProfileKarma.module.scss';
+import {Link} from 'react-router-dom';
+
+type UserProfileKarmaProps = {
+    username: string;
+};
+
+export const UserProfileKarma = (props: UserProfileKarmaProps) => {
+    const api = useAPI();
+    const [karmaResult, setKarmaResult] = useState<UserKarmaResponse | undefined>();
+
+    useEffect(() => {
+        api.userAPI.userKarma(props.username)
+            .then(result => {
+                console.log('Karma response', result);
+                setKarmaResult(result);
+            })
+            .catch(err => {
+                console.error('Karma response error', err);
+            });
+    }, [api.userAPI]);
+
+
+    const sumPostRating = !karmaResult ? 0 :
+        Object.keys(karmaResult.postRatingBySubsite)
+            .reduce((acc, key) => acc + karmaResult.postRatingBySubsite[key], 0);
+
+    const sumCommentRating = !karmaResult ? 0 :
+        Object.keys(karmaResult.commentRatingBySubsite)
+            .reduce((acc, key) => acc + karmaResult.commentRatingBySubsite[key], 0);
+
+    const activeKarmaVotesSum = !karmaResult ? 0 :
+        Object.keys(karmaResult.activeKarmaVotes)
+            .reduce((acc, key) => acc + karmaResult.activeKarmaVotes[key], 0);
+
+    const activeKarmaVotesCount = !karmaResult ? 0 : Object.keys(karmaResult.activeKarmaVotes).length;
+
+    const positiveKarmaVotes = karmaResult &&
+        Object.keys(karmaResult.activeKarmaVotes).filter(key => karmaResult.activeKarmaVotes[key] > 0);
+
+    const negativeKarmaVotes = karmaResult &&
+        Object.keys(karmaResult.activeKarmaVotes).filter(key => karmaResult.activeKarmaVotes[key] < 0);
+
+    return (
+        !karmaResult ?
+            <div>Загрузка...</div>
+            : <>
+                <div className={styles.container}>
+                    <Karma commentsSumRating={sumCommentRating} postsSumRating={sumPostRating}
+                           profileVotesCount={activeKarmaVotesCount} profileVotesSum={activeKarmaVotesSum}/>
+
+                    <div>
+                        <h3>Голоса активных пользователей:</h3>
+                        <div className={ratingSwitchStyles.listDown}>
+                            <div className={ratingSwitchStyles.listScrollContainer}>
+                                {!!negativeKarmaVotes?.length && <div className={ratingSwitchStyles.listMinus}>
+                                    {negativeKarmaVotes.map((key) => {
+                                        const vote = karmaResult.activeKarmaVotes[key];
+                                        return <div key={key}>
+                                            <Username className={styles.username} user={{username: key}}/>{vote}
+                                        </div>;
+                                    })}
+                                </div>}
+                                {!!positiveKarmaVotes?.length && <div className={ratingSwitchStyles.listPlus}>
+                                    {positiveKarmaVotes.map((key) => {
+                                            const vote = karmaResult.activeKarmaVotes[key];
+                                            return <div key={key}>
+                                                <Username className={styles.username} user={{username: key}}/>+{vote}
+                                            </div>;
+                                        }
+                                    )}
+                                </div>}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div className={styles.container}>
+                    <div>
+                        <h3>Рейтинг постов:</h3>
+                        {Object.keys(karmaResult.postRatingBySubsite).map((key) => {
+                            const rating = karmaResult.postRatingBySubsite[key];
+                            return <div key={key}><Link
+                                to={key === 'main' ? '/' : `/s/${key}`}>{key}</Link>: {rating}
+                            </div>;
+                        })}
+                    </div>
+                    <div>
+                        <h3>Рейтинг комментариев:</h3>
+                        {Object.keys(karmaResult.commentRatingBySubsite).map((key) => {
+                            const rating = karmaResult.commentRatingBySubsite[key];
+                            return <div key={key}><Link
+                                to={key === 'main' ? '/' : `/s/${key}`}>{key}</Link>: {rating}
+                            </div>;
+                        })}
+                    </div>
+                </div>
+            </>
+    );
+};

--- a/frontend/src/Pages/CreatePostPage.module.css
+++ b/frontend/src/Pages/CreatePostPage.module.css
@@ -36,3 +36,10 @@
     display: inline;
     content: "⚠ ";
 }
+
+.createpost .lastPostMessage {
+    margin-bottom: 20px;
+    border-left: var(--danger) solid 4px;
+    padding-left: 20px;
+    line-height: 1.5em;
+}

--- a/frontend/src/Pages/CreatePostPage.tsx
+++ b/frontend/src/Pages/CreatePostPage.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import styles from './CreatePostPage.module.css';
 import createCommentStyles from '../Components/CommentComponent.module.scss';
 import {useAPI, useAppState} from '../AppState/AppState';
@@ -7,10 +7,12 @@ import CreateCommentComponent from '../Components/CreateCommentComponent';
 import {CommentInfo} from '../Types/PostInfo';
 import {toast} from 'react-toastify';
 import classNames from 'classnames';
+import SlowMode from '../Components/SlowMode';
+import {observer} from 'mobx-react-lite';
 
-export function CreatePostPage() {
+export const CreatePostPage = observer(() => {
     const api = useAPI();
-    const {site} = useAppState();
+    const {site, userRestrictions} = useAppState();
     const [title, setTitle] = useState('');
     const navigate = useNavigate();
 
@@ -21,8 +23,7 @@ export function CreatePostPage() {
             const result = await api.postAPI.create(site, title, text);
             console.log('CREATE', result);
             navigate((site !== 'main' ? `/s/${site}` : '') + `/p${result.post.id}`);
-        }
-        catch (error) {
+        } catch (error) {
             console.log('CREATE ERR', error);
             toast.error('Пост хороший, но создать его не удалось 🤐');
             throw error;
@@ -30,6 +31,23 @@ export function CreatePostPage() {
 
         return;
     };
+
+    useEffect(() => {
+        api.user.refreshUserRestrictions();
+    }, [api]);
+
+    if (Number.isInteger(userRestrictions?.restrictedToPostId)) {
+        return <RestrictedToPostIdMessage postId={userRestrictions!.restrictedToPostId as number}/>;
+    }
+
+    if (userRestrictions?.postSlowModeWaitSec) {
+        return <RestrictedSlowMode
+            endTime={new Date(Date.now() + userRestrictions.postSlowModeWaitSec * 1000)}
+            endCallback={() => {
+                api.user.refreshUserRestrictions();
+            }}
+        />;
+    }
 
     const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setTitle(e.target.value);
@@ -39,10 +57,34 @@ export function CreatePostPage() {
         <div className={styles.container}>
             <div className={classNames(styles.createpost, createCommentStyles.content)}>
                 <div className={styles.form}>
-                    <input className={styles.title} type="text" placeholder="Без названия" maxLength={64} value={title} onChange={handleTitleChange} />
-                    <CreateCommentComponent open={true} onAnswer={handleAnswer} />
+                    {userRestrictions?.restrictedToPostId === true && <LastPostMessage/>}
+                    <input className={styles.title} type="text" placeholder="Без названия" maxLength={64} value={title}
+                           onChange={handleTitleChange}/>
+                    <CreateCommentComponent open={true} onAnswer={handleAnswer}/>
                 </div>
             </div>
         </div>
     );
-}
+});
+
+const RestrictedToPostIdMessage = (props: { postId: number }) => {
+    return <div className={styles.restrictedToPostIdMessage}>
+        Возможность создавать посты заблокирована из-за низкой кармы.
+        Можно только комментировать <a href={`/p${props.postId}`}>этот пост</a>.
+    </div>;
+};
+
+const LastPostMessage = () => {
+    return <div className={styles.lastPostMessage}>
+        Внимание! Из-за низкой кармы возможность создавать посты ограничена.
+        Этот пост, на данный момент, будет последним, который можно создать.
+    </div>;
+};
+
+const RestrictedSlowMode = (props: { endTime: Date; endCallback: () => void }) => {
+    return <SlowMode endTime={props.endTime} endCallback={props.endCallback}>
+        <div className={styles.restrictedSlowMode}>
+            Возможность создавать посты ограничена из-за низкой кармы. До конца ожидания осталось:
+        </div>
+    </SlowMode>;
+};

--- a/frontend/src/Pages/PostPage.tsx
+++ b/frontend/src/Pages/PostPage.tsx
@@ -4,7 +4,7 @@ import {Link, useLocation, useParams, useSearchParams} from 'react-router-dom';
 import {CommentInfo, PostInfo, PostLinkInfo} from '../Types/PostInfo';
 import PostComponent from '../Components/PostComponent';
 import CommentComponent from '../Components/CommentComponent';
-import CreateCommentComponent from '../Components/CreateCommentComponent';
+import {CreateCommentComponentRestricted} from '../Components/CreateCommentComponent';
 import {usePost} from '../API/use/usePost';
 import {useAppState} from '../AppState/AppState';
 
@@ -120,7 +120,7 @@ export default function PostPage() {
                                 )
                             }
                         </div>
-                        <CreateCommentComponent open={true} post={post} onAnswer={handleAnswer} />
+                        <CreateCommentComponentRestricted open={true} post={post} onAnswer={handleAnswer} />
                     </div>
                     :
                     (

--- a/frontend/src/Pages/UserPage.tsx
+++ b/frontend/src/Pages/UserPage.tsx
@@ -11,6 +11,7 @@ import UserProfilePosts from '../Components/UserProfilePosts';
 import UserProfileComments from '../Components/UserProfileComments';
 import {UserProfileInvites} from '../Components/UserProfileInvites';
 import {observer} from 'mobx-react-lite';
+import {UserProfileKarma} from '../Components/UserProfileKarma';
 
 export const UserPage = observer(() => {
     const {userInfo} = useAppState();
@@ -25,11 +26,12 @@ export const UserPage = observer(() => {
     const isPosts = page === 'posts';
     const isComments = page === 'comments';
     const isInvites = page === 'invites';
+    const isKarma = page === 'karma';
 
     const navigate = useNavigate();
     const location = useLocation();
 
-    const isProfile = !isPosts && !isComments && !isInvites;
+    const isProfile = !isPosts && !isComments && !isInvites && !isKarma;
 
     useEffect(() => {
         if (state.status === 'ready') {
@@ -57,12 +59,16 @@ export const UserPage = observer(() => {
                 <div className={styles.header}>
                     <div className={styles.username}>{user.username}</div>
                     <div className={styles.name}>{user.name}</div>
-                    <div className={styles.registered}>#{user.id}, зарегистрирован <DateComponent date={user.registered} /></div>
+                    <div className={styles.registered}>#{user.id}, зарегистрирован <DateComponent date={user.registered} />
+                        {user.active && <span className={styles.active} title={'Был на сайте в эту неделю'}>, 🌚 активен</span>}
+                        {!user.active && <span className={styles.active} title={'Не был на сайте в эту неделю'}>, 🌑 неактивен</span>}
+                    </div>
                 </div>
                 <div className={styles.controls}>
                     <Link className={`${styles.control} ${isProfile ? styles.active : ''}`} to={base}>Профиль</Link>
                     <Link className={`${styles.control} ${isPosts ? styles.active : ''}`} to={base + '/posts'}>Посты</Link>
                     <Link className={`${styles.control} ${isComments ? styles.active : ''}`} to={base + '/comments'}>Комментарии</Link>
+                    <Link className={`${styles.control} ${isKarma ? styles.active : ''}`} to={base + '/karma'}>Карма</Link>
                     {isMyProfile && <Link className={`${styles.control} ${isInvites ? styles.active : ''}`} to={'/profile/invites'}>Инвайты</Link>}
                     <div className={styles.karma}>
                         <RatingSwitch rating={rating} type='user' id={user.id} double={true} />
@@ -83,6 +89,7 @@ export const UserPage = observer(() => {
                     {isPosts && <UserProfilePosts username={user.username} />}
                     {isComments && <UserProfileComments username={user.username} />}
                     {isInvites && <UserProfileInvites />}
+                    {isKarma && <UserProfileKarma username={user.username} />}
                 </div>
             </div>
         );

--- a/frontend/src/Types/UserInfo.ts
+++ b/frontend/src/Types/UserInfo.ts
@@ -18,5 +18,6 @@ export type UserInfo = UserBaseInfo & {
 
 export type UserProfileInfo = UserInfo & {
     registered: Date;
+    active: boolean;
 };
 


### PR DESCRIPTION
❗ NOTE:   this PR is made on top of  #94  (review and merge #94 first)

### Implemented:
* Slow mode for posts and comments (wait time between posting two posts or comments)
* Commenting restrictions to the post with specific ID
* Restrictions are calculated on the server and validated both on the server and the client
* Voting restrictions

### Current thresholds:
when effective karma < -10:
* slow mode for posts 12 hours
* slow mode for comments 10 minutes
* disabled ability to vote for anything

when effective karma <= -1000 (lowest possible value currently):
* ability create one last post if there aren't any currently
* commenting restricted to the last own post
* comment slow mode 1 hour
* disabled ability to vote for anything


### Demo:
(don't pay attention to timer values, see above for actual numbers)

1.  User with karma -1000 and no posts can create one last post and comment only there:
![orb-timer6](https://user-images.githubusercontent.com/2865203/178176313-674dccdc-8d70-4805-af08-9bba4cb5e526.gif)

2. Commenting slow mode demo:
![orb-timer4](https://user-images.githubusercontent.com/2865203/178176422-26567b5d-1a1d-45a8-818e-fc6e7da20e19.gif)
 
3. Slow mode demo2:
![orb-timer3](https://user-images.githubusercontent.com/2865203/178176473-e98b8d0e-8082-41fd-a31b-bb36f4206150.gif)

4. Post slow mode demo:
![orb-timer2](https://user-images.githubusercontent.com/2865203/178176500-b6058815-1bdc-4f32-9c33-cea9cfb86911.gif)


### Testing:
* manually verified all comment/post scenarios for users:
   * with positive effective karma
   * with karma < -10
   * with karma == -1000
