### PR TITLE
add animation to loader so it doesn't flash when page loads quickly

### DIFF
--- a/frontend/src/Pages/LoadingPage.css
+++ b/frontend/src/Pages/LoadingPage.css
@@ -1,6 +1,0 @@
-.loading {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-}

--- a/frontend/src/Pages/LoadingPage.module.css
+++ b/frontend/src/Pages/LoadingPage.module.css
@@ -1,0 +1,18 @@
+.loading {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    animation: fadein 1s ease-in;
+    animation-fill-mode: forwards;
+    animation-delay: 0.5s;
+}
+
+.loading img {
+    box-shadow: 0 0 100px 18px rgba(0,0,0,0.6);
+}
+
+@keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}

--- a/frontend/src/Pages/LoadingPage.tsx
+++ b/frontend/src/Pages/LoadingPage.tsx
@@ -15,6 +15,8 @@ export default function LoadingPage() {
     });
 
     return (
-        <img className="loading" alt="Loading..." src="/img/robots.gif" />
+        <div className={styles.loading} style={{opacity: 0}}>
+            <img alt="Loading..." src="/img/robots.gif" />
+        </div>
     );
 }

--- a/frontend/src/Pages/LoadingPage.tsx
+++ b/frontend/src/Pages/LoadingPage.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react';
-import './LoadingPage.css';
+import styles from './LoadingPage.module.css';
 
 export default function LoadingPage() {
     document.title = 'ЪУЬ';


### PR DESCRIPTION
It is very annoying when page loads and robots banner is flashing for a moment before page loads.
Adding an animation (with 0.5s delay) and smooth border so it will show up only when backend takes a long time to respond.
Fast 3G:
![Fast 3G](https://i.imgur.com/QXWrA6X.gif)

Slow 3G:
![Slow 3G](https://i.imgur.com/vSkKlBn.gif)

Artificial 2s delay for API response
![Artificial 2s delay for API response](https://i.imgur.com/01pV92A.gif)