### PR TITLE
set mysql to image instead of build context

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,16 +16,17 @@ services:
 
   mysql:
     platform: linux/amd64
-    build:
-      context: mysql
+    image: mysql:5.7
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     volumes:
       - mysql_db:/var/lib/mysql
+      - $PWD/mysql/schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro
     ports:
       - "3306:3306"
-
+      - "33060:33060"
+      
   redis:
     image: redis:7
     restart: always

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -19,14 +19,14 @@ services:
 
   mysql:
     platform: linux/amd64
-    build:
-      context: mysql
+    image: mysql:5.7
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     volumes:
       - mysql_db:/var/lib/mysql
-
+      - $PWD/mysql/schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro
+  
   redis:
     image: redis:7
     restart: always

--- a/docker-compose.ssl.dev.yml
+++ b/docker-compose.ssl.dev.yml
@@ -17,15 +17,16 @@ services:
 
   mysql:
     platform: linux/amd64
-    build:
-      context: mysql
+    image: mysql:5.7
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     volumes:
       - mysql_db:/var/lib/mysql
+      - $PWD/mysql/schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro
     ports:
       - "3306:3306"
+      - "33060:33060"
 
   redis:
     image: redis:7

--- a/docker-compose.ssl.local.yml
+++ b/docker-compose.ssl.local.yml
@@ -21,13 +21,13 @@ services:
 
   mysql:
     platform: linux/amd64
-    build:
-      context: mysql
+    image: mysql:5.7
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     volumes:
       - mysql_db:/var/lib/mysql
+      - $PWD/mysql/schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro
 
   redis:
     image: redis:7

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,5 +1,0 @@
-FROM mysql:5.7.37
-
-ADD schema.sql /docker-entrypoint-initdb.d
-
-EXPOSE 3306


### PR DESCRIPTION
Replaced custom mysql context with a build script with MySQL image with an initdb script.

Starts faster, doesn't require build. Starting from scratch would require just to delete the _mysql_db_ volume, no need to rebuild the image with `--no-cache`.

Now tested with dev, properly publishes basic + MySQL X ports (3306 & 33060).