### PR TITLE
Fix redis health check

### DIFF
--- a/docker-compose.ssl.local.yml
+++ b/docker-compose.ssl.local.yml
@@ -40,7 +40,7 @@ services:
     volumes:
       - redis_data:/data
     healthcheck:
-      test: [ "CMD", "redis-cli ping | grep PONG" ]
+      test: "[ $$(redis-cli -a $REDIS_PASSWORD ping) = 'PONG' ]"
       interval: 5s
       timeout: 20s
       retries: 10


### PR DESCRIPTION
As is apparent from this [failed deployment](https://github.com/spaceshelter/orbitar/actions/runs/3675068369) the current health check is not working.

Reverting back the the old (working one).

# Testing

Locally:

works:

    test: "[ $(redis-cli -a ${REDIS_PASSWORD} ping) = 'PONG' ]"

Doesn't work:

    test: "[ $(redis-cli -a ${REDIS_PASSWORD} ping) = 'PONG1' ]"

    test: "[ $(redis-cli  ping) = 'PONG' ]"

Syntax wise, per https://docs.docker.com/compose/compose-file/compose-file-v3/

![image](https://user-images.githubusercontent.com/2865203/207161387-9d3f11e0-a17d-40da-89c8-8cc778397563.png)
