### PR TITLE
Added --watch to caddy's startup args

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,6 +13,8 @@ services:
       - $PWD/caddy/Caddyfile.dev:/etc/caddy/Caddyfile
       - caddy_data:/data
       - caddy_config:/config
+    # Default caddy command borrowed from https://github.com/caddyserver/caddy-docker/blob/master/Dockerfile.tmpl
+    command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile", "--watch"] 
 
   mysql:
     platform: linux/amd64

--- a/docker-compose.ssl.dev.yml
+++ b/docker-compose.ssl.dev.yml
@@ -14,6 +14,8 @@ services:
       - $PWD/caddy/certs:/certs
       - caddy_data:/data
       - caddy_config:/config
+    # Default caddy command borrowed from https://github.com/caddyserver/caddy-docker/blob/master/Dockerfile.tmpl
+    command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile", "--watch"] 
 
   mysql:
     platform: linux/amd64


### PR DESCRIPTION
Fixes #188 for local development.

Watching `Caddyfile` for changes in production is [discouraged](https://caddy.community/t/why-is-caddy-run-watch-dangerous/8981).

The right way would be to [reload caddy gracefully](https://hub.docker.com/_/caddy) after the config changes are complete.

For us it would be something in the likes of
`docker-compose -f docker-compose.ssl.local.yml exec -w /etc/caddy caddy caddy reload`