### PR TITLE
Trivial: Notifications to new comments only

### DIFF
--- a/backend/src/managers/NotificationManager.ts
+++ b/backend/src/managers/NotificationManager.ts
@@ -236,7 +236,7 @@ export default class NotificationManager {
         }
 
         const subdomain = (site.subdomain === 'main' ? '' : '/s/' + site.subdomain);
-        const url = `${baseUrl}${subdomain}/p${notification.source.postId}#${notification.source.commentId}`;
+        const url = `${baseUrl}${subdomain}/p${notification.source.postId}?new#${notification.source.commentId}`;
         const icon = `${baseUrl}/favicon.ico`;
 
         let title = '';

--- a/frontend/src/Components/NotificationsPopup.tsx
+++ b/frontend/src/Components/NotificationsPopup.tsx
@@ -105,6 +105,7 @@ export default function NotificationsPopup(props: NotificationsPopupProps) {
                         post={{ id: notify.source.post.id, site: notify.source.post.site }}
                         commentId={notify.source.comment?.id}
                         onClick={e => handleNotificationClick(e, notify)}
+                        onlyNew={true}
                     >
                         <div className={styles.type}>{notify.type === 'answer' ? <CommentIcon /> : <MentionIcon />}</div>
                         <div className={styles.content}>


### PR DESCRIPTION
Currently notification and webpush links open posts in the "all comments mode" (links like `http://orbitar.local/p1963#54371`).

This is not convenient and there is no reason to do that.

This tiny change make the links look like `http://orbitar.local/p1963?new#54371`, selecting "only new comments" mode by default.