### PR TITLE
Fix Access denied in MYSQL logs

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,7 @@ services:
       - "3306:3306"
       - "33060:33060"
     healthcheck:
-        test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+        test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost", "-uroot", "-p${MYSQL_ROOT_PASSWORD}"]
         interval: 5s
         timeout: 20s
         retries: 10

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -27,7 +27,7 @@ services:
       - mysql_db:/var/lib/mysql
       - $PWD/mysql/schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro
     healthcheck:
-      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost", "-uroot", "-p${MYSQL_ROOT_PASSWORD}"]
       interval: 5s
       timeout: 20s
       retries: 10

--- a/docker-compose.ssl.dev.yml
+++ b/docker-compose.ssl.dev.yml
@@ -30,7 +30,7 @@ services:
       - "3306:3306"
       - "33060:33060"
     healthcheck:
-        test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+        test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost", "-uroot", "-p${MYSQL_ROOT_PASSWORD}"]
         interval: 5s
         timeout: 20s
         retries: 10

--- a/docker-compose.ssl.local.yml
+++ b/docker-compose.ssl.local.yml
@@ -29,7 +29,7 @@ services:
       - mysql_db:/var/lib/mysql
       - $PWD/mysql/schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro
     healthcheck:
-        test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+        test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost", "-uroot", "-p${MYSQL_ROOT_PASSWORD}"]
         interval: 5s
         timeout: 20s
         retries: 10


### PR DESCRIPTION
Our MySQL container logs are flooded with messages
```
mysql_1  | 2022-12-19T01:05:06.879379Z 2 [Note] Access denied for user 'root'@'localhost' (using password: NO)
mysql_1  | 2022-12-19T01:05:11.992378Z 3 [Note] Access denied for user 'root'@'localhost' (using password: NO)
mysql_1  | 2022-12-19T01:05:17.089115Z 4 [Note] Access denied for user 'root'@'localhost' (using password: NO)
mysql_1  | 2022-12-19T01:05:22.162562Z 5 [Note] Access denied for user 'root'@'localhost' (using password: NO)
mysql_1  | 2022-12-19T01:05:27.271109Z 6 [Note] Access denied for user 'root'@'localhost' (using password: NO)
mysql_1  | 2022-12-19T01:05:32.409882Z 7 [Note] Access denied for user 'root'@'localhost' (using password: NO)
```

This is because healthcheck is failing to connect. It returns 0 as failed authentication is still a sign that the server works.

The PR should fix this issue and reduce the logging eloquentness.