### PR TITLE
Feed docker build: pin slim-buster image version to allow better caching

### DIFF
--- a/feed/Dockerfile
+++ b/feed/Dockerfile
@@ -1,5 +1,5 @@
 # Tells docker to use the latest Rust official image
-FROM rustlang/rust:nightly-buster-slim as builder
+FROM rust:1.64-slim-buster as builder
 WORKDIR /feed
 # first create a cached layer with the dependencies
 RUN mkdir -p ./src && echo 'fn main() { panic!("Dummy Image Called!") }' > ./src/main.rs


### PR DESCRIPTION
Pinned to rust:1.64-slim-buster
<img width="730" alt="image" src="https://user-images.githubusercontent.com/2865203/209690655-f195517f-ad76-4c14-a3be-6c679e77e927.png">

https://hub.docker.com/layers/library/rust/1.64-slim-buster/images/sha256-c761809aae5fe07769dab99f4404ca5d71a954934a74484e48eb06c0260ef484?context=explore