### PR TITLE
Fix mp4 video looping settings for the video embed

### DIFF
--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -77,7 +77,7 @@ function processVideoEmbed(img: HTMLImageElement) {
             video.src = videoUrl;
             video.controls = true;
             video.autoplay = true;
-            video.loop = !!img.dataset.loop;
+            video.loop = !!img.dataset.loop && img.dataset.loop !== 'false';
             video.style.width = img.width.toString() + 'px';
             video.style.height = img.height.toString() + 'px';
             img.parentElement?.replaceWith(video);


### PR DESCRIPTION
The problem was that `data-loop` attribute has "false" value as text:
```
<img src="https://idiod.video/preview/..." alt="" data-video="https://idiod.video/..." data-loop="false" class="video-embed-processed">
```

Alternative would be to change TheParser to not include `data-video` attribute at all, when video is not looped, but that would require bumping parser version (and consequently re-parsing all content on the site). I'd avoid that for now (will fix next time when Parser version is bumped).