### PR TITLE
Calculate self-regulation "contentRating" part based on the unique users

### DIFF
--- a/backend/migrations/20230121673961-normalized-sr.js
+++ b/backend/migrations/20230121673961-normalized-sr.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+    dbm = options.dbmigrate;
+    type = dbm.dataType;
+    seed = seedLink;
+};
+
+exports.up = async function(db) {
+    await db.runSql(`
+      drop table if exists user_user_rating;
+      create table user_user_rating
+      (
+          voter_id        int           not null,
+          user_id        int           not null,
+          comment_rating int default 0 not null,
+          post_rating    int default 0 not null,
+          primary key (user_id, voter_id),
+          constraint fk_user_user_rating_user_id foreign key (user_id) references users (user_id) on delete cascade on update cascade,
+          constraint fk_user_user_rating_voter_id foreign key (voter_id) references users (user_id) on delete cascade on update cascade
+      ) engine=InnoDB;
+  `);
+
+    // populate from post_votes and comment_votes
+    await db.runSql(`
+        insert into user_user_rating (user_id, voter_id, comment_rating, post_rating)
+        select user_id,
+               voter_id,
+               sum(cr),
+               sum(pr)
+        from (select author_id as user_id, voter_id, sum(vote) as cr, 0 as pr
+              from comment_votes
+                       left join comments on comment_votes.comment_id = comments.comment_id
+              group by user_id, voter_id
+              union all
+              select author_id as user_id, voter_id, 0, sum(vote) as pr
+              from post_votes
+                       left join posts on post_votes.post_id = posts.post_id
+              group by user_id, voter_id
+        ) votes
+        group by user_id, voter_id;
+    `);
+
+    return null;
+};
+
+exports.down = async function(db) {
+    await db.runSql('drop table user_user_rating;');
+};
+
+exports._meta = {
+    "version": 1
+};

--- a/backend/src/api/UserController.ts
+++ b/backend/src/api/UserController.ts
@@ -234,18 +234,25 @@ export default class UserController {
                 return response.error(ERROR_CODES.NOT_FOUND, 'User not found', 404);
             }
 
+            const effectiveKarmaDebug = await this.userManager.getUserEffectiveKarma(profile.id);
             const restrictions = await this.userManager.getUserRestrictions(profile.id);
+            const {rating: totalNormalizedContentRating, voters: contentVotersNum} =
+                await this.userManager.getNormalizedUserContentRating(profile.id);
             const ratingBySubsite: UserRatingBySubsite = await this.userManager.getUserRatingBySubsite(profile.id);
             const activeKarmaVotes = await this.userManager.getActiveKarmaVotes(profile.id);
             const trialProgress = await this.userManager.getTrialProgressRaw(profile.id);
 
             return response.success({
-                effectiveKarma: restrictions.effectiveKarma,
+                effectiveKarma: effectiveKarmaDebug.effectiveKarma,
+                effectiveKarmaUserRating: effectiveKarmaDebug.userRating,
+                effectiveKarmaContentRating: effectiveKarmaDebug.contentRating,
                 senatePenalty: restrictions.senatePenalty,
                 activeKarmaVotes,
                 postRatingBySubsite: ratingBySubsite.postRatingBySubsite,
                 commentRatingBySubsite: ratingBySubsite.commentRatingBySubsite,
-                trialProgress
+                trialProgress,
+                totalNormalizedContentRating,
+                contentVotersNum
             });
         }
         catch (error) {

--- a/backend/src/api/types/requests/UserProfile.ts
+++ b/backend/src/api/types/requests/UserProfile.ts
@@ -27,11 +27,15 @@ export type TrialProgressDebugInfo = {
 
 export type UserKarmaResponse = {
     effectiveKarma: number;
+    effectiveKarmaUserRating: number;
+    effectiveKarmaContentRating: number;
     senatePenalty: number;
     activeKarmaVotes: Record<string, number>;
     postRatingBySubsite: Record<string, number>;
     commentRatingBySubsite: Record<string, number>;
     trialProgress: TrialProgressDebugInfo;
+    totalNormalizedContentRating: number;
+    contentVotersNum: number
 };
 
 /* see UserRestrictions */

--- a/frontend/src/API/UserAPI.ts
+++ b/frontend/src/API/UserAPI.ts
@@ -72,11 +72,16 @@ export type TrialProgressDebugInfo = {
 
 export type UserKarmaResponse = {
     effectiveKarma: number;
+    effectiveKarmaUserRating: number;
+    effectiveKarmaContentRating: number;
     senatePenalty: number;
     activeKarmaVotes: Record<string, number>;
+
     postRatingBySubsite: Record<string, number>;
     commentRatingBySubsite: Record<string, number>;
     trialProgress: TrialProgressDebugInfo;
+    totalNormalizedContentRating: number;
+    contentVotersNum: number
 };
 
 /* see UserRestrictions */

--- a/frontend/src/Components/Karma.tsx
+++ b/frontend/src/Components/Karma.tsx
@@ -3,7 +3,6 @@ import './KarmaCalculator.scss';
 
 type KarmaCalculatorProps = {
     senatePenalty?: number;
-    postsSumRating?: number;
     contentSumRating?: number;
     profileVotesCount?: number;
     profileVotesSum?: number;

--- a/frontend/src/Components/KarmaCalculator.scss
+++ b/frontend/src/Components/KarmaCalculator.scss
@@ -7,3 +7,7 @@
     }
   }
 }
+#karmaCalculator label div {
+  color: var(--fgSoftest);
+  max-width: 350px;
+}

