### PR TITLE
Fix docker compose file used in prod db backup

### DIFF
--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Dump database
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
-        run: echo $MYSQL_ROOT_PASSWORD | docker-compose -f /orbitar/docker-compose.yml exec -T mysql mysqldump --default-character-set=utf8mb4 --single-transaction --add-drop-database --databases orbitar_db activity_db -u root -p > ${{ env.backupFileName }}
+        run: echo $MYSQL_ROOT_PASSWORD | docker-compose -f /orbitar/docker-compose.ssl.local.yml \
+            exec -T mysql mysqldump --default-character-set=utf8mb4 --single-transaction --add-drop-database \
+            --databases orbitar_db activity_db -u root -p > ${{ env.backupFileName }}
 
       - name: Compress database
         env:


### PR DESCRIPTION
See this error:
https://github.com/spaceshelter/orbitar/actions/runs/3691197469/jobs/6248975758

after yesterday's deploy `docker-compose.ssl.local.yml` is used.