### PR TITLE
Speedup the feed build by using the correct toolchain and docker caching

### DIFF
--- a/feed/Dockerfile
+++ b/feed/Dockerfile
@@ -1,5 +1,5 @@
 # Tells docker to use the latest Rust official image
-FROM rust:1.64-slim-buster as builder
+FROM rustlang/rust:nightly-buster-slim as builder
 WORKDIR /feed
 # first create a cached layer with the dependencies
 RUN mkdir -p ./src && echo 'fn main() { panic!("Dummy Image Called!") }' > ./src/main.rs
@@ -14,8 +14,8 @@ RUN touch -a -m ./src/main.rs
 RUN cargo build --release
 
 FROM debian:buster-slim
-COPY --from=builder /feed /feed
+COPY --from=builder /feed/target/release/orbitar-index /feed/orbitar-index
 WORKDIR /feed
 EXPOSE 6767
 # Run the binary built inside the container
-CMD ["./target/release/orbitar-index"]
+CMD ["./orbitar-index"]

--- a/feed/Dockerfile
+++ b/feed/Dockerfile
@@ -1,9 +1,9 @@
 # Tells docker to use the latest Rust official image
-FROM rust:slim-buster as builder
+FROM rust:1.64-slim-buster as builder
 WORKDIR /feed
 # first create a cached layer with the dependencies
 RUN mkdir -p ./src && echo 'fn main() { panic!("Dummy Image Called!") }' > ./src/main.rs
-COPY ["Cargo.toml", "Cargo.lock",  "./"]
+COPY ["Cargo.toml", "Cargo.lock", "rust-toolchain.toml",  "./"]
 RUN cargo build --release
 RUN rm -rf ./src
 # Copy the project files from your machine to the container

--- a/feed/rust-toolchain
+++ b/feed/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/feed/rust-toolchain.toml
+++ b/feed/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2022-11-04"

--- a/feed/rust-toolchain.toml
+++ b/feed/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-11-04"
+channel = "nightly"

--- a/feed/src/main.rs
+++ b/feed/src/main.rs
@@ -1,5 +1,6 @@
 #![feature(test)]
 #[macro_use]
+#[allow(unused_imports)]
 extern crate test;
 
 #[macro_use]


### PR DESCRIPTION
Before the image had `stable` rust toolchain and had to re-download and recompile everything.

The fix ensure that docker cache layer has all dependencies pre-built and cached on the correct toolchain, so only local changes are recompiled.