### PR TITLE
Fix changing of the feed sorting on subsites

### DIFF
--- a/frontend/src/API/PostAPIHelper.ts
+++ b/frontend/src/API/PostAPIHelper.ts
@@ -16,7 +16,7 @@ type FeedSubscriptionsResult = {
     posts: PostInfo[];
     sites: Record<string, SiteInfo>;
     total: number;
-    sorting?: FeedSorting;
+    sorting: FeedSorting;
 };
 
 type PostResult = {
@@ -104,7 +104,8 @@ export default class PostAPIHelper {
         return {
             posts: this.fixPosts(response.posts, response.users),
             sites: response.sites,
-            total: response.total
+            total: response.total,
+            sorting: FeedSorting.postCommentedAt
         };
     }
 

--- a/frontend/src/API/use/useFeed.ts
+++ b/frontend/src/API/use/useFeed.ts
@@ -6,7 +6,9 @@ import {FeedSorting} from '../../Types/FeedSortingSettings';
 
 export type FeedType = 'all' | 'subscriptions' | 'site' | 'watch' | 'watch-all' | 'user-profile';
 
-export function useFeed(id: string, feedType: FeedType | undefined, page: number, perpage: number, changedSorting?: FeedSorting) {
+export function useFeed(id: string, feedType: FeedType | undefined, page: number, perpage: number,
+                        setSorting?: (sorting: FeedSorting) => void, sorting?: FeedSorting) {
+
     const api = useAPI();
     const [cachedPosts, setCachedPosts] = useCache<PostInfo[]>('feed', [id, feedType, page, perpage]);
 
@@ -14,7 +16,6 @@ export function useFeed(id: string, feedType: FeedType | undefined, page: number
     const [loading, setLoading] = useState(true);
     const [pages, setPages] = useState(0);
     const [error, setError] = useState<[string, Error]>();
-    const [sorting, setSorting] = useState<FeedSorting | undefined>(FeedSorting.postCommentedAt);
 
     const updatePost = useMemo(() => {
         return (id: number, partial: Partial<PostInfo>) => {
@@ -43,7 +44,7 @@ export function useFeed(id: string, feedType: FeedType | undefined, page: number
                     setPosts(result.posts);
                     const pages = Math.floor((result.total - 1) / perpage) + 1;
                     setPages(pages);
-                    setSorting(result.sorting);
+                    setSorting?.(result.sorting);
                 })
                 .catch(error => {
                     console.log('FEED ERROR', error);
@@ -60,7 +61,7 @@ export function useFeed(id: string, feedType: FeedType | undefined, page: number
                     setPosts(result.posts);
                     const pages = Math.floor((result.total - 1) / perpage) + 1;
                     setPages(pages);
-                    setSorting(result.sorting);
+                    setSorting?.(result.sorting);
                 })
                 .catch(error => {
                     console.log('FEED ERROR', error);
@@ -77,7 +78,7 @@ export function useFeed(id: string, feedType: FeedType | undefined, page: number
                     setPosts(result.posts);
                     const pages = Math.floor((result.total - 1) / perpage) + 1;
                     setPages(pages);
-                    setSorting(result.sorting);
+                    setSorting?.(result.sorting);
                 })
                 .catch(error => {
                     console.log('FEED ERROR', error);
@@ -114,7 +115,7 @@ export function useFeed(id: string, feedType: FeedType | undefined, page: number
                 setError(['Не удалось загрузить ленту постов', error]);
             });
         }
-    }, [id, feedType, page, api.post, perpage, changedSorting]);
+    }, [id, feedType, page, api.post, perpage, sorting]);
 
-    return { posts, loading, pages, error, updatePost, sorting, setLoading };
+    return { posts, loading, pages, error, updatePost, setLoading };
 }

--- a/frontend/src/Pages/FeedPage.tsx
+++ b/frontend/src/Pages/FeedPage.tsx
@@ -40,8 +40,8 @@ export default function FeedPage() {
     const perpage = 20;
     const page = parseInt(search.get('page') || '1');
 
-    const [changeSorting, setChangeSorting] = useState<FeedSorting>();
-    const {posts, loading, pages, error, updatePost, sorting, setLoading} = useFeed(site, feedType, page, perpage, changeSorting);
+    const [sorting, setSorting] = useState<FeedSorting>();
+    const {posts, loading, pages, error, updatePost, setLoading} = useFeed(site, feedType, page, perpage, setSorting, sorting);
 
     useEffect(() => {
         window.scrollTo({ top: 0 });
@@ -62,7 +62,7 @@ export default function FeedPage() {
         e.preventDefault();
         setLoading(true);
         await api.feed.saveSorting(site, newFeedSorting);
-        setChangeSorting(newFeedSorting);
+        setSorting(newFeedSorting);
         setLoading(false);
     };
 


### PR DESCRIPTION
Issue description:
On the subsites that were not previously visited, it was impossible to change sorting (button didn't do anything).

The problem was in misalignment between two states and their default values. I simplified the whole thing to have a single state.