### PR TITLE
Parser: strip non-printable characters from the beginning and the end

### DIFF
--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -55,8 +55,10 @@ export default class TheParser {
     }
 
     parse(text: string): ParseResult {
-        // strip newlines from the beginning and end
-        text = text.replace(/^[\r\n]+|[\r\n]+$/g, '');
+        // strip non-printable characters from the beginning and the end (including newlines and spaces)
+        // see https://stackoverflow.com/questions/1176904/how-to-remove-all-non-printable-characters-in-a-string
+        // eslint-disable-next-line no-control-regex
+        text = text.replace(/^[\x00-\x20\x7F-\xA0\xAD]+|[\x00-\x20\x7F-\xA0\xAD]+$/ug, '');
 
         const doc = this.parseDocument(text, {
             decodeEntities: false

--- a/backend/test/parser/TheParser.test.ts
+++ b/backend/test/parser/TheParser.test.ts
@@ -68,6 +68,12 @@ test('mp4 video element', () => {
     );
 });
 
+test('strip leading and trailing non-printable chars', () => {
+    const orig = Buffer.from([0x00, 0x01, 0x20, 0x34, 0x32, 0x16, 0x20, 0x0D, 0x0A]).toString('utf8');
+    const parsed = p.parse(orig).text;
+    expect(parsed).toEqual('42');
+});
+
 test('remove line breaks at the beginning and the end', () => {
     expect(
         p.parse('Hello, \n' +


### PR DESCRIPTION
Avoid comments with hanging text:
<img width="307" alt="image" src="https://user-images.githubusercontent.com/2865203/214185624-4fb5c96b-62c1-4607-b806-438a7817c6ff.png">
(spaces mixed with newlines)