### PR TITLE
Fix extra line breaks around large images

### DIFF
--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -40,7 +40,12 @@ function updateVideo(video: HTMLVideoElement) {
 
 function updateImg(img: HTMLImageElement) {
     if (img.naturalWidth > 500 || img.naturalHeight > 500) {
-        img.classList.add('image-large');
+        // will be displayed as block if not immediately surrounded by <br>
+        const nextBr = !img.nextSibling || img.nextSibling.nodeName === 'BR';
+        const prevBr = !img.previousSibling || img.previousSibling.nodeName === 'BR';
+        if (!nextBr || !prevBr) {
+            img.classList.add('image-large');
+        }
     }
 
     let el: HTMLElement | null = img;


### PR DESCRIPTION
Currently large images are wrapped in blocks (to avoid "hanging" on text), see #190 

However, if there are already line breaks around images, currently a superfluous extra space is added. This PR fixes that behavior (at least in some cases).

Demo:
![demo1](https://user-images.githubusercontent.com/2865203/208266700-183735c4-3a01-4caa-b0c3-78d57235896c.gif)