### PR TITLE
Fix orbitarMediaPoster for url with /raw at the end

### DIFF
--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -339,7 +339,7 @@ export default class TheParser {
         };
         const orbitarMediaPoster = () => {
             if (url.startsWith(this.mediaHostingConfig.url)) {
-                const match = url.match(/.*\/([^.]+\.mp4)$/);
+                const match = url.match(/.*\/([^.]+\.mp4)(\/raw)?$/);
                 return match && [`${this.mediaHostingConfig.url}/preview/${encodeURI(match[1])}`,
                     `${this.mediaHostingConfig.url}/${encodeURI(match[1])}/raw`];
             }


### PR DESCRIPTION
Currently, urls like "https://site/123.mp4" and "https://site/123.mp4/raw" will be rendered differently.
Small patch to fix this behavior.