### PR TITLE
Flush redis cache

### DIFF
--- a/.github/workflows/restore-sanitized-db.yml
+++ b/.github/workflows/restore-sanitized-db.yml
@@ -98,10 +98,10 @@ jobs:
           unzip -P $BACKUP_PASSWORD -o `ls -t *.zip | head -n 1`
           docker-compose -f docker-compose.ssl.local.yml exec -T mysql /usr/bin/mysql -u root --password=$MYSQL_ROOT_PASSWORD --default-character-set=utf8mb4 < `ls -t *.sql | head -n 1`
 
-      - name: Restart backend
-        run: docker-compose -f docker-compose.ssl.local.yml start backend
-
       - name: Flush Redis cache
         env:
           REDIS_PASSWORD: orbitar
         run: docker-compose -f docker-compose.ssl.local.yml exec -e REDISCLI_AUTH=$REDIS_PASSWORD redis redis-cli FLUSHALL
+
+      - name: Restart backend
+        run: docker-compose -f docker-compose.ssl.local.yml start backend

--- a/.github/workflows/restore-sanitized-db.yml
+++ b/.github/workflows/restore-sanitized-db.yml
@@ -100,3 +100,8 @@ jobs:
 
       - name: Restart backend
         run: docker-compose -f docker-compose.ssl.local.yml start backend
+
+      - name: Flush Redis cache
+        env:
+          REDIS_PASSWORD: orbitar
+        run: docker-compose -f docker-compose.ssl.local.yml exec -e REDISCLI_AUTH=$REDIS_PASSWORD redis redis-cli FLUSHALL


### PR DESCRIPTION
After restoration of the DB we restart the backend container but we don't flush the redis cache, and it stays populated with the old info.

This change resolves this nuisance.