### PR TITLE
format total search results number

### DIFF
--- a/frontend/src/Pages/SearchPage.tsx
+++ b/frontend/src/Pages/SearchPage.tsx
@@ -23,7 +23,7 @@ function SearchResult(props: {
     return <>
         <div className={styles.stats}>
             {!total.value ? 'Ничего не найдено' :
-                <>{total.value} найдено {total.value > 250 && <>(250 показано)</>}</>}
+                <>{total.value.toLocaleString()} найдено {total.value > 250 && <>(250 показано)</>}</>}
         </div>
 
         {results.map((resultItem: SearchResultEntity) => {


### PR DESCRIPTION
Before
<img width="285" alt="image" src="https://user-images.githubusercontent.com/57953386/209453299-72c9a47f-6c09-4bd1-ba03-185d809af61e.png">

After (US format)
<img width="282" alt="image" src="https://user-images.githubusercontent.com/57953386/209453313-77d7b179-33ad-42a0-aef4-638d6a36786a.png">