### PR TITLE
Fix `useFeed` being called two times in a row

### DIFF
--- a/frontend/src/API/use/useConditional.ts
+++ b/frontend/src/API/use/useConditional.ts
@@ -1,0 +1,12 @@
+import {useRef} from 'react';
+
+/**
+ * Bumps the value of a variable to the next value if condition is true.
+ */
+export function useConditional(conditional: boolean): number {
+    const ref = useRef<number>(0);
+    if (conditional) {
+        ref.current++;
+    }
+    return ref.current;
+}

--- a/frontend/src/API/use/useFeed.ts
+++ b/frontend/src/API/use/useFeed.ts
@@ -3,6 +3,8 @@ import {useEffect, useMemo, useState} from 'react';
 import {PostInfo} from '../../Types/PostInfo';
 import {useCache} from './useCache';
 import {FeedSorting} from '../../Types/FeedSortingSettings';
+import {useConditional} from './useConditional';
+import {usePrevious} from './usePrevious';
 
 export type FeedType = 'all' | 'subscriptions' | 'site' | 'watch' | 'watch-all' | 'user-profile';
 
@@ -16,6 +18,9 @@ export function useFeed(id: string, feedType: FeedType | undefined, page: number
     const [loading, setLoading] = useState(true);
     const [pages, setPages] = useState(0);
     const [error, setError] = useState<[string, Error]>();
+    const prevSorting = usePrevious(sorting);
+    // handles initial load when sorting is undefined and initialized for the first time
+    const sortingChanged = useConditional(prevSorting !== undefined && prevSorting !== sorting);
 
     const updatePost = useMemo(() => {
         return (id: number, partial: Partial<PostInfo>) => {
@@ -115,7 +120,7 @@ export function useFeed(id: string, feedType: FeedType | undefined, page: number
                 setError(['Не удалось загрузить ленту постов', error]);
             });
         }
-    }, [id, feedType, page, api.post, perpage, sorting, filter]);
+    }, [id, feedType, page, api.post, perpage, sortingChanged, filter]);
 
     return { posts, loading, pages, error, updatePost, setLoading };
 }

--- a/frontend/src/API/use/usePrevious.ts
+++ b/frontend/src/API/use/usePrevious.ts
@@ -1,0 +1,13 @@
+import {useEffect, useRef} from 'react';
+
+/**
+ * Returns the previous value of a variable (before the change).
+ * @param value
+ */
+export function usePrevious<T>(value: T): T | undefined {
+    const ref = useRef<T>();
+    useEffect(() => {
+        ref.current = value;
+    }, [value]);
+    return ref.current;
+}


### PR DESCRIPTION
The problem was in the value of `sorting` being used as effect dependency.

Initially `sorting` was `undefined` and it was initialized to the stored sorting value returned by the feed request. Which in turn resulted feed request performed two times: first for the "undefined" value, second time for the concrete value.