### PR TITLE
Status request improvements

### DIFF
--- a/backend/src/api/PostController.ts
+++ b/backend/src/api/PostController.ts
@@ -322,13 +322,9 @@ export default class PostController {
         const { post_id: postId, comments, last_comment_id: lastCommentId } = request.body;
 
         const readUpdated = await this.postManager.setRead(postId, userId, comments, lastCommentId);
-            // update in background
-            // .then()
-            // .catch(err => {
-            //     this.logger.error(`Read update failed`, { error: err, user_id: userId, post_id: postId, comments: comments, last_comment_id: lastCommentId });
-            // });
 
         if (readUpdated) {
+            this.userManager.deleteUserStatsCache(userId);
             const status = await this.userManager.getUserStats(userId);
             return response.success({
                 notifications: status.notifications,
@@ -367,6 +363,7 @@ export default class PostController {
 
         try {
             await this.postManager.setWatch(postId, userId, watch);
+            this.userManager.deleteUserStatsCache(userId);
             response.success({watch});
         }
         catch (err) {

--- a/backend/src/api/StatusController.ts
+++ b/backend/src/api/StatusController.ts
@@ -46,6 +46,4 @@ export default class StatusController {
             return response.error('error', 'Unknown error', 500);
         }
     }
-
-
 }

--- a/backend/src/api/StatusController.ts
+++ b/backend/src/api/StatusController.ts
@@ -26,12 +26,9 @@ export default class StatusController {
             return response.authRequired();
         }
 
-        const siteName = request.body.site;
-
         try {
             const userId = request.session.data.userId;
             const user = await this.userManager.getById(userId);
-            const site = siteName ? await this.siteManager.getSiteByNameWithUserInfo(userId, siteName) : undefined;
             const stats = await this.userManager.getUserStats(userId);
             const subscriptions = await this.siteManager.getSubscriptions(userId);
 
@@ -42,7 +39,6 @@ export default class StatusController {
 
             return response.success({
                 user,
-                site: site ? this.enricher.siteInfoToEntity(site) : undefined,
                 subscriptions: subscriptions.map(site => this.enricher.siteInfoToEntity(site)),
                 ...stats
             });

--- a/backend/src/api/StatusController.ts
+++ b/backend/src/api/StatusController.ts
@@ -30,7 +30,6 @@ export default class StatusController {
             const userId = request.session.data.userId;
             const user = await this.userManager.getById(userId);
             const stats = await this.userManager.getUserStats(userId);
-            const subscriptions = await this.siteManager.getSubscriptions(userId);
 
             if (!user) {
                 // Something wrong, user should exist!
@@ -39,7 +38,6 @@ export default class StatusController {
 
             return response.success({
                 user,
-                subscriptions: subscriptions.map(site => this.enricher.siteInfoToEntity(site)),
                 ...stats
             });
         }

--- a/backend/src/api/types/requests/Status.ts
+++ b/backend/src/api/types/requests/Status.ts
@@ -1,6 +1,6 @@
 import {UserEntity} from '../entities/UserEntity';
 
-export type StatusRequest = {};
+export type StatusRequest = Record<string, never>;
 
 export type StatusResponse = {
     user: UserEntity;

--- a/backend/src/api/types/requests/Status.ts
+++ b/backend/src/api/types/requests/Status.ts
@@ -1,13 +1,10 @@
 import {UserEntity} from '../entities/UserEntity';
 import {SiteWithUserInfoEntity} from '../entities/SiteEntity';
 
-export type StatusRequest = {
-    site?: string;
-};
+export type StatusRequest = {};
 
 export type StatusResponse = {
     user: UserEntity;
-    site?: SiteWithUserInfoEntity;
     watch: {
         posts: number;
         comments: number;

--- a/backend/src/api/types/requests/Status.ts
+++ b/backend/src/api/types/requests/Status.ts
@@ -1,5 +1,4 @@
 import {UserEntity} from '../entities/UserEntity';
-import {SiteWithUserInfoEntity} from '../entities/SiteEntity';
 
 export type StatusRequest = {};
 
@@ -13,5 +12,4 @@ export type StatusResponse = {
         unread: number;
         visible: number;
     }
-    subscriptions: SiteWithUserInfoEntity[];
 };

--- a/backend/src/api/types/requests/Subscriptions.ts
+++ b/backend/src/api/types/requests/Subscriptions.ts
@@ -1,7 +1,7 @@
 import {SiteWithUserInfoEntity} from '../entities/SiteEntity';
 
-export type SubscriptionsRequest = {};
+export type SubscriptionsRequest = Record<string, never>;
 
 export type SubscriptionsResponse = {
     subscriptions: SiteWithUserInfoEntity[];
-}
+};

--- a/backend/src/api/types/requests/Subscriptions.ts
+++ b/backend/src/api/types/requests/Subscriptions.ts
@@ -1,0 +1,7 @@
+import {SiteWithUserInfoEntity} from '../entities/SiteEntity';
+
+export type SubscriptionsRequest = {};
+
+export type SubscriptionsResponse = {
+    subscriptions: SiteWithUserInfoEntity[];
+}

--- a/backend/src/managers/NotificationManager.ts
+++ b/backend/src/managers/NotificationManager.ts
@@ -131,6 +131,7 @@ export default class NotificationManager {
     async sendNotification(forUserId: number, notification: UserNotification) {
         const json = JSON.stringify(notification);
         await this.notificationsRepository.addNotification(forUserId, notification.type, notification.source.byUserId, notification.source.postId, notification.source.commentId, json);
+        this.userCache.deleteUserStatsCache(forUserId);
 
         // send push in background
         this.sendWebPush(forUserId, notification).then().catch();

--- a/backend/src/managers/PostManager.ts
+++ b/backend/src/managers/PostManager.ts
@@ -218,6 +218,7 @@ export default class PostManager {
         }
 
         await this.bookmarkRepository.setWatch(postId, userId, true);
+        this.userManager.clearUserStatsCache();
 
         // fan out in background
         this.feedManager.postFanOut(commentRaw.site_id, commentRaw.post_id,

--- a/backend/src/managers/UserCache.ts
+++ b/backend/src/managers/UserCache.ts
@@ -1,4 +1,4 @@
-import {UserInfo} from './types/UserInfo';
+import {UserInfo, UserStats} from './types/UserInfo';
 import UserRepository from '../db/repositories/UserRepository';
 import {UserRaw} from '../db/types/UserRaw';
 
@@ -7,6 +7,7 @@ export class UserCache {
     private cacheId: Record<number, UserInfo> = {};
     private cacheUsername: Record<string, UserInfo> = {};
     private cachedUserParents: Record<number, number | undefined | false> = {};
+    private userStatsCache = new Map<number, UserStats>();
 
     constructor(userRepository: UserRepository) {
         this.userRepository = userRepository;
@@ -85,4 +86,19 @@ export class UserCache {
         };
     }
 
+    getUserStatsCache(forUserId: number): UserStats | undefined {
+        return this.userStatsCache.get(forUserId);
+    }
+
+    cacheUserStats(forUserId: number, stats: UserStats) {
+        this.userStatsCache.set(forUserId, stats);
+    }
+
+    deleteUserStatsCache(forUserId: number) {
+        this.userStatsCache.delete(forUserId);
+    }
+
+    clearUserStatsCache() {
+        this.userStatsCache.clear();
+    }
 }

--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -141,7 +141,7 @@ export default class UserManager {
                 comments: unreadComments,
                 posts: 0
             }
-        }
+        };
 
         this.userStatsCache.set(forUserId, stats);
         return stats;

--- a/frontend/src/API/APIHelper.ts
+++ b/frontend/src/API/APIHelper.ts
@@ -67,7 +67,6 @@ export default class APIHelper {
             this.appState.setWatchCommentsCount(status.watch.comments);
             this.appState.setUnreadNotificationsCount(status.notifications.unread);
             this.appState.setVisibleNotificationsCount(status.notifications.visible);
-            this.appState.setSubscriptions(status.subscriptions);
             this.appState.setAppLoadingState(AppLoadingState.authorized);
 
             // start fetch status update
@@ -112,7 +111,6 @@ export default class APIHelper {
             this.appState.setWatchCommentsCount(status.watch.comments);
             this.appState.setUnreadNotificationsCount(status.notifications.unread);
             this.appState.setVisibleNotificationsCount(status.notifications.visible);
-            this.appState.setSubscriptions(status.subscriptions);
             this.appState.setAppLoadingState(AppLoadingState.authorized);
         }
         finally {

--- a/frontend/src/API/APIHelper.ts
+++ b/frontend/src/API/APIHelper.ts
@@ -61,16 +61,13 @@ export default class APIHelper {
         try {
             this.appState.appLoadingState = AppLoadingState.loading;
 
-            const status = await this.authAPI.status(this.appState.site);
+            const status = await this.authAPI.status();
 
             this.appState.setUserInfo(status.user);
             this.appState.setWatchCommentsCount(status.watch.comments);
             this.appState.setUnreadNotificationsCount(status.notifications.unread);
             this.appState.setVisibleNotificationsCount(status.notifications.visible);
             this.appState.setSubscriptions(status.subscriptions);
-            if (status.site) {
-                this.appState.setSiteInfo(status.site);
-            }
             this.appState.setAppLoadingState(AppLoadingState.authorized);
 
             // start fetch status update
@@ -109,16 +106,13 @@ export default class APIHelper {
 
     async fetchStatusUpdate() {
         try {
-            const status = await this.authAPI.status(this.appState.site);
+            const status = await this.authAPI.status();
 
             this.appState.setUserInfo(status.user);
             this.appState.setWatchCommentsCount(status.watch.comments);
             this.appState.setUnreadNotificationsCount(status.notifications.unread);
             this.appState.setVisibleNotificationsCount(status.notifications.visible);
             this.appState.setSubscriptions(status.subscriptions);
-            if (status.site) {
-                this.appState.setSiteInfo(status.site);
-            }
             this.appState.setAppLoadingState(AppLoadingState.authorized);
         }
         finally {

--- a/frontend/src/API/APIHelper.ts
+++ b/frontend/src/API/APIHelper.ts
@@ -35,7 +35,7 @@ export default class APIHelper {
     private baseAPI: APIBase;
     private initRetryCount = 0;
     private appState: AppState;
-    private updateInterval: number = parseInt(process.env.REACT_APP_STATUS_UPDATE_INTERVAL || '60');
+    private updateInterval: number = parseInt(process.env.REACT_APP_STATUS_UPDATE_INTERVAL || '30');
 
     constructor(api: APIBase, appState: AppState) {
         this.baseAPI = api;

--- a/frontend/src/API/AuthAPI.ts
+++ b/frontend/src/API/AuthAPI.ts
@@ -1,6 +1,5 @@
 import APIBase from './APIBase';
 import {UserInfo} from '../Types/UserInfo';
-import {SiteWithUserInfo} from '../Types/SiteInfo';
 
 type StatusRequest = {};
 type StatusResponse = {
@@ -13,7 +12,6 @@ type StatusResponse = {
         unread: number;
         visible: number;
     }
-    subscriptions: SiteWithUserInfo[];
 };
 
 type SignInRequest = Record<string, unknown>;

--- a/frontend/src/API/AuthAPI.ts
+++ b/frontend/src/API/AuthAPI.ts
@@ -1,7 +1,7 @@
 import APIBase from './APIBase';
 import {UserInfo} from '../Types/UserInfo';
 
-type StatusRequest = {};
+type StatusRequest = Record<string, never>;
 type StatusResponse = {
     user: UserInfo;
     watch: {

--- a/frontend/src/API/AuthAPI.ts
+++ b/frontend/src/API/AuthAPI.ts
@@ -2,11 +2,8 @@ import APIBase from './APIBase';
 import {UserInfo} from '../Types/UserInfo';
 import {SiteWithUserInfo} from '../Types/SiteInfo';
 
-type StatusRequest = {
-    site?: string;
-};
+type StatusRequest = {};
 type StatusResponse = {
-    site?: SiteWithUserInfo;
     user: UserInfo;
     watch: {
         posts: number;
@@ -40,8 +37,8 @@ export default class AuthAPI {
         this.api = api;
     }
 
-    async status(site: string): Promise<StatusResponse> {
-        return await this.api.request<StatusRequest, StatusResponse>('/status', { site });
+    async status(): Promise<StatusResponse> {
+        return await this.api.request<StatusRequest, StatusResponse>('/status', {});
     }
 
     async signIn(username: string, password: string): Promise<SignInResponse> {

--- a/frontend/src/API/SiteAPI.ts
+++ b/frontend/src/API/SiteAPI.ts
@@ -36,6 +36,11 @@ type SiteListResponse = {
     sites: SiteWithUserInfo[];
 };
 
+type SubscriptionsRequest = {};
+type SubscriptionsResponse = {
+    subscriptions: SiteWithUserInfo[];
+};
+
 export default class SiteAPI {
     private api: APIBase;
 
@@ -61,6 +66,10 @@ export default class SiteAPI {
             main,
             bookmarks
         });
+    }
+
+    async subscriptions(): Promise<SubscriptionsResponse> {
+        return await this.api.request<SubscriptionsRequest, SubscriptionsResponse>('/site/subscriptions', {});
     }
 
     async list(page: number, perpage: number): Promise<SiteListResponse> {

--- a/frontend/src/API/SiteAPI.ts
+++ b/frontend/src/API/SiteAPI.ts
@@ -36,7 +36,7 @@ type SiteListResponse = {
     sites: SiteWithUserInfo[];
 };
 
-type SubscriptionsRequest = {};
+type SubscriptionsRequest = Record<string, never>;
 type SubscriptionsResponse = {
     subscriptions: SiteWithUserInfo[];
 };

--- a/frontend/src/API/SiteAPIHelper.ts
+++ b/frontend/src/API/SiteAPIHelper.ts
@@ -29,6 +29,12 @@ export default class SiteAPIHelper {
         }
     }
 
+    async subscriptons(): Promise<SiteWithUserInfo[]> {
+        const result = await this.api.subscriptions();
+        this.appState.setSubscriptions(result.subscriptions);
+        return result.subscriptions;
+    }
+
     async list(page: number, perpage: number): Promise<SiteWithUserInfo[]> {
         const result = await this.api.list(page, perpage);
         return result.sites;

--- a/frontend/src/API/SiteAPIHelper.ts
+++ b/frontend/src/API/SiteAPIHelper.ts
@@ -33,4 +33,13 @@ export default class SiteAPIHelper {
         const result = await this.api.list(page, perpage);
         return result.sites;
     }
+
+    async updateSiteInfo() {
+        if (this.appState.site) {
+            const result = await this.api.site(this.appState.site);
+            if (result && result.site.site === this.appState.site) {
+                this.appState.setSiteInfo(result.site);
+            }
+        }
+    }
 }

--- a/frontend/src/AppState/AppState.tsx
+++ b/frontend/src/AppState/AppState.tsx
@@ -48,7 +48,7 @@ export class AppState {
     watchCommentsCount = 0;
 
     @observable.struct
-    subscriptions: SiteWithUserInfo[] = [];
+    subscriptions: SiteWithUserInfo[] | undefined = undefined;
 
     browserHistory = createBrowserHistory();
     router = new RouterStore(this.browserHistory);

--- a/frontend/src/Components/SiteSidebar.tsx
+++ b/frontend/src/Components/SiteSidebar.tsx
@@ -44,6 +44,14 @@ export const SiteSidebar = observer((props: SidebarProps) => {
         }
     }, [siteInfo, api.site]);
 
+    useEffect(() => {
+        if (subscriptions === undefined) {
+            api.site.subscriptons().then().catch(
+                () => toast.error('Не удалось получить список подписок!'),
+            );
+        }
+    });
+
     return (
         <div className={classNames(styles.sidebar, {
             [styles.open]: props.menuState === 'close',
@@ -62,7 +70,7 @@ export const SiteSidebar = observer((props: SidebarProps) => {
                     </div>}
                     {siteInfo?.siteInfo && <div className='site-info'>{siteInfo.siteInfo}</div>}
                     <div className='subsites'>
-                        { subscriptions.map(site => {
+                        { subscriptions && subscriptions.map(site => {
                             return <div key={site.site}><Link onClick={menuToggle} to={site.site === 'main' ? '/' : `/s/${site.site}`}>{site.name}</Link></div>;
                         }) }
                     </div>

--- a/frontend/src/Components/SiteSidebar.tsx
+++ b/frontend/src/Components/SiteSidebar.tsx
@@ -1,10 +1,10 @@
 import styles from './SiteSidebar.module.scss';
 import {Link} from 'react-router-dom';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {useAPI, useAppState} from '../AppState/AppState';
 import {toast} from 'react-toastify';
 import {observer} from 'mobx-react-lite';
-import {TopbarMenuState} from '../Components/Topbar';
+import {TopbarMenuState} from './Topbar';
 import classNames from 'classnames';
 
 type SidebarProps = {
@@ -35,6 +35,14 @@ export const SiteSidebar = observer((props: SidebarProps) => {
                 toast.error('Настройки подписки не изменены!');
             });
     };
+
+    useEffect(() => {
+        if (!siteInfo) {
+            api.site.updateSiteInfo().then().catch(
+                () => toast.error('Не удалось обновить информацию о сайте!'),
+            );
+        }
+    }, [siteInfo, api.site]);
 
     return (
         <div className={classNames(styles.sidebar, {

--- a/frontend/src/Components/SiteSidebar.tsx
+++ b/frontend/src/Components/SiteSidebar.tsx
@@ -50,7 +50,7 @@ export const SiteSidebar = observer((props: SidebarProps) => {
                 () => toast.error('Не удалось получить список подписок!'),
             );
         }
-    });
+    }, [subscriptions]);
 
     return (
         <div className={classNames(styles.sidebar, {


### PR DESCRIPTION
Performance/refactoring:

* Remove unnecessary request from status (moved to separate requests, invoked only when needed):
  * site information
  * subscription
* Cache status (`UserStats`) per user
  cache is invalidated when:
      * user visits post, watches/unwatches
      * comment is posted
* since status requests are now very cheap, increase status poll frequency to once per 30 seconds (was 1 minute)


Note: for ease of review this PR is split into the self-contained commits.