### PR TITLE
Add rate limiters for most critical actions

### DIFF
--- a/backend/src/db/repositories/SiteRepository.ts
+++ b/backend/src/db/repositories/SiteRepository.ts
@@ -1,5 +1,5 @@
 import DB from '../DB';
-import {SiteRaw, SiteWithUserInfoRaw} from '../types/SiteRaw';
+import {SiteRaw, SiteWithUserInfoRaw, UserSiteSubscription} from '../types/SiteRaw';
 import CodeError from '../../CodeError';
 
 export default class SiteRepository {
@@ -131,6 +131,22 @@ export default class SiteRepository {
                 forUserId,
                 limitFrom,
                 limit: perpage
+            });
+    }
+
+    getSubscription(userId: number, siteId: number): Promise<UserSiteSubscription | undefined> {
+        return this.db.fetchOne<UserSiteSubscription>(`
+                select
+                    feed_main,
+                    feed_bookmarks
+                from user_sites
+                where
+                    user_id = :user_id
+                    and site_id = :site_id
+            `,
+            {
+                user_id: userId,
+                site_id: siteId
             });
     }
 }

--- a/backend/src/db/types/SiteRaw.ts
+++ b/backend/src/db/types/SiteRaw.ts
@@ -8,7 +8,9 @@ export interface SiteRaw {
     site_info?: string;
 }
 
-export type SiteWithUserInfoRaw = SiteRaw & {
+export type UserSiteSubscription = {
     feed_main: number;
     feed_bookmarks: number;
 };
+
+export type SiteWithUserInfoRaw = SiteRaw & UserSiteSubscription;

--- a/backend/src/managers/FeedManager.ts
+++ b/backend/src/managers/FeedManager.ts
@@ -241,6 +241,13 @@ export default class FeedManager {
         }
 
         const siteId = site.id;
+
+        const existingSubscription = await this.siteManager.getSubscription(userId, site.id);
+        if (existingSubscription && !!existingSubscription.feed_main === main &&
+            !!existingSubscription.feed_bookmarks === bookmarks) {
+            return { main, bookmarks };
+        }
+
         await this.siteManager.siteSubscribe(userId, site.id, main, bookmarks);
 
         // fanout in background

--- a/backend/src/managers/SiteManager.ts
+++ b/backend/src/managers/SiteManager.ts
@@ -1,7 +1,7 @@
 import {SiteBaseInfo, SiteInfo, SiteWithUserInfo} from './types/SiteInfo';
 import UserManager from './UserManager';
 import SiteRepository from '../db/repositories/SiteRepository';
-import {SiteWithUserInfoRaw} from '../db/types/SiteRaw';
+import {SiteWithUserInfoRaw, UserSiteSubscription} from '../db/types/SiteRaw';
 
 export default class SiteManager {
     private siteRepository: SiteRepository;
@@ -87,6 +87,10 @@ export default class SiteManager {
 
     async siteSubscribe(userId: number, siteId: number, main: boolean, bookmarks: boolean) {
         await this.siteRepository.subscribe(userId, siteId, main, bookmarks);
+    }
+
+    getSubscription(userId: number, siteId: number): Promise<UserSiteSubscription | undefined> {
+        return this.siteRepository.getSubscription(userId, siteId);
     }
 
     async getSubscriptions(forUserId: number): Promise<SiteWithUserInfo[]> {


### PR DESCRIPTION
### Limits added:
* creating posts: 5/hour
* editing posts:  40/(30 mins)
* creating and editing comments (shared, 40/(30 mins) )
* changing site subscriptions 60/hour

Limits added exclusively on server-side for simplicity. Legitimate users should not encounter them.

Example of the rate limiting response in the logs:
```
[info   ] HTTP     429 POST 172.18.0.1 /api/v1/post/create {"meta":{"req":{"body":{"content":"adfdsaff","site":"test","title":""}},"res":{"statusCode":429},"responseTime":2}}
```


**Note**: the value for creating comments was derived from the so called "eduardi threshold". Basically, maximum amount of comments created within 30-minute window is by meme posters ≈35/30mins. The only user above that threshold was `eduardi`, peaking at 70comments/30mins.
