### PR TITLE
Trivial: Remove the extra '@' in the link to parent comment

### DIFF
--- a/frontend/src/Components/SignatureComponent.tsx
+++ b/frontend/src/Components/SignatureComponent.tsx
@@ -27,7 +27,7 @@ export const SignatureComponent = (props: SignatureComponentProps) => {
         <div className={styles.signature}>
             {(props.showSite && props.site && props.site !== 'main') ? <><Link to={`/s/${props.site}`}>{props.site}</Link> • </> : ''}
             <Username className={styles.username} user={props.author} /> • <PostLink post={props.postLink} commentId={props.commentId}><DateComponent date={props.date} /></PostLink>
-            {props.parentCommentId && <> • <PostLink className={'arrow i i-arrow'} post={props.postLink} onlyNew={props.postLinkIsNew} commentId={props.parentCommentId}> @{props.parentCommentAuthor}</PostLink></>}
+            {props.parentCommentId && <> • <PostLink className={'arrow i i-arrow'} post={props.postLink} onlyNew={props.postLinkIsNew} commentId={props.parentCommentId}> {props.parentCommentAuthor}</PostLink></>}
             {props.editFlag && <> • <button className={styles.toggleHistory} onClick={props.onHistoryClick}>изменён</button></>}
         </div>
     );


### PR DESCRIPTION
As per poll results:
<img width="382" alt="image" src="https://user-images.githubusercontent.com/2865203/184506551-7de431e4-e068-4ce2-8d47-5c7de78f6b17.png">
<img width="371" alt="image" src="https://user-images.githubusercontent.com/2865203/184506559-46edd593-ded2-4c84-8c02-6bad7d0edd01.png">
