### PR TITLE
Avoid exception on malformed input in aes decode

### DIFF
--- a/backend/src/parser/CryptoUtils.ts
+++ b/backend/src/parser/CryptoUtils.ts
@@ -8,12 +8,16 @@ export function aesEncryptToBase64(data, key) {
 }
 
 export function aesDecryptFromBase64(base64data, key) {
-    const decoded = CryptoJS.enc.Base64.parse(base64data);
-    const iv = CryptoJS.lib.WordArray.create(decoded.clone().words.slice(0, 4));
-    const ciphertext = CryptoJS.lib.WordArray.create(decoded.clone().words.slice(4));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const decrypted = CryptoJS.AES.decrypt({ciphertext} as any, CryptoJS.enc.Utf8.parse(key), {
-        iv
-    });
-    return decrypted.toString(CryptoJS.enc.Utf8);
+    try {
+        const decoded = CryptoJS.enc.Base64.parse(base64data);
+        const iv = CryptoJS.lib.WordArray.create(decoded.clone().words.slice(0, 4));
+        const ciphertext = CryptoJS.lib.WordArray.create(decoded.clone().words.slice(4));
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const decrypted = CryptoJS.AES.decrypt({ciphertext} as any, CryptoJS.enc.Utf8.parse(key), {
+            iv
+        });
+        return decrypted.toString(CryptoJS.enc.Utf8);
+    } catch (e) {
+        return '';
+    }
 }


### PR DESCRIPTION
Should fix the test failure: 
https://github.com/spaceshelter/orbitar/actions/runs/4077069917/jobs/7025623009#step:8:72