### PR TITLE
Bump prod node version to v16

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:14 as build
+FROM node:16 as build
 WORKDIR /backend
 COPY package*.json ./
 RUN npm install
 COPY . .
-RUN npm install --only=production && npm run build && rm -rf src
+RUN npm install && npm run build && rm -rf src
 
-FROM node:14
+FROM node:16
 COPY --from=build /backend /backend
 WORKDIR /backend
 EXPOSE 5001

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",
     "@types/express": "^4.17.13",
@@ -28,7 +28,6 @@
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "argparse": "^2.0.1",
     "eslint": "^8.14.0",
-    "typescript": "^4.6.3",
     "@types/redis": "^4.0.11",
     "@types/web-push": "^3.3.2",
     "jest": "^28.1.0",
@@ -38,6 +37,7 @@
     "image-size": "^1.0.2"
   },
   "dependencies": {
+    "typescript": "^4.6.3",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "db-migrate": "^1.0.0-beta.18",

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14 as build
+FROM node:16 as build
 WORKDIR /frontend-build
 COPY package*.json ./
 RUN npm install
@@ -13,6 +13,6 @@ RUN npm run build && cp -r build/ /build
 WORKDIR /build
 RUN rm -rf /frontend-build
 
-FROM node:14
+FROM node:16
 COPY --from=build /build /build
 CMD rm -rf /frontend/* && cp -r /build/. /frontend/ && ls /frontend


### PR DESCRIPTION
Reason: found some incompatible API used in #170 :
```
[error  ] POST     translatedHtml.replaceAll is not a function {"stack":"TypeError: translatedHtml.replaceAll is not a function\n    at TranslationManager.<anonymous> (/backend/build/managers/TranslationManager.js:78:45)\n    at Generator.next (<anonymous>)\n    at fulfilled (/backend/build/managers/TranslationManager.js:5:58)\n    at processTicksAndRejections (internal/process/task_queues.js:95:5)"}
```

Testing:
```
 docker-compose -p orbitar-dev -f docker-compose.local.yml up -d --build
```

During the local test found that `backend` image fails to build from scratch:
```
#0 2.508 > backend@1.0.0 build
#0 2.508 > npx tsc
#0 2.508
#0 3.050 npm WARN exec The following package was not found and will be installed: tsc
#0 3.260
#0 3.261
#0 3.261                 This is not the tsc command you are looking for
#0 3.261
#0 3.262
#0 3.262 To get access to the TypeScript compiler, tsc, from the command line either:
#0 3.262
#0 3.263 - Use npm install typescript to first add TypeScript to your project before using npx
#0 3.263 - Use yarn to avoid accidentally running code from un-installed packages
```

Fixed.