### PR TITLE
Fix status update cycle after first login

### DIFF
--- a/frontend/src/Pages/FeedPage.tsx
+++ b/frontend/src/Pages/FeedPage.tsx
@@ -8,8 +8,9 @@ import {FeedType, useFeed} from '../API/use/useFeed';
 import {APIError} from '../API/APIBase';
 import {FeedSorting} from '../Types/FeedSortingSettings';
 import classNames from 'classnames';
+import {observer} from 'mobx-react-lite';
 
-export default function FeedPage() {
+const FeedPage = observer(() => {
     const { site, siteInfo } = useAppState();
     const api = useAPI();
 
@@ -92,6 +93,7 @@ export default function FeedPage() {
             </div>
         </div>
     );
-}
+});
 
+export default FeedPage;
 

--- a/frontend/src/Pages/InvitePage.tsx
+++ b/frontend/src/Pages/InvitePage.tsx
@@ -58,9 +58,7 @@ export default function InvitePage() {
                 setFormDisabled(false);
                 console.log('USE SUCCESS', result);
                 navigate('/');
-                api.init().then(() => {
-
-                });
+                api.init().then();
             })
             .catch(error => {
                 setFormDisabled(false);

--- a/frontend/src/Pages/SignInPage.tsx
+++ b/frontend/src/Pages/SignInPage.tsx
@@ -34,6 +34,7 @@ export default function SignInPage() {
         api.auth.signIn(data.username, data.password)
             .then(() => {
                 navigate(location.pathname, {replace: true});
+                api.init().then();
             })
             .catch(error => {
                 setSigningIn(false);


### PR DESCRIPTION
Also fixes subsites list and feed sorting options display (after login).


Context: status update cycle is responsible for setting `AppState.siteInfo`. When user is not authenticated, the cycle stops (intentionally) and has to be restarted after login.