### PR TITLE
Render username mentions as links with icons

### DIFF
--- a/backend/src/managers/TranslationManager.ts
+++ b/backend/src/managers/TranslationManager.ts
@@ -7,7 +7,7 @@ import TheParser from '../parser/TheParser';
 import {stripHtml} from 'string-strip-html';
 import {Logger} from 'winston';
 import {addOnPostRun, FastText, FastTextModel} from '../../langid/fasttext.js';
-import {urlRegex} from '../parser/urlregex';
+import {urlRegex} from '../parser/regexprs';
 
 const fasttextModelPromise: Promise<FastTextModel> = new Promise<FastText>((resolve) => {
     addOnPostRun(() => {

--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -1,10 +1,10 @@
 import {DomHandler, DomHandlerOptions, Parser, ParserOptions} from 'htmlparser2';
-import { Document, Element, ChildNode } from 'domhandler';
-import { escape as htmlEscape } from 'html-escaper';
+import {ChildNode, Document, Element} from 'domhandler';
+import {escape as htmlEscape} from 'html-escaper';
 import escapeHTML from 'escape-html';
 import Url from 'url-parse';
 import qs from 'qs';
-import {urlRegex, urlRegexExact} from './urlregex';
+import {mentionsRegex, urlRegex, urlRegexExact} from './regexprs';
 import {MediaHostingConfig} from '../config';
 
 export type ParseResult = {
@@ -121,24 +121,45 @@ export default class TheParser {
         return { text: '', mentions: [], urls: [], images: [] };
     }
 
-    private parseText(text: string): ParseResult {
+    private extractMentions(text: string): { type: 'text' | 'mention', data: string }[] {
+        const tokens: { type: 'text' | 'mention', data: string }[] = [];
 
-        const tokens: { type: string; data: string }[] = [];
+        let sText = text;
+        mentionsRegex.lastIndex = 0;
+        let match = mentionsRegex.exec(sText);
+        while (match) {
+            const mention = match[0];
+            const pText = sText.substring(0, match.index);
+            if (pText) {
+                tokens.push({type: 'text', data: pText});
+            }
+            sText = sText.substring(match.index + mention.length);
+            tokens.push({ type: 'mention', data: match[1] });
+            mentionsRegex.lastIndex = 0;
+            match = mentionsRegex.exec(sText);
+        }
+        if (sText) {
+            tokens.push({ type: 'text', data: sText });
+        }
+        return tokens;
+    }
+
+    private parseText(text: string): ParseResult {
+        const tokens: { type: 'text' | 'url' | 'mention'; data: string }[] = [];
 
         let sText = text;
         urlRegex.lastIndex = 0;
         let match = urlRegex.exec(sText);
         while (match) {
             const url = match[0];
-            const pText = sText.substring(0, match.index);
-            tokens.push({ type: 'text', data: pText });
+            tokens.push(...this.extractMentions(sText.substring(0, match.index)));
             sText = sText.substring(match.index + url.length);
             tokens.push({ type: 'url', data: url });
             urlRegex.lastIndex = 0; //match.index + url.length;
 
             match = urlRegex.exec(sText);
         }
-        tokens.push({ type: 'text', data: sText });
+        tokens.push(...this.extractMentions(sText));
 
         const mentions = [];
         const urls = [];
@@ -146,15 +167,13 @@ export default class TheParser {
         let escaped = tokens
             .map((token) => {
                 if (token.type === 'text') {
-                    // check for mentions
-                    const mentionRes = token.data.match(/\B(?:@|\/u\/)([a-zа-яе0-9_-]+)/gi);
-                    if (mentionRes) {
-                        mentions.push(...mentionRes);
-                    }
                     return htmlEscape(token.data);
                 } else if (token.type === 'url') {
                     urls.push(token.data);
                     return this.processUrl(token.data);
+                } else if (token.type === 'mention') {
+                    mentions.push(token.data);
+                    return `<a href="${encodeURI(`/u/${token.data}`)}" target="_blank" class="mention">${htmlEscape(token.data)}</a>`;
                 }
             })
             .join('');
@@ -280,6 +299,9 @@ export default class TheParser {
         }
 
         const result = this.parseChildNodes(node.children);
+        if (result.urls.length > 0 || result.mentions.length > 0) {
+            return result;
+        }
         const text = `<a href="${encodeURI(decodeURI(url))}" target="_blank">${result.text}</a>`;
 
         return { ...result, text, urls: [ ...result.urls, url ] } ;

--- a/backend/src/parser/regexprs.ts
+++ b/backend/src/parser/regexprs.ts
@@ -97,3 +97,4 @@ function getRegex(path = '\\S*') {
 
 export const urlRegex = new RegExp('\\b' + getRegex('(?:[^\\s.,:;!()\\[\\]{}]|[.,:;!]+\\b)*'), 'gi');
 export const urlRegexExact = new RegExp('^' + getRegex() + '$', 'i');
+export const mentionsRegex = new RegExp('\\B@([a-zа-я0-9_-]+)', 'gi');

--- a/backend/test/parser/TheParser.test.ts
+++ b/backend/test/parser/TheParser.test.ts
@@ -124,3 +124,52 @@ test('remove extra line break after blockquote tag', () => {
     );
 });
 
+test('unwrap nested links', () => {
+    expect(
+        p.parse('<a href="https://test.com"><a href="https://test.com">test</a></a>').text
+    ).toEqual(
+        '<a href="https://test.com" target="_blank">test</a>'
+    );
+
+    expect(
+        p.parse('<a href="https://test.com">https://test2.com</a> test').text
+    ).toEqual(
+        '<a href="https://test2.com" target="_blank">https://test2.com</a> test'
+    );
+});
+
+test('mentions', () => {
+    // `<a href="${encodeURI(`/u/${token.data}`)}" target="_blank" class="mention">${htmlEscape(token.data)}</a>`;
+
+    expect(
+        p.parse('@test').text
+    ).toEqual(
+        '<a href="/u/test" target="_blank" class="mention">test</a>'
+    );
+
+    expect(
+        p.parse('@test test').text
+    ).toEqual(
+        '<a href="/u/test" target="_blank" class="mention">test</a> test'
+    );
+
+    expect(
+        p.parse('@test test @test').text
+    ).toEqual(
+        '<a href="/u/test" target="_blank" class="mention">test</a> test <a href="/u/test" target="_blank" class="mention">test</a>'
+    );
+
+    // urls, text, mentions
+    expect(
+        p.parse('https://test.com @test test').text
+    ).toEqual(
+        '<a href="https://test.com" target="_blank">https://test.com</a> <a href="/u/test" target="_blank" class="mention">test</a> test'
+    );
+
+    // mentions in links take precedence
+    expect(
+        p.parse('<a href="https://test.com">@test</a>').text
+    ).toEqual(
+        '<a href="/u/test" target="_blank" class="mention">test</a>'
+    );
+});

--- a/backend/test/parser/urlregex.test.ts
+++ b/backend/test/parser/urlregex.test.ts
@@ -1,4 +1,4 @@
-import {urlRegex, urlRegexExact} from "../../src/parser/urlregex";
+import {urlRegex, urlRegexExact, mentionsRegex} from "../../src/parser/regexprs";
 
 test('valid ULR parsing', () => {
     const validUrls = [
@@ -121,4 +121,58 @@ test('URL extraction', () => {
     expect(urlRegex.exec("http://test.com?q=123,blabla")[0]).toEqual("http://test.com?q=123,blabla");
     urlRegex.lastIndex = 0;
     expect(urlRegex.exec("https://i.imgur.com/LEv7f25.mp4")[0]).toEqual("https://i.imgur.com/LEv7f25.mp4");
+});
+
+test('mention extraction', () => {
+    // baseline
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.exec("@test")[0]).toEqual("@test");
+
+    // start of the mention must be clearly separated from the text
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.test("a@test")).toBe(false);
+
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.exec(".@test as")[0]).toEqual("@test");
+
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.exec("a @test as")[0]).toEqual("@test");
+
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.exec("(@test)")[0]).toEqual("@test");
+
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.exec("[@test]")[0]).toEqual("@test");
+
+    // cyrillic
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.exec("@тест")[0]).toEqual("@тест");
+
+    //case insensitive
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.exec("@TEST")[0]).toEqual("@TEST");
+
+    // cyrillic case insensitive
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.exec("@ТЕСТ")[0]).toEqual("@ТЕСТ");
+
+    // numbers
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.exec("@test123")[0]).toEqual("@test123");
+
+    // underscore
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.exec("@test_123")[0]).toEqual("@test_123");
+
+    // dash
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.exec("@test-123")[0]).toEqual("@test-123");
+
+    // dot delimiter
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.exec('@test.123')[0]).toEqual('@test');
+
+    // first group
+    mentionsRegex.lastIndex = 0;
+    expect(mentionsRegex.exec('@test.123')[1]).toEqual('test');
 });

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -98,6 +98,13 @@ svg#spoiler-mask {
   }
 }
 
+a.mention:before {
+  content: '@';
+  color: transparent;
+  background: url('./Assets/user.svg') no-repeat -1px 2px;
+  background-size: 16px 16px;
+}
+
 details.expand {
   background-color: var(--dim1);
   border-radius: 4px;


### PR DESCRIPTION
Demo:
![mention icon2](https://user-images.githubusercontent.com/2865203/221432905-a852b8b9-669a-44b7-b5bc-3e26d0f29ad8.gif)

Changes:
* Parser replaces mentions with `<a href="/u/username" target="_blank" class="mention">username</a>`
* Mentions are rendered as links with an icon <img width="13" alt="image" src="https://user-images.githubusercontent.com/2865203/221432969-25cc2b86-3890-453f-9328-a22fd90b520a.png"> instead of `@`
* Unit tests
