### PR TITLE
FLUSH PRIVILEGES to avoid race conditions during initial server setup

### DIFF
--- a/backend/migrations/20220427220023-store-session.js
+++ b/backend/migrations/20220427220023-store-session.js
@@ -21,6 +21,7 @@ exports.up = async function(db) {
     used: { type: 'datetime', notNull: true, defaultValue: new String('CURRENT_TIMESTAMP') },
   });
   await db.runSql(`grant delete on ${process.env.MYSQL_DATABASE}.* to '${process.env.MYSQL_USER}'@'%';`);
+  await db.runSql(`flush privileges;`);
   return null;
 };
 

--- a/mysql/schema.sql
+++ b/mysql/schema.sql
@@ -8,6 +8,7 @@ USE `orbitar_db`;
 CREATE USER 'orbitar'@'%' IDENTIFIED BY 'orbitar';
 GRANT SELECT, INSERT, UPDATE, DELETE ON orbitar_db.* TO 'orbitar'@'%';
 GRANT SELECT, INSERT, UPDATE, DELETE ON activity_db.* TO 'orbitar'@'%'; -- activity_db does not exist in the original schema, but added in migrations
+FLUSH PRIVILEGES;
 
 DROP TABLE IF EXISTS `comment_votes`;
 CREATE TABLE `comment_votes` (


### PR DESCRIPTION
Users report that during the initial server setup db migration fail sporadically.

Mysql logs:
```
[ERROR] unhandledRejection
[ERROR] Error: Can't find any matching row in the user table
```
Relevant:
https://stackoverflow.com/questions/12877458/mysql-error-1133-cant-find-any-matching-row-in-the-user-table