### PR TITLE
Revert "render username mentions as links with icons (#275)"

### DIFF
--- a/backend/src/managers/TranslationManager.ts
+++ b/backend/src/managers/TranslationManager.ts
@@ -7,7 +7,7 @@ import TheParser from '../parser/TheParser';
 import {stripHtml} from 'string-strip-html';
 import {Logger} from 'winston';
 import {addOnPostRun, FastText, FastTextModel} from '../../langid/fasttext.js';
-import {urlRegex} from '../parser/regexprs';
+import {urlRegex} from '../parser/urlregex';
 
 const fasttextModelPromise: Promise<FastTextModel> = new Promise<FastText>((resolve) => {
     addOnPostRun(() => {

--- a/backend/src/parser/urlregex.ts
+++ b/backend/src/parser/urlregex.ts
@@ -97,4 +97,3 @@ function getRegex(path = '\\S*') {
 
 export const urlRegex = new RegExp('\\b' + getRegex('(?:[^\\s.,:;!()\\[\\]{}]|[.,:;!]+\\b)*'), 'gi');
 export const urlRegexExact = new RegExp('^' + getRegex() + '$', 'i');
-export const mentionsRegex = new RegExp('\\B@([a-zа-я0-9_-]+)', 'gi');

--- a/backend/test/parser/TheParser.test.ts
+++ b/backend/test/parser/TheParser.test.ts
@@ -130,56 +130,6 @@ test('remove extra line break after blockquote tag', () => {
     );
 });
 
-test('unwrap nested links', () => {
-    expect(
-        p.parse('<a href="https://test.com"><a href="https://test.com">test</a></a>').text
-    ).toEqual(
-        '<a href="https://test.com" target="_blank">test</a>'
-    );
-
-    expect(
-        p.parse('<a href="https://test.com">https://test2.com</a> test').text
-    ).toEqual(
-        '<a href="https://test2.com" target="_blank">https://test2.com</a> test'
-    );
-});
-
-test('mentions', () => {
-    // `<a href="${encodeURI(`/u/${token.data}`)}" target="_blank" class="mention">${htmlEscape(token.data)}</a>`;
-
-    expect(
-        p.parse('@test').text
-    ).toEqual(
-        '<a href="/u/test" target="_blank" class="mention">test</a>'
-    );
-
-    expect(
-        p.parse('@test test').text
-    ).toEqual(
-        '<a href="/u/test" target="_blank" class="mention">test</a> test'
-    );
-
-    expect(
-        p.parse('@test test @test').text
-    ).toEqual(
-        '<a href="/u/test" target="_blank" class="mention">test</a> test <a href="/u/test" target="_blank" class="mention">test</a>'
-    );
-
-    // urls, text, mentions
-    expect(
-        p.parse('https://test.com @test test').text
-    ).toEqual(
-        '<a href="https://test.com" target="_blank">https://test.com</a> <a href="/u/test" target="_blank" class="mention">test</a> test'
-    );
-
-    // mentions in links take precedence
-    expect(
-        p.parse('<a href="https://test.com">@test</a>').text
-    ).toEqual(
-        '<a href="/u/test" target="_blank" class="mention">test</a>'
-    );
-});
-
 test('parse html comment', () => {
     // returns escaped html comment as text
     expect(

--- a/backend/test/parser/urlregex.test.ts
+++ b/backend/test/parser/urlregex.test.ts
@@ -1,4 +1,4 @@
-import {urlRegex, urlRegexExact, mentionsRegex} from "../../src/parser/regexprs";
+import {urlRegex, urlRegexExact} from "../../src/parser/urlregex";
 
 test('valid ULR parsing', () => {
     const validUrls = [
@@ -121,58 +121,4 @@ test('URL extraction', () => {
     expect(urlRegex.exec("http://test.com?q=123,blabla")[0]).toEqual("http://test.com?q=123,blabla");
     urlRegex.lastIndex = 0;
     expect(urlRegex.exec("https://i.imgur.com/LEv7f25.mp4")[0]).toEqual("https://i.imgur.com/LEv7f25.mp4");
-});
-
-test('mention extraction', () => {
-    // baseline
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.exec("@test")[0]).toEqual("@test");
-
-    // start of the mention must be clearly separated from the text
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.test("a@test")).toBe(false);
-
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.exec(".@test as")[0]).toEqual("@test");
-
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.exec("a @test as")[0]).toEqual("@test");
-
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.exec("(@test)")[0]).toEqual("@test");
-
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.exec("[@test]")[0]).toEqual("@test");
-
-    // cyrillic
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.exec("@тест")[0]).toEqual("@тест");
-
-    //case insensitive
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.exec("@TEST")[0]).toEqual("@TEST");
-
-    // cyrillic case insensitive
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.exec("@ТЕСТ")[0]).toEqual("@ТЕСТ");
-
-    // numbers
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.exec("@test123")[0]).toEqual("@test123");
-
-    // underscore
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.exec("@test_123")[0]).toEqual("@test_123");
-
-    // dash
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.exec("@test-123")[0]).toEqual("@test-123");
-
-    // dot delimiter
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.exec('@test.123')[0]).toEqual('@test');
-
-    // first group
-    mentionsRegex.lastIndex = 0;
-    expect(mentionsRegex.exec('@test.123')[1]).toEqual('test');
 });

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -98,13 +98,6 @@ svg#spoiler-mask {
   }
 }
 
-a.mention:before {
-  content: '@';
-  color: transparent;
-  background: url('./Assets/user.svg') no-repeat -1px 2px;
-  background-size: 16px 16px;
-}
-
 details.expand {
   background-color: var(--dim1);
   border-radius: 4px;


### PR DESCRIPTION
This reverts commit 9bb23ae5da4fc0c454107e90ac20dc22f4e9aed7 to fix the issue with non-working `@`-mentions