### PR TITLE
Improve the display of the large images inside the ContentComponent

### DIFF
--- a/frontend/src/Components/ContentComponent.module.scss
+++ b/frontend/src/Components/ContentComponent.module.scss
@@ -1,12 +1,12 @@
 .content {
   max-height: fit-content;
-  
+
   iframe, video {
       max-width: 100%;
       aspect-ratio: 16 / 9;
       height: auto;
   }
-  
+
   &.cut {
     max-height: 650px;
     overflow: hidden;
@@ -15,6 +15,11 @@
   }
   b, i, u, strike, blockquote{
     color: var(--fg);
+  }
+
+  img {
+    max-width: 100%;
+    max-height: 500px;
   }
 }
 

--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -39,6 +39,10 @@ function updateVideo(video: HTMLVideoElement) {
 }
 
 function updateImg(img: HTMLImageElement) {
+    if (img.naturalWidth > 500 || img.naturalHeight > 500) {
+        img.classList.add('image-large');
+    }
+
     let el: HTMLElement | null = img;
     while (el) {
         if (el.tagName.toUpperCase() === 'A') {

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -102,6 +102,9 @@ img.image-preview {
   max-height: none;
   cursor: zoom-out;
 }
+img.image-large {
+  display: block;
+}
 img.low-rating, video.low-rating, iframe.low-rating {
   opacity: 0.5;
   /*blur*/


### PR DESCRIPTION
Three cases are improved/fixed.

1. Large image is displayed as block instead of inline, fix annoying "hanging" images:
```
test test https://idiod.video/m3pxt9.png test test
```
<img width="866" alt="image" src="https://user-images.githubusercontent.com/2865203/205471354-7d0072f5-2890-4e7b-a6bd-83bab066312a.png">

2. Large images nested inside of links have their dimensions properly capped (and also displayed as block):
```
test<a href="https://orbitar.space"><b>https://idiod.video/m3pxt9.png</b></a>test
```
<img width="929" alt="image" src="https://user-images.githubusercontent.com/2865203/205471363-28b0e69c-354e-4bd3-a949-710aef508715.png">

3. Small images and images nested in the links are displayed inline as before:
```
test<a href="https://orbitar.space"><b>https://idiod.video/100x100/m3pxt9.png</b></a>test
```
<img width="526" alt="image" src="https://user-images.githubusercontent.com/2865203/205471437-3484cae7-b516-4995-88c9-bcf7ce992ced.png">