--- a/frontend/src/Components/UserProfileKarma.tsx
+++ b/frontend/src/Components/UserProfileKarma.tsx
@@ -47,10 +47,6 @@ export const UserProfileKarma = (props: UserProfileKarmaProps) => {
         Object.keys(karmaResult.postRatingBySubsite)
             .reduce((acc, key) => acc + karmaResult.postRatingBySubsite[key], 0);
 
-    const sumCommentRating = !karmaResult ? 0 :
-        Object.keys(karmaResult.commentRatingBySubsite)
-            .reduce((acc, key) => acc + karmaResult.commentRatingBySubsite[key], 0);
-
     const activeKarmaVotesSum = !karmaResult ? 0 :
         Object.keys(karmaResult.activeKarmaVotes)
             .reduce((acc, key) => acc + karmaResult.activeKarmaVotes[key], 0);
@@ -173,14 +169,28 @@ export const UserProfileKarma = (props: UserProfileKarmaProps) => {
 
             {karmaResult && <>
                 <div>
-                    Прогресс прав:
+                    <div>
+                    <h3>Детали кармы:</h3>
+                    <pre>
+                        {JSON.stringify({
+                            effectiveKarma: karmaResult.effectiveKarma,
+                            userRating: karmaResult.effectiveKarmaUserRating,
+                            contentRating: karmaResult.effectiveKarmaContentRating,
+                            totalNormalizedContentRating: karmaResult.totalNormalizedContentRating,
+                            contentVotersNum: karmaResult.contentVotersNum,
+                        }, null, 2)}
+                    </pre>
+                    </div>
+                    <div>
+                    <h3>Прогресс прав:</h3>
                     <pre>
                         {JSON.stringify(karmaResult.trialProgress, null, 2)}
                     </pre>
+                    </div>
                 </div>
 
                 <div className={styles.container}>
-                    <Karma commentsSumRating={sumCommentRating} postsSumRating={sumPostRating}
+                    <Karma contentSumRating={karmaResult.totalNormalizedContentRating} postsSumRating={sumPostRating}
                            profileVotesCount={activeKarmaVotesCount} profileVotesSum={activeKarmaVotesSum}
                            senatePenalty={karmaResult.senatePenalty} />
 

--- a/frontend/src/Components/UserProfileKarma.tsx
+++ b/frontend/src/Components/UserProfileKarma.tsx
@@ -43,10 +43,6 @@ export const UserProfileKarma = (props: UserProfileKarmaProps) => {
     }, [api.userAPI, debug, props.username]);
 
 
-    const sumPostRating = !karmaResult ? 0 :
-        Object.keys(karmaResult.postRatingBySubsite)
-            .reduce((acc, key) => acc + karmaResult.postRatingBySubsite[key], 0);
-
     const activeKarmaVotesSum = !karmaResult ? 0 :
         Object.keys(karmaResult.activeKarmaVotes)
             .reduce((acc, key) => acc + karmaResult.activeKarmaVotes[key], 0);
@@ -190,7 +186,7 @@ export const UserProfileKarma = (props: UserProfileKarmaProps) => {
                 </div>
 
                 <div className={styles.container}>
-                    <Karma contentSumRating={karmaResult.totalNormalizedContentRating} postsSumRating={sumPostRating}
+                    <Karma contentSumRating={karmaResult.totalNormalizedContentRating}
                            profileVotesCount={activeKarmaVotesCount} profileVotesSum={activeKarmaVotesSum}
                            senatePenalty={karmaResult.senatePenalty} />
 


### PR DESCRIPTION
To recap, the final self-regulation score is composed of the `contentRating` and `userRating` (each in the range 0..1):

     ((contentRating + 1) * userRating - 1) * 1000

Before, the `contentRating` part was based on the sum (absolute value) of the other's votes for the user's content:

```sql
select sum(vote) from votes where user_id = ...
```

This could lead to abuse, as any individual user can potentially vote for every possible content entity of another user, creating biased distribution.

To mitigate the issue above, this PR proposes to first group votes by users, then normalize them (using a non-linear function) into a fixed range, and only after that do the final sum:

```sql
select sum(rating) from (
   select non_linear_transform( sum(votes) ) 
    from votes where user_id = ...
    group by voter_id
)
```

This way the contribution to the `contentRating` from each individual voter is bounded.

Specifically, the actual implementation uses scaled bipolar sigmoid function as a non-linear transform (final range from -2 to 2):
```sql
select sum(rating) as rating, count(*) as voters
   from (SELECT (4 / (1 + EXP(LEAST(50, -0.1 * sum(comment_rating + post_rating))))) - 2 AS rating
   FROM user_user_rating
     WHERE user_user_rating.user_id = :user_id
       and exists(select 1 from user_karma where user_karma.voter_id = user_user_rating.voter_id and vote != 0)
         group by voter_id
   ) t
```
Additionally, only votes from the users with full rights are considered.

