### PR TITLE
DB actions

### DIFF
--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -1,0 +1,38 @@
+name: Backup DB
+
+concurrency: prod
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '20 1 * * *' # At 01:20 UTC every day
+
+jobs:
+  backup-db:
+    runs-on: [self-hosted, prod]
+    environment: Production
+    steps:
+      - name: Set backup name
+        run: echo "backupFileName=${HOSTNAME}_$(date +%Y-%m-%d_%H-%M-%S)_dump.sql" >> $GITHUB_ENV
+
+      - name: Dump database
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+        run: echo $MYSQL_ROOT_PASSWORD | docker-compose -f /orbitar/docker-compose.yml exec -T mysql mysqldump --default-character-set=utf8mb4 --single-transaction --add-drop-database --databases orbitar_db activity_db -u root -p > ${{ env.backupFileName }}
+      
+      - name: Compress database
+        env:
+          BACKUP_PASSWORD: ${{ secrets.BACKUP_PASSWORD }}
+        run: zip -m -P $BACKUP_PASSWORD ${{ env.backupFileName }}.zip ${{ env.backupFileName }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.backupFileName }}
+          path: ${{ env.backupFileName }}.zip
+          if-no-files-found: error
+
+      - name: Clean working directory
+        run: |
+          rm -rf ./* || true
+          rm -rf ./.??* || true

--- a/.github/workflows/restore-sanitized-db.yml
+++ b/.github/workflows/restore-sanitized-db.yml
@@ -1,0 +1,102 @@
+name: Restore Sanitized DB
+
+concurrency: stage
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  schedule:
+    - cron: '50 1 * * MON' # At 01:50 UTC every Monday
+
+jobs:
+  sanitize-db:
+    runs-on: ubuntu-latest
+    environment: Production
+
+    env:
+      MYSQL_ROOT_PASSWORD: root
+
+    services:
+      mysql:
+        image: mysql:5.7
+        ports:
+          - "3306:3306"
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=10s --health-retries=10
+
+    steps:
+      - name: Download DB backup
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: backup-db.yml
+          workflow_conclusion: success
+          check_artifacts: true
+
+      - name: Unzip artifact & load DB
+        env:
+          BACKUP_PASSWORD: ${{ secrets.BACKUP_PASSWORD }}
+        run: |
+          cd `ls -t | head -n 1`
+          unzip -P $BACKUP_PASSWORD `ls -t | head -n 1`
+          cat `ls -t *.sql | head -n 1` | /usr/bin/mysql -h 127.0.0.1 -u root -p$MYSQL_ROOT_PASSWORD
+
+      - name: Remove PII
+        run: |
+          cat <<EOF | /usr/bin/mysql -h 127.0.0.1 -u root -p$MYSQL_ROOT_PASSWORD --database orbitar_db
+          delete from invites;
+          delete from user_webpush;
+          update users set email='user@example.com';
+          EOF
+
+      - name: Dump database
+        run: mysqldump --host 127.0.0.1 --column-statistics=0 --default-character-set=utf8mb4 --single-transaction --add-drop-database --databases orbitar_db activity_db -u root -p$MYSQL_ROOT_PASSWORD > stage-backup.sql
+      
+      - name: Compress database
+        env:
+          BACKUP_PASSWORD: ${{ secrets.STAGING_BACKUP_PASSWORD }}
+        run: zip -m -P $BACKUP_PASSWORD stage-backup.zip stage-backup.sql
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: stage-backup
+          path: stage-backup.zip
+          if-no-files-found: error
+
+  restore-db:
+    needs: sanitize-db
+    environment: Staging
+    runs-on: [self-hosted, stage]
+    steps:
+      - name: Delete previous artifacts
+        run: |
+          rm -rf ./*.sql || true
+          rm -rf ./*.zip || true
+
+      - uses: actions/checkout@v3
+        with:
+          ref: dev
+
+      - name: Copy configuration
+        run: |
+          cp -f /opt/deployment-specific-files/chain.pem $GITHUB_WORKSPACE/caddy/certs
+          cp -f /opt/deployment-specific-files/priv.pem $GITHUB_WORKSPACE/caddy/certs
+          cp -f /opt/deployment-specific-files/.env $GITHUB_WORKSPACE/      
+      
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: stage-backup
+
+      - name: Stop backend
+        run: docker-compose -f docker-compose.ssl.local.yml stop backend
+
+      - name: Unzip & restore backup
+        env:
+          BACKUP_PASSWORD: ${{ secrets.BACKUP_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+        run: |
+          unzip -P $BACKUP_PASSWORD -o `ls -t *.zip | head -n 1`
+          docker-compose -f docker-compose.ssl.local.yml exec -T mysql /usr/bin/mysql -u root --password=$MYSQL_ROOT_PASSWORD --default-character-set=utf8mb4 < `ls -t *.sql | head -n 1`
+
+      - name: Restart backend
+        run: docker-compose -f docker-compose.ssl.local.yml start backend


### PR DESCRIPTION
Added 2 workflows:
- Backup DB
- Restore Sanitized DB.

## Backup DB
Dumps the databases daily at 01:20 UTC daily using `mysqldump`, zips the dump with a password and uploads it as an artifact.

**Requires**:
- create _Production_ environment in _Settings > Environments_
- create two environment secrets:
  - `MYSQL_ROOT_PASSWORD` - obviously, the root password of the production MySQL server
  - `BACKUP_PASSWORD` - the password to encrypt the ZIP file with
- configure GitHub runner on the production server (pending from me & @Aivean)

## Restore Sanitized DB
Downloads the latest backup at 01:50 UTC every Monday created by the _Backup DB_ workflow, restores it on a random MySQL server, removes the PII, dumps the updated DB, and uploads it as an artifact, encrypted by a password.

**Requires:**
- Backup workflow to run at least once
- create the 3rd environment secret in _Production__:
  - STAGING_BACKUP_PASSWORD - the password to encrypt the sanitized ZIP for Staging environment
 - create two environment secrets in _Staging_:
  - `MYSQL_ROOT_PASSWORD` - obviously, the root password of the production MySQL server
  - `BACKUP_PASSWORD` - the password to decrypt the ZIP encrypted with `STAGING_BACKUP_PASSWORD`