### PR TITLE
strip newline after blocks

### DIFF
--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -70,10 +70,11 @@ export default class TheParser {
 
     private parseChildNodes(doc: ChildNode[]): ParseResult {
         const p = {text: '', mentions: [], urls: [], images: []};
-        let prevBQ = false; // if previous node was blockquote
+        let prevIsBlock = false; // if previous node was block tag
+        const blockTags = ['blockquote', 'expand'];
         for (let node of doc) {
-            if (prevBQ && node.type === 'text') {
-                // remove a single newline after blockquote, allow only a single one if multiple were present
+            if (prevIsBlock && node.type === 'text') {
+                // remove a single newline after block tags, allow only a single one if multiple were present
                 node = {
                     ...node,
                     data: node.data.replace(/^(\r?\n|[\r\n])(\r?\n|[\r\n])?(\r?\n|[\r\n])*/, '$2')
@@ -85,7 +86,7 @@ export default class TheParser {
             p.mentions.push(...res.mentions);
             p.urls.push(...res.urls);
             p.images.push(...res.images);
-            prevBQ = node.type === 'tag' && node.tagName.toLowerCase() === 'blockquote';
+            prevIsBlock = node.type === 'tag' && blockTags.includes(node.tagName.toLowerCase());
         }
         return p;
     }


### PR DESCRIPTION
Small fix for expand tag.

Before:
![11](https://user-images.githubusercontent.com/230060/225928504-d0a30ba8-748f-4b26-b1bf-d9c722aa338b.png)

After:
![22](https://user-images.githubusercontent.com/230060/225928578-f5aee416-6aaa-4296-8dfb-c960a0429e75.png)
