### PR TITLE
Save the draft post/comment in the local storage in case the page is reloaded

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "react-textarea-autosize": "^8.3.4",
         "react-toastify": "^8.2.0",
         "typescript": "^4.6.3",
+        "use-debounce": "^8.0.4",
         "webfonts-loader": "^7.5.2"
       },
       "devDependencies": {
@@ -17144,6 +17145,17 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/use-debounce": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-8.0.4.tgz",
+      "integrity": "sha512-fGqsYQzl8kLHF2QpQSgIwgOgJmnh6j5L6SIzQiHdLfwp3q1egUL3btq5Bg2SJysH6A0ILLgT2IqXZKoNJr0nFw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
@@ -30587,6 +30599,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
       "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "requires": {}
+    },
+    "use-debounce": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-8.0.4.tgz",
+      "integrity": "sha512-fGqsYQzl8kLHF2QpQSgIwgOgJmnh6j5L6SIzQiHdLfwp3q1egUL3btq5Bg2SJysH6A0ILLgT2IqXZKoNJr0nFw==",
       "requires": {}
     },
     "use-isomorphic-layout-effect": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.0",
     "react-toastify": "^8.2.0",
+    "use-debounce": "^8.0.4",
     "typescript": "^4.6.3",
     "webfonts-loader": "^7.5.2",
     "react-textarea-autosize": "^8.3.4",

--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -110,7 +110,9 @@ export default function CommentComponent(props: CommentProps) {
             </div>
             {(props.comment.answers || answerOpen) ?
                 <div className={styles.answers + (isFlat?' isFlat':'')}>
-                    {props.onAnswer && <CreateCommentComponentRestricted open={answerOpen} post={props.comment.postLink} comment={props.comment} onAnswer={handleAnswer} />}
+                    {props.onAnswer && <CreateCommentComponentRestricted open={answerOpen} post={props.comment.postLink}
+                                                                         comment={props.comment} onAnswer={handleAnswer}
+                                                                         storageKey={`cp:${props.comment.id}`}/>}
                     {props.comment.answers && props.onAnswer ? props.comment.answers.map( (comment, idx) =>
                         <CommentComponent maxTreeDepth={maxDepth} depth={depth+1} parent={props.comment} key={comment.id}
                                           comment={comment} onAnswer={props.onAnswer} onEdit={props.onEdit} unreadOnly={props.unreadOnly} idx={idx} />) : <></>}

--- a/frontend/src/Pages/CreatePostPage.tsx
+++ b/frontend/src/Pages/CreatePostPage.tsx
@@ -60,7 +60,7 @@ export const CreatePostPage = observer(() => {
                     {userRestrictions?.restrictedToPostId === true && <LastPostMessage/>}
                     <input className={styles.title} type="text" placeholder="Без названия" maxLength={64} value={title}
                            onChange={handleTitleChange}/>
-                    <CreateCommentComponent open={true} onAnswer={handleAnswer}/>
+                    <CreateCommentComponent open={true} onAnswer={handleAnswer} storageKey={`np:${site}`}/>
                 </div>
             </div>
         </div>

--- a/frontend/src/Pages/PostPage.tsx
+++ b/frontend/src/Pages/PostPage.tsx
@@ -120,7 +120,7 @@ export default function PostPage() {
                                 )
                             }
                         </div>
-                        <CreateCommentComponentRestricted open={true} post={post} onAnswer={handleAnswer} />
+                        <CreateCommentComponentRestricted open={true} post={post} onAnswer={handleAnswer} storageKey={`c:${post.id}`} />
                     </div>
                     :
                     (


### PR DESCRIPTION
### Demo:
![orb-ls](https://user-images.githubusercontent.com/2865203/203409858-bca853ca-2742-4e8a-81fb-dbecdf3e2c13.gif)

### Notes:
* saves draft in the local storage per key:
   * the key is parent comment id for posts, subsite for the new post
* removes local storage record on send or when text is cleared
* editing is not supported (the text is restored from the latest content version)