### PR TITLE
Added activity_db rights to schema

### DIFF
--- a/mysql/schema.sql
+++ b/mysql/schema.sql
@@ -7,7 +7,7 @@ USE `orbitar_db`;
 
 CREATE USER 'orbitar'@'%' IDENTIFIED BY 'orbitar';
 GRANT SELECT, INSERT, UPDATE, DELETE ON orbitar_db.* TO 'orbitar'@'%';
-
+GRANT SELECT, INSERT, UPDATE, DELETE ON activity_db.* TO 'orbitar'@'%'; -- activity_db does not exist in the original schema, but added in migrations
 
 DROP TABLE IF EXISTS `comment_votes`;
 CREATE TABLE `comment_votes` (


### PR DESCRIPTION
When orbitar is set up from scratch, initial schema is upgraded by migrations progressively.

When orbitar database is restored from backup, some of the migrations are skipped as they are marked as complete in the backup.
However, the backup does not include changes to grants included in some migrations. As a result, the scenario when one sets up orbitar and restores a backup may result in a situation where orbitar is non-functional.

This PR is supposed to fix this.

Tested the following scenarios:
1. Deploying orbitar from scratch
2. Restoring backup to the existing deployment
3. Removing volumes from the previous scenarios, restoring database, deploying orbitar on top of the restored database.