### PR TITLE
Fail media backup step if  ` backup_media.js` fails

### DIFF
--- a/backend/backup_media.sh
+++ b/backend/backup_media.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -ex
+
 MYSQL_CONTAINER=$(docker ps --format "{{.Names}}" | grep mysql | grep orbitar)
 # get backup dir from the first argument
 BACKUP_DIR=$1
@@ -7,7 +9,6 @@ if [ -z "$BACKUP_DIR" ]; then
     exit 1
 fi
 
-# 30 minutes timeout
 docker run --rm -i --name=orbitar-backup-media -v "${PWD}":/app -v "$BACKUP_DIR":/orbitar_backup --network container:"$MYSQL_CONTAINER" \
   -e "MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD" \
   --entrypoint='/bin/bash' node:17 -c "cd /app/ && npm install && node backup_media.js /orbitar_backup"


### PR DESCRIPTION
Fix silent errors [like this one](https://github.com/spaceshelter/orbitar/actions/runs/3672291757/jobs/6208332055). Failures should be explicit.