### PR TITLE
Restore empty style for the search bar

### DIFF
--- a/frontend/src/Pages/SearchPage.tsx
+++ b/frontend/src/Pages/SearchPage.tsx
@@ -110,7 +110,7 @@ export default function SearchPage() {
     };
 
     return (
-        <div className={classNames(styles.search)}>
+        <div className={classNames(styles.search, {[styles.empty]: !searchTermFromUrl })}>
             {isSearching && <div className={feedStyles.loading}></div>}
 
             <div className={feedStyles.container}>


### PR DESCRIPTION
...that makes search bar displayed closer to the center when search page is first loaded