### PR TITLE
Fix pager losing query string parameters on filtered pages

### DIFF
--- a/frontend/src/Components/Paginator.tsx
+++ b/frontend/src/Components/Paginator.tsx
@@ -6,6 +6,7 @@ interface PaginatorProps {
     page: number;
     pages: number;
     base: string;
+    queryStringParams?: Record<string, string>;
 }
 
 export default function Paginator(props: PaginatorProps) {
@@ -15,10 +16,12 @@ export default function Paginator(props: PaginatorProps) {
         if (i === props.page) {
             classes.push(styles.current);
         }
-        let search = '';
-        if (i > 1) {
-            search = 'page=' + i;
+        const params = new URLSearchParams(props.queryStringParams || {});
+        if (i > 1 || (params && Object.keys(params).length)) {
+            params.set('page', i.toString());
         }
+        const search = params.toString();
+        console.log(search);
 
         pages.push(<Link key={i} className={classes.join(' ')} to={{pathname: props.base, search}}>{i}</Link>);
     }

--- a/frontend/src/Components/Paginator.tsx
+++ b/frontend/src/Components/Paginator.tsx
@@ -21,7 +21,6 @@ export default function Paginator(props: PaginatorProps) {
             params.set('page', i.toString());
         }
         const search = params.toString();
-        console.log(search);
 
         pages.push(<Link key={i} className={classes.join(' ')} to={{pathname: props.base, search}}>{i}</Link>);
     }

--- a/frontend/src/Components/UserProfileComments.tsx
+++ b/frontend/src/Components/UserProfileComments.tsx
@@ -86,6 +86,8 @@ export default function UserProfileComments(props: UserProfileCommentsProps) {
         window.scrollTo({ top: 0 });
     }, [page]);
 
+    const params = filter ? {filter} : undefined;
+
     return (
         <div className={styles.container}>
             <div className={styles.filter}>
@@ -103,7 +105,7 @@ export default function UserProfileComments(props: UserProfileCommentsProps) {
                                  : <div className={styles.loading}>Загрузка...</div>
                          )
                      }
-                    <Paginator page={page} pages={pages} base={`/u/${props.username}/comments`} />
+                    <Paginator page={page} pages={pages} base={`/u/${props.username}/comments`} queryStringParams={params} />
                 </>}
             </div>
         </div>

--- a/frontend/src/Components/UserProfilePosts.tsx
+++ b/frontend/src/Components/UserProfilePosts.tsx
@@ -49,6 +49,7 @@ export default function UserProfilePosts(props: UserProfilePostsProps) {
         window.scrollTo({ top: 0 });
     }, [page]);
 
+    const params = filter ? {filter} : undefined;
     return (
         <div className={styles.container}>
           <div className={feedStyles.filter}>
@@ -61,7 +62,7 @@ export default function UserProfilePosts(props: UserProfilePostsProps) {
                     {posts && <div className={styles.posts}>
                         {posts.map(post => <PostComponent key={post.id} post={post} showSite={true} onChange={updatePost} autoCut={true} />)}
                     </div>}
-                    <Paginator page={page} pages={pages} base={`/u/${props.username}/posts`} />
+                    <Paginator page={page} pages={pages} base={`/u/${props.username}/posts`} queryStringParams={params} />
                 </>}
             </div>
         </div>


### PR DESCRIPTION
On user profile comments and posts pages this change adds filter parameter to pager links