### PR TITLE
Add pictshare instance for media self-hosting

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -91,7 +91,7 @@ const redis = new Redis(config.redis, logger.child({ service: 'REDIS' }));
 
 const db = new DB(config.mysql, logger.child({ service: 'DB' }));
 
-const theParser = new TheParser();
+const theParser = new TheParser(config.site.domain);
 
 const bookmarkRepository = new BookmarkRepository(db);
 const commentRepository = new CommentRepository(db);

--- a/backend/test/parser/TheParser.test.ts
+++ b/backend/test/parser/TheParser.test.ts
@@ -1,9 +1,10 @@
 
 import TheParser from "../../src/parser/TheParser";
 
-test('parse A tag', () => {
-    const p = new TheParser();
+const p = new TheParser('orbitar.local');
 
+
+test('parse A tag', () => {
     // already encoded
     expect(
         p.parse('<a href="https://ru.wikipedia.org/wiki/%D0%A1%D0%BB%D0%B0%D0%B2%D0%B0_%D0%A3%D0%BA%D1%80%D0%B0%D0%B8%D0%BD%D0%B5">тест</a>').text
@@ -26,8 +27,6 @@ test('parse A tag', () => {
 });
 
 test('detect url in text', () => {
-    const p = new TheParser();
-
     expect(
         p.parse('Hello, \n' +
             'http://hello.world test\n' +
@@ -41,8 +40,6 @@ test('detect url in text', () => {
 });
 
 test('return valid youtube url', () => {
-  const p = new TheParser();
-
   expect(
       p.parse('https://www.youtube.com/watch?v=aboZctrHfK8'
       ).text
@@ -52,24 +49,24 @@ test('return valid youtube url', () => {
 });
 
 test('idiod video embed', () => {
-    const p = new TheParser();
-
     expect(p.parse('https://idiod.video/8feuw2.mp4').text).toEqual(
         `<a class="video-embed" href="https://idiod.video/8feuw2.mp4" target="_blank"><img src="https://idiod.video/preview/8feuw2.mp4" alt="" data-video="https://idiod.video/8feuw2.mp4" data-loop="false"/></a>`
     );
 });
 
-test('mp4 video element', () => {
-    const p = new TheParser();
+test('orbitar video embed', () => {
+    expect(p.parse('https://orbitar.local/media/8feuw2.mp4').text).toEqual(
+        `<a class="video-embed" href="https://orbitar.local/media/8feuw2.mp4/raw" target="_blank"><img src="https://orbitar.local/media/preview/8feuw2.mp4" alt="" data-video="https://orbitar.local/media/8feuw2.mp4/raw" data-loop="false"/></a>`
+    );
+});
 
+test('mp4 video element', () => {
     expect(p.parse('<video src="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4">').text).toEqual(
         `<video  preload="metadata" controls="" width="500"><source src="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4" type="video/mp4"></video>`
     );
 });
 
 test('remove line breaks at the beginning and the end', () => {
-    const p = new TheParser();
-
     expect(
         p.parse('Hello, \n' +
             'world'
@@ -97,8 +94,6 @@ test('remove line breaks at the beginning and the end', () => {
 });
 
 test('remove extra line break after blockquote tag', () => {
-    const p = new TheParser();
-
     expect(
         p.parse('<blockquote>Hello</blockquote>\nworld'
         ).text

--- a/caddy/Caddyfile.dev
+++ b/caddy/Caddyfile.dev
@@ -1,10 +1,9 @@
 http://{$SERVER_DOMAIN} {
-  # idiod.video proxy
+  # pictshare proxy
   handle_path /upload {
     rewrite * /api/upload.php
-    reverse_proxy https://idiod.video {
-      header_up Host idiod.video
-      header_up +authorization "Client-ID {$IMGUR_CLIENT_ID}"
+    reverse_proxy http://pictshare {
+      header_up Host localhost
       header_up -origin
       header_up -referer
       header_up -sec-ch-ua
@@ -13,6 +12,16 @@ http://{$SERVER_DOMAIN} {
       header_up -sec-fetch-dest
       header_up -sec-fetch-mode
       header_up -sec-fetch-site
+    }
+  }
+
+  handle_path /media/* {
+    # rewrite to http://pictshare/*
+    uri strip_prefix /media
+    reverse_proxy http://pictshare {
+      header_up Host localhost
+      header_up -origin
+      header_up -referer
     }
   }
 

--- a/caddy/Caddyfile.local
+++ b/caddy/Caddyfile.local
@@ -9,11 +9,11 @@ http://{$SERVER_DOMAIN} {
     Vary Origin
   }
 
-  # idiod.video proxy
+  # pictshare proxy
   handle_path /upload {
     rewrite * /api/upload.php
-    reverse_proxy https://idiod.video {
-      header_up Host idiod.video
+    reverse_proxy http://pictshare {
+      header_up Host localhost
       header_up -origin
       header_up -referer
       header_up -sec-ch-ua
@@ -22,6 +22,16 @@ http://{$SERVER_DOMAIN} {
       header_up -sec-fetch-dest
       header_up -sec-fetch-mode
       header_up -sec-fetch-site
+    }
+  }
+
+  handle_path /media/* {
+    # rewrite to http://pictshare/*
+    uri strip_prefix /media
+    reverse_proxy http://pictshare {
+      header_up Host localhost
+      header_up -origin
+      header_up -referer
     }
   }
 

--- a/caddy/Caddyfile.ssl.dev
+++ b/caddy/Caddyfile.ssl.dev
@@ -1,11 +1,11 @@
 {$SERVER_DOMAIN} {
   tls /certs/orbitar.crt /certs/orbitar.key
 
-  # idiod.video proxy
+  # pictshare proxy
   handle_path /upload {
     rewrite * /api/upload.php
-    reverse_proxy https://idiod.video {
-      header_up Host idiod.video
+    reverse_proxy http://pictshare {
+      header_up Host localhost
       header_up -origin
       header_up -referer
       header_up -sec-ch-ua
@@ -14,6 +14,16 @@
       header_up -sec-fetch-dest
       header_up -sec-fetch-mode
       header_up -sec-fetch-site
+    }
+  }
+
+  handle_path /media/* {
+    # rewrite to http://pictshare/*
+    uri strip_prefix /media
+    reverse_proxy http://pictshare {
+      header_up Host localhost
+      header_up -origin
+      header_up -referer
     }
   }
 

--- a/caddy/Caddyfile.ssl.local
+++ b/caddy/Caddyfile.ssl.local
@@ -11,11 +11,11 @@
     Vary Origin
   }
 
-  # idiod.video proxy
+  # pictshare proxy
   handle_path /upload {
     rewrite * /api/upload.php
-    reverse_proxy https://idiod.video {
-      header_up Host idiod.video
+    reverse_proxy http://pictshare {
+      header_up Host localhost
       header_up -origin
       header_up -referer
       header_up -sec-ch-ua
@@ -24,6 +24,16 @@
       header_up -sec-fetch-dest
       header_up -sec-fetch-mode
       header_up -sec-fetch-site
+    }
+  }
+
+  handle_path /media/* {
+    # rewrite to http://pictshare/*
+    uri strip_prefix /media
+    reverse_proxy http://pictshare {
+      header_up Host localhost
+      header_up -origin
+      header_up -referer
     }
   }
 
@@ -40,6 +50,6 @@
   header {
     Access-Control-Allow-Origin .* "{header.Origin}"
   }
-  
+
   reverse_proxy http://backend:5001
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -105,9 +105,20 @@ services:
       elasticsearch-setup:
         condition: service_completed_successfully
 
+
+  pictshare:
+    image: hascheksolutions/pictshare
+    volumes:
+      - pictshare_data:/var/www/data
+    environment:
+      MAX_UPLOAD_SIZE: 100
+      AUTO_UPDATE: "false"
+      ALLOW_BLOATING: "false"
+
 volumes:
   caddy_data:
   caddy_config:
   mysql_db:
   redis_data:
   elasticsearch_data:
+  pictshare_data:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -128,6 +128,16 @@ services:
       backend:
         condition: service_started # TODO change to service_healthy when we have a healthcheck
 
+  pictshare:
+    image: hascheksolutions/pictshare
+    volumes:
+      - pictshare_data:/var/www/data
+    environment:
+      MAX_UPLOAD_SIZE: 100
+      AUTO_UPDATE: "false"
+      ALLOW_BLOATING: "false"
+
+
 volumes:
   caddy_data:
   caddy_config:
@@ -135,3 +145,4 @@ volumes:
   mysql_db:
   redis_data:
   elasticsearch_data:
+  pictshare_data:

--- a/docker-compose.ssl.dev.yml
+++ b/docker-compose.ssl.dev.yml
@@ -106,9 +106,20 @@ services:
       elasticsearch-setup:
         condition: service_completed_successfully
 
+
+  pictshare:
+    image: hascheksolutions/pictshare
+    volumes:
+      - pictshare_data:/var/www/data
+    environment:
+      MAX_UPLOAD_SIZE: 100
+      AUTO_UPDATE: "false"
+      ALLOW_BLOATING: "false"
+
 volumes:
   caddy_data:
   caddy_config:
   mysql_db:
   redis_data:
   elasticsearch_data:
+  pictshare_data:

--- a/docker-compose.ssl.local.yml
+++ b/docker-compose.ssl.local.yml
@@ -129,6 +129,16 @@ services:
       backend:
         condition: service_started # TODO change to service_healthy when we have a healthcheck
 
+  pictshare:
+    image: hascheksolutions/pictshare
+    volumes:
+      - pictshare_data:/var/www/data
+    environment:
+      MAX_UPLOAD_SIZE: 100
+      AUTO_UPDATE: "false"
+      ALLOW_BLOATING: "false"
+
+
 volumes:
   caddy_data:
   caddy_config:
@@ -136,3 +146,4 @@ volumes:
   mysql_db:
   redis_data:
   elasticsearch_data:
+  pictshare_data:

--- a/frontend/src/Components/MediaUploader.tsx
+++ b/frontend/src/Components/MediaUploader.tsx
@@ -179,7 +179,9 @@ export default function MediaUploader(props: MediaUploaderProps) {
                         .then(data => {
                             if (data.status === 'ok') {
                                 console.log('UPLOAD COMPLETE', data);
-                                props.onSuccess('https://idiod.video/' + data.url, uploadData.type);
+                                props.onSuccess(
+                                    `${window.location.protocol}//${window.location.host}/media/${data.url}`,
+                                    uploadData.type);
                             } else {
                                 console.log('UPLOAD FAILED: no link', data, file.type);
                                 toast.error('Произошла ошибка при загрузке 🥺');


### PR DESCRIPTION
Adds [`pictshare`](https://github.com/HaschekSolutions/pictshare/) docker-compose service.

The uploaded media is accessible via https://orbitar.domain/media/hash.ext