### PR TITLE
More self-regulation restrictions

### DIFF
--- a/backend/src/api/InviteController.ts
+++ b/backend/src/api/InviteController.ts
@@ -70,6 +70,13 @@ export default class InviteController {
                 return response.error('invalid-code', 'Invite code not found or already used');
             }
 
+            const issuerRestrictions = await this.userManager.getUserRestrictions(invite.issued_by);
+            if (!issuerRestrictions.canInvite) {
+                this.logger.warn(`Invite issuer ${invite.issued_by} has no permission to invite`,
+                    {invite: code});
+                return response.error('invalid-code', 'Invite code can\'t be used');
+            }
+
             return response.success({
                 code: invite.code,
                 inviter: invite.issuer

--- a/backend/src/api/types/requests/UserProfile.ts
+++ b/backend/src/api/types/requests/UserProfile.ts
@@ -23,4 +23,5 @@ export type UserRestrictionsResponse = {
     commentSlowModeWaitSec: number;
     restrictedToPostId: number | true | false;
     canVote: boolean;
+    canInvite: boolean;
 };

--- a/backend/src/managers/types/UserInfo.ts
+++ b/backend/src/managers/types/UserInfo.ts
@@ -42,4 +42,5 @@ export type UserRestrictions = {
                                                   if true - restriction active, but no posts,
                                                   if false - no restriction */
     canVote: boolean; /* if user can vote for posts, comments and karma */
+    canInvite: boolean; /* whether invites by this user should work */
 };

--- a/frontend/src/API/UserAPI.ts
+++ b/frontend/src/API/UserAPI.ts
@@ -63,6 +63,7 @@ export type UserRestrictionsResponse = {
     commentSlowModeWaitSec: number;
     restrictedToPostId: number | true | false;
     canVote: boolean;
+    canInvite: boolean;
 };
 
 export default class UserAPI {

--- a/frontend/src/Components/Karma.tsx
+++ b/frontend/src/Components/Karma.tsx
@@ -40,7 +40,7 @@ export function Karma(props: KarmaCalculatorProps) {
 
     return (
         <div id='karmaCalculator'>
-            <h1>Калькулятор кармы</h1>
+            <h1>Калькулятор</h1>
             <h2>Входные данные</h2>
                 <label className="slider">Суммарный рейтинг всех постов: {allPostsValue}<br/>
                         <input type="range" min="-2000" max="30000" value={allPostsValue} step="100" onChange={e => setP( +e.target.value) } />
@@ -60,11 +60,11 @@ export function Karma(props: KarmaCalculatorProps) {
 
                 <div>
                     <h2>-------------------------------------</h2>
-                    <h2>Результат</h2>
+                    <h2>Формула саморегуляции:</h2>
                     <p> Рейтинг контента: {contentRating}</p>
                     <p> Рейтинг юзера: {userRating}</p>
-                    <p> Сырая Карма: {rawKarma}</p>
-                    <p> Карма: {karma}</p>
+                    <p> Сырой результат: {rawKarma}</p>
+                    <p> Результат: {karma}</p>
                 </div>
         </div>
     );

--- a/frontend/src/Components/UserProfileKarma.module.scss
+++ b/frontend/src/Components/UserProfileKarma.module.scss
@@ -3,3 +3,25 @@
   display: flex;
   flex-direction: row;
 }
+
+.restricted {
+  border-radius: 5px;
+  padding: 5px;
+  background-color: var(--danger);
+  font-size: 14px;
+  line-height: 20px;
+  margin-top: 5px;
+  white-space: nowrap;
+}
+
+.restricted a {
+  text-shadow: var(--bg) 0 0 2px;
+}
+
+.subsiteList {
+  background: var(--elevated);
+  box-shadow: 0 0 4px var(--shadow);
+  border-radius: 8px;
+  border-right: 1px solid var(--bg);
+  padding: 10px;
+}

--- a/frontend/src/Pages/UserPage.tsx
+++ b/frontend/src/Pages/UserPage.tsx
@@ -60,15 +60,15 @@ export const UserPage = observer(() => {
                     <div className={styles.username}>{user.username}</div>
                     <div className={styles.name}>{user.name}</div>
                     <div className={styles.registered}>#{user.id}, зарегистрирован <DateComponent date={user.registered} />
-                        {user.active && <span className={styles.active} title={'Был на сайте в эту неделю'}>, <span className={'i i-alive'}></span>  активен</span>}
-                        {!user.active && <span className={styles.active} title={'Не был на сайте в эту неделю'}>, <span className={'i i-ghost'}></span> неактивен</span>}
+                        {user.active && <span className={styles.active} title={'Активно посещал сайт в эту неделю'}>, <span className={'i i-alive'}></span>  активен</span>}
+                        {!user.active && <span className={styles.active} title={'Не был или был недолго на сайте в эту неделю'}>, <span className={'i i-ghost'}></span> неактивен</span>}
                     </div>
                 </div>
                 <div className={styles.controls}>
                     <Link className={`${styles.control} ${isProfile ? styles.active : ''}`} to={base}>Профиль</Link>
                     <Link className={`${styles.control} ${isPosts ? styles.active : ''}`} to={base + '/posts'}>Посты</Link>
                     <Link className={`${styles.control} ${isComments ? styles.active : ''}`} to={base + '/comments'}>Комментарии</Link>
-                    <Link className={`${styles.control} ${isKarma ? styles.active : ''}`} to={base + '/karma'}>Карма</Link>
+                    <Link className={`${styles.control} ${isKarma ? styles.active : ''}`} to={base + '/karma'}>Саморегуляция</Link>
                     {isMyProfile && <Link className={`${styles.control} ${isInvites ? styles.active : ''}`} to={'/profile/invites'}>Инвайты</Link>}
                     <div className={styles.karma}>
                         <RatingSwitch rating={rating} type='user' id={user.id} double={true} />


### PR DESCRIPTION
### Changes

* renamed profile page "karma" -> "self-regulation"
* removed "karma calculator" -> "self-regulation formula calculator"
* invites are disabled when issuer's "self-regulation score" <= 0
* when "self-regulation score" < -10 karma votes by the user are revoked (triggered on certain actions)
* display active restrictions in profile
* minor change in `VoteRepository.ts`: add `voterId` and `userId` for all vote-returning queries
   *  and remove now unnecessary call to `UserManager.getByUsername` in `UserManager`

### Example restrictions displayed:
![image](https://user-images.githubusercontent.com/2865203/183808454-627d36b0-b84b-4e51-ba65-8dbad7deb67a.png)

### Network error when checking an invite of the user with low "self-regulation score":
![image](https://user-images.githubusercontent.com/2865203/183808504-9f286c4e-ca54-468e-a556-d5faabb77da7.png)

### Calculator after renaming:
<img width="671" alt="image" src="https://user-images.githubusercontent.com/2865203/183809972-4c176eb9-6b51-4ebe-a195-35a8d1038783.png">

### Testing:
* tested locally on recent dump
* tested in debugger