### PR TITLE
fix parsing html comments and directives

### DIFF
--- a/backend/src/api/PostController.ts
+++ b/backend/src/api/PostController.ts
@@ -199,6 +199,7 @@ export default class PostController {
         }
         catch (err) {
             this.logger.error('Post get error', { error: err, post_id: postId });
+            this.logger.error(err);
             return response.error('error', 'Unknown error', 500);
         }
     }
@@ -224,6 +225,7 @@ export default class PostController {
         }
         catch (err) {
             this.logger.error('Post edit error', { error: err, user_id: userId, post_id: id, format, content, title });
+            this.logger.error(err);
 
             if (err instanceof CodeError && err.code === 'access-denied') {
                 return response.error('access-denied', 'Access-denied');
@@ -258,6 +260,7 @@ export default class PostController {
         }
         catch (err) {
             this.logger.error('Post create failed', { error: err, user_id: userId, site, format, content, title });
+            this.logger.error(err);
             return response.error('error', 'Unknown error', 500);
         }
     }
@@ -273,6 +276,7 @@ export default class PostController {
             response.success({ content : result });
         } catch (err) {
             this.logger.error('Comment create failed', { error: err, user_id: userId, content });
+            this.logger.error(err);
             return response.error('error', 'Unknown error', 500);
         }
     }
@@ -357,6 +361,7 @@ export default class PostController {
         }
         catch (err) {
             this.logger.error('Bookmark failed', { error: err, user_id: userId, post_id: postId, bookmark });
+            this.logger.error(err);
             return response.error('error', 'Unknown error', 500);
         }
     }
@@ -376,6 +381,7 @@ export default class PostController {
         }
         catch (err) {
             this.logger.error('Watch failed', { error: err, user_id: userId, post_id: postId, watch });
+            this.logger.error(err);
             return response.error('error', 'Unknown error', 500);
         }
     }
@@ -405,6 +411,7 @@ export default class PostController {
         }
         catch (err) {
             this.logger.error('Comment get error', { error: err, comment_id: commentId });
+            this.logger.error(err);
             return response.error('error', 'Unknown error', 500);
         }
     }
@@ -439,6 +446,7 @@ export default class PostController {
         }
         catch (err) {
             this.logger.error('Comment edit error', { error: err, comment_id: commentId });
+            this.logger.error(err);
 
             if (err instanceof CodeError && err.code === 'access-denied') {
                 return response.error('access-denied', 'Access-denied');
@@ -488,6 +496,7 @@ export default class PostController {
         }
         catch (err) {
             this.logger.error('History request error', { error: err, ref_id: id, ref_type: type });
+            this.logger.error(err);
 
             if (err instanceof CodeError && err.code === 'access-denied') {
                 return response.error('access-denied', 'Access-denied');

--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -111,11 +111,11 @@ export default class TheParser {
         }
 
         if (node.type === 'directive') {
-            return escapeHTML(`<${node.data}>`);
+            return {text: escapeHTML(`<${node.data}>`), mentions: [], urls: [], images: []};
         }
 
         if (node.type === 'comment') {
-            return escapeHTML(`<!-- ${node.data} -->`);
+            return {text: escapeHTML(`<!--${node.data}-->`), mentions: [], urls: [], images: []};
         }
 
         return { text: '', mentions: [], urls: [], images: [] };

--- a/backend/test/parser/TheParser.test.ts
+++ b/backend/test/parser/TheParser.test.ts
@@ -173,3 +173,69 @@ test('mentions', () => {
         '<a href="/u/test" target="_blank" class="mention">test</a>'
     );
 });
+
+test('parse html comment', () => {
+    // returns escaped html comment as text
+    expect(
+        p.parse('<!-- test -->').text
+    ).toEqual('&lt;!-- test --&gt;');
+
+    expect(
+        p.parse('<!-- test -->test').text
+    ).toEqual('&lt;!-- test --&gt;test');
+
+    expect(
+        p.parse('test<!-- test -->').text
+    ).toEqual('test&lt;!-- test --&gt;');
+
+    expect(
+        p.parse('test<!-- test -->test').text
+    ).toEqual('test&lt;!-- test --&gt;test');
+
+    expect(
+        p.parse('test<!-- test -->test<!-- test -->test').text
+    ).toEqual('test&lt;!-- test --&gt;test&lt;!-- test --&gt;test');
+
+});
+
+test('parse html comment with html tags', () => {
+    expect(
+        p.parse('<!-- <a href="http://test.com">test</a> -->').text
+    ).toEqual('&lt;!-- &lt;a href=&quot;http://test.com&quot;&gt;test&lt;/a&gt; --&gt;');
+});
+
+test('parse html directive', () => {
+    // returns escaped html directive as text
+    expect(
+        p.parse('<!DOCTYPE html>').text
+    ).toEqual('&lt;!DOCTYPE html&gt;');
+
+    expect(
+        p.parse('<!DOCTYPE html>test').text
+    ).toEqual('&lt;!DOCTYPE html&gt;test');
+
+    expect(
+        p.parse('test<!DOCTYPE html>').text
+    ).toEqual('test&lt;!DOCTYPE html&gt;');
+
+    expect(
+        p.parse('test<!DOCTYPE html>test').text
+    ).toEqual('test&lt;!DOCTYPE html&gt;test');
+
+    expect(
+        p.parse('test<!DOCTYPE html>test<!DOCTYPE html>test').text
+    ).toEqual('test&lt;!DOCTYPE html&gt;test&lt;!DOCTYPE html&gt;test');
+
+    expect(
+        p.parse('<?xml version="1.0" encoding="UTF-8"?>').text
+    ).toEqual('&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;');
+
+    expect(
+        p.parse('<?xml version="1.0" encoding="UTF-8"?>test').text
+    ).toEqual('&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;test');
+
+    expect(
+        p.parse('test<?xml version="1.0" encoding="UTF-8"?>').text
+    ).toEqual('test&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;');
+
+});


### PR DESCRIPTION
Before: html comments and directives were broken (parser threw an error).

See unit test for examples.