### PR TITLE
fix #121 posts without read comments not showing in watch

### DIFF
--- a/backend/migrations/20220913233142-user-bookmarks-read-comments-not-null.js
+++ b/backend/migrations/20220913233142-user-bookmarks-read-comments-not-null.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+    dbm = options.dbmigrate;
+    type = dbm.dataType;
+    seed = seedLink;
+};
+
+exports.up = async function (db) {
+    await db.runSql(`
+        update user_bookmarks
+        set read_comments = 0
+        where read_comments is null;
+    `);
+    await db.runSql(`
+        alter table user_bookmarks modify read_comments int not null default 0;
+    `)
+};
+
+exports.down = async function (db) {
+    await db.runSql(`
+        alter table user_bookmarks modify read_comments int null;
+    `);
+};
+
+exports._meta = {
+    "version": 1
+};

--- a/backend/src/db/repositories/UserRepository.ts
+++ b/backend/src/db/repositories/UserRepository.ts
@@ -95,7 +95,7 @@ export default class UserRepository {
 
     async getUserUnreadComments(forUserId: number): Promise<number> {
         const res = await this.db.fetchOne<{ cnt: string }>(`
-          select sum(p.comments - COALESCE(ub.read_comments, 0)) cnt
+          select sum(p.comments - ub.read_comments) cnt
             from
               user_bookmarks ub
               join posts p on (p.post_id = ub.post_id)


### PR DESCRIPTION
Changes:
* made  `orbitar_db.user_bookmarks.read_comments` non-null

related: #100

Testing:
* manual:
   * used a fresh user to add a post with lots of comments to watched
   * observed the comments number appear near the "fire" and the post appear in "feed/watch/all",  but not in "feed/watch"
   * applied the fix
   * observed post appear also in the "feed/watch"