### PR TITLE
Dynamically set videos aspect ratio after rendering

### DIFF
--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -19,6 +19,23 @@ function updateContent(div: HTMLDivElement) {
             updateImg(img);
         };
     });
+
+    div.querySelectorAll('video').forEach(video => {
+        updateVideo(video);
+    });
+}
+
+function updateVideo(video: HTMLVideoElement) {
+    if (video.dataset.aspectRatioProcessed) {
+        return;
+    }
+    video.addEventListener('loadeddata', () => {
+        if (video.readyState < 3 || video.videoHeight === 0) {
+            return;
+        }
+        video.style.aspectRatio = (video.videoWidth / video.videoHeight).toString();
+        video.dataset.aspectRatioProcessed = '1';
+    });
 }
 
 function updateImg(img: HTMLImageElement) {


### PR DESCRIPTION
After we applied aspect ratio css rule for embedded videos, vertical videos started to get shrinked, this dynamically fixes videos (`<video>` tag) depending on their actual aspect ratios

@thinkjazz could you please also take a look, thanks