### PR TITLE
fix error when user is not found

### DIFF
--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -121,7 +121,7 @@ export default class UserManager {
     async checkPassword(username: string, password: string): Promise<UserInfo | false> {
         const userRaw = await this.userRepository.getUserByUsername(username);
 
-        if (!await bcrypt.compare(password, userRaw.password)) {
+        if (!userRaw || !await bcrypt.compare(password, userRaw.password)) {
             return false;
         }
 


### PR DESCRIPTION
If you try to login with non-existing username - you'll get 500 error because `userRaw` is undefined so it doesn't have `password` field. No existing security threat - just cleanup