### PR TITLE
stop other videos

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react-dom": "^17.0.14",
         "@types/textarea-caret": "^3.0.1",
         "@types/webscopeio__react-textarea-autocomplete": "^4.7.2",
+        "@types/youtube": "^0.0.47",
         "@webscopeio/react-textarea-autocomplete": "^4.9.2",
         "check-password-strength": "^2.0.7",
         "classnames": "^2.3.1",
@@ -3549,6 +3550,11 @@
       "version": "21.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
+    },
+    "node_modules/@types/youtube": {
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@types/youtube/-/youtube-0.0.47.tgz",
+      "integrity": "sha512-uwqm0DUeg+2pff/8y9b22JJb+qWKOcG5aCn2yyT7hmLdK/M8+VECcK6QuNqdAR93IAqTmZeqK2nizTlQg5j+XA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.21.0",
@@ -20795,6 +20801,11 @@
       "version": "21.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
+    },
+    "@types/youtube": {
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@types/youtube/-/youtube-0.0.47.tgz",
+      "integrity": "sha512-uwqm0DUeg+2pff/8y9b22JJb+qWKOcG5aCn2yyT7hmLdK/M8+VECcK6QuNqdAR93IAqTmZeqK2nizTlQg5j+XA=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.21.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@types/react-dom": "^17.0.14",
     "@types/textarea-caret": "^3.0.1",
     "@types/webscopeio__react-textarea-autocomplete": "^4.7.2",
+    "@types/youtube": "^0.0.47",
     "@webscopeio/react-textarea-autocomplete": "^4.9.2",
     "check-password-strength": "^2.0.7",
     "classnames": "^2.3.1",

--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -186,7 +186,6 @@ function updateExpand(expand: HTMLDetailsElement) {
 }
 
 function stopVideo(el: HTMLElement, exept?: HTMLElement) {
-    console.log('--');
     el.querySelectorAll('video').forEach(video => {
         if (video === exept)
             return;

--- a/frontend/src/Services/ObserverService.ts
+++ b/frontend/src/Services/ObserverService.ts
@@ -1,0 +1,64 @@
+type IntersectionCallback = (entry: IntersectionObserverEntry) => void;
+type ElementCallbacks = WeakMap<Element, Set<IntersectionCallback>>;
+
+const INTERSECTION_RATIO = .5;
+let intersectionObserver: IntersectionObserver;
+let onShown: ElementCallbacks;
+let onHidden: ElementCallbacks;
+
+function handleIntersections(entries: IntersectionObserverEntry[]) {
+    entries.forEach((entry) => {
+        if (entry.isIntersecting && entry.intersectionRatio > INTERSECTION_RATIO) {
+            fireEvent(onShown, entry);
+        } else {
+            fireEvent(onHidden, entry);
+        }
+    });
+}
+
+function fireEvent(callbacks: ElementCallbacks, entry: IntersectionObserverEntry) {
+    const cbs = callbacks.get(entry.target);
+    cbs && Array.from(cbs, (cb)=> cb(entry));
+}
+
+function addEventListener(callbacks: ElementCallbacks, el: Element, cb: IntersectionCallback) {
+    const cbs = callbacks.get(el);
+    (cbs && cbs.add(cb)) || callbacks.set(el, new Set([cb]));
+}
+
+function removeEventListener(callbacks: ElementCallbacks, el: Element, cb: IntersectionCallback) {
+    const cbs = callbacks.get(el);
+    cbs && cbs.delete(cb);
+}
+
+export function createObserverService() {
+    onShown = new WeakMap();
+    onHidden = new WeakMap();
+    intersectionObserver = new IntersectionObserver(
+        handleIntersections,
+        {
+            rootMargin: '0px',
+            threshold: 0.5,
+        },
+    );
+}
+
+export function observeOnShown(el: Element, callback: IntersectionCallback) {
+    addEventListener(onShown, el, callback);
+    intersectionObserver.observe(el);
+}
+
+export function observeOnHidden(el: Element, callback: IntersectionCallback) {
+    addEventListener(onHidden, el, callback);
+    intersectionObserver.observe(el);
+}
+
+export function unobserveOnShown(el: Element, callback: IntersectionCallback) {
+    removeEventListener(onShown, el, callback);
+    intersectionObserver.unobserve(el);
+}
+
+export function unobserveOnHidden(el: Element, callback: IntersectionCallback) {
+    removeEventListener(onHidden, el, callback);
+    intersectionObserver.unobserve(el);
+}


### PR DESCRIPTION
Only one video at a time is allowed to play, other videos will be paused. 
Works with video and YouTube.
YouTube Iframe API is used for playback events.

Edit:

Added IntersectionObserver wrapper to track element's visibility and stop invisible videos that are scrolled out of the viewport.