### PR TITLE
Annotations for the universal deployment workflow

### DIFF
--- a/.github/workflows/deploy-universal.yml
+++ b/.github/workflows/deploy-universal.yml
@@ -30,7 +30,33 @@ on:
           - "--no-cache"
 
 jobs:
+  info:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Info
+        run: |
+            if [ "${{ github.event.inputs.environment }}" = "prod" ]; then
+              echo "::warning::Deploying to PRODUCTION!"
+            elif [ "${{ github.event.inputs.environment }}" = "stage" ]; then
+              echo "::notice::Deploying to STAGE"
+            fi
+            # warn if flags are set
+            if [ "${{ github.event.inputs.delete-volumes }}" = "true" ]; then
+              echo "::warning::Deleting volumes!"
+            fi
+            if [ "${{ github.event.inputs.restore-db }}" = "true" ]; then
+              echo "::warning::Restoring DB!"
+            fi
+            if [ "${{ github.event.inputs.flush-redis }}" = "true" ]; then
+              echo "::warning::Flushing redis!"
+            fi
+            if [ "${{ github.event.inputs.build-flag }}" != "None" ]; then
+              echo "::notice::Build flag: ${{ github.event.inputs.build-flag }}"
+            fi
+
+
   deployment:
+    needs: info
     concurrency: ${{ github.event.inputs.environment }}
     runs-on: [self-hosted, "${{ github.event.inputs.environment }}"]
     environment: ${{ github.event.inputs.environment == 'stage' && 'Staging' || 'Production' }}


### PR DESCRIPTION
Add annotations that are printed before deployment step is run.

Allows to easily see what the deployment will do (printed before actual deployment is approved/run):
<img width="1360" alt="image" src="https://user-images.githubusercontent.com/2865203/207184958-11cb3340-c5cb-42fe-97c5-2935afca50a2.png">


Examples (disregard the deployment failures):
* https://github.com/spaceshelter/orbitar/actions/runs/3680855499
* https://github.com/spaceshelter/orbitar/actions/runs/3680848212
* https://github.com/spaceshelter/orbitar/actions/runs/3680851451
