### PR TITLE
Minor fix: post and comment votes list failing due to a mistake in SQL

### DIFF
--- a/backend/src/db/repositories/VoteRepository.ts
+++ b/backend/src/db/repositories/VoteRepository.ts
@@ -160,7 +160,7 @@ export default class VoteRepository {
     }
 
     async getPostVotes(postId: number): Promise<VoteWithUsername[]> {
-        return await this.db.fetchAll(`select u.username, v.vote, v.user_id as userId, v.voter_id as voterId
+        return await this.db.fetchAll(`select u.username, v.vote, u.user_id as userId, v.voter_id as voterId
                                        from post_votes v
                                                 join users u on (v.voter_id = u.user_id)
                                        where v.post_id = :post_id
@@ -170,7 +170,7 @@ export default class VoteRepository {
     }
 
     async getCommentVotes(commentId: number): Promise<VoteWithUsername[]> {
-        return await this.db.fetchAll(`select u.username, v.vote, v.user_id as userId, v.voter_id as voterId
+        return await this.db.fetchAll(`select u.username, v.vote, u.user_id as userId, v.voter_id as voterId
                                        from comment_votes v
                                                 join users u on (v.voter_id = u.user_id)
                                        where v.comment_id = :comment_id


### PR DESCRIPTION
Found during the testing of the `dev` branch:

Query failed Unknown column `'v.user_id'` in `'field list'` 
```
{"code":"ER_BAD_FIELD_ERROR","errno":1054,"sql":"
select u.username, v.vote, v.user_id as userId, v.voter_id as voterId
  from post_votes v
  join users u on (v.voter_id = u.user_id)
    where v.post_id = 1692
    order by voted_at desc
","
sqlMessage":"Unknown column 'v.user_id' in 'field list'",
"sqlState":"42S22",
"stack":"Error: Unknown column 'v.user_id' in 'field list' 
```