### PR TITLE
Deduplicate notifications when mentioning user multiple times

### DIFF
--- a/backend/src/managers/NotificationManager.ts
+++ b/backend/src/managers/NotificationManager.ts
@@ -137,13 +137,8 @@ export default class NotificationManager {
         this.sendWebPush(forUserId, notification).then().catch();
     }
 
-    async sendAnswerNotify(parentCommentId: number, byUserId: number, postId: number, commentId?: number) {
-        const commentRaw = await this.commentRepository.getComment(parentCommentId);
-        if (!commentRaw) {
-            return false;
-        }
-
-        if (commentRaw.author_id === byUserId) {
+    async sendAnswerNotify(forUserId: number, byUserId: number, postId: number, commentId?: number) {
+        if (forUserId === byUserId) {
             return false;
         }
 
@@ -157,7 +152,7 @@ export default class NotificationManager {
             }
         };
 
-        await this.sendNotification(commentRaw.author_id, notification);
+        await this.sendNotification(forUserId, notification);
     }
 
     async sendMentionNotify(mention: string, byUserId: number, postId: number, commentId?: number) {

--- a/backend/src/managers/PostManager.ts
+++ b/backend/src/managers/PostManager.ts
@@ -251,6 +251,7 @@ export default class PostManager {
             parentAuthor = await this.userManager.getById(parentComment.author_id);
         }
         for (const mention of new Set(parseResult.mentions)) {
+            // if author of parent comment/post was mentioned - do not send notifications - they are already notified about answer to their comment
             if (mention.toLowerCase() === parentAuthor?.username.toLowerCase()) {
                 continue;
             }

--- a/backend/src/managers/PostManager.ts
+++ b/backend/src/managers/PostManager.ts
@@ -83,7 +83,7 @@ export default class PostManager {
 
         await this.bookmarkRepository.setWatch(postRaw.post_id, userId, true);
 
-        for (const mention of new Set(parseResult.mentions)) {
+        for (const mention of parseResult.mentions) {
             await this.notificationManager.sendMentionNotify(mention, userId, postRaw.post_id);
         }
 
@@ -250,9 +250,10 @@ export default class PostManager {
             const parentComment = await this.commentRepository.getComment(parentCommentId);
             parentAuthor = await this.userManager.getById(parentComment.author_id);
         }
-        for (const mention of new Set(parseResult.mentions)) {
-            // if author of parent comment/post was mentioned - do not send notifications - they are already notified about answer to their comment
-            if (mention.toLowerCase() === parentAuthor?.username.toLowerCase()) {
+        for (const mention of parseResult.mentions) {
+            // if author of parent comment/post was mentioned - do not send notifications:
+            // they are already notified about answer to their comment
+            if (mention === parentAuthor?.username.toLowerCase()) {
                 continue;
             }
             await this.notificationManager.sendMentionNotify(mention, userId, postId, commentRaw.comment_id);

--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -65,7 +65,9 @@ export default class TheParser {
             decodeEntities: false
         });
 
-        return this.parseChildNodes(doc.childNodes);
+        const parseResult = this.parseChildNodes(doc.childNodes);
+        parseResult.mentions = [...new Set(parseResult.mentions)];
+        return parseResult;
     }
 
     private parseChildNodes(doc: ChildNode[]): ParseResult {
@@ -175,7 +177,7 @@ export default class TheParser {
                     urls.push(token.data);
                     return this.processUrl(token.data);
                 } else if (token.type === 'mention') {
-                    mentions.push(token.data);
+                    mentions.push(token.data.toLowerCase());
                     return `<a href="${encodeURI(`/u/${token.data}`)}" target="_blank" class="mention">${htmlEscape(token.data)}</a>`;
                 }
             })

--- a/backend/test/parser/TheParser.test.ts
+++ b/backend/test/parser/TheParser.test.ts
@@ -167,7 +167,13 @@ test('mentions', () => {
     expect(
         parse('@test test @test')
     ).toEqual(
-        ['<a href="/u/test" target="_blank" class="mention">test</a> test <a href="/u/test" target="_blank" class="mention">test</a>', ['test', 'test']]
+        ['<a href="/u/test" target="_blank" class="mention">test</a> test <a href="/u/test" target="_blank" class="mention">test</a>', ['test']]
+    );
+
+    expect(
+        parse('@test test @test1')
+    ).toEqual(
+        ['<a href="/u/test" target="_blank" class="mention">test</a> test <a href="/u/test1" target="_blank" class="mention">test1</a>', ['test', 'test1']]
     );
 
     // urls, text, mentions


### PR DESCRIPTION
Tested three cases:
* multiple mentions in the post
* multiple mentions in a standalone comment
* multiple mentions in the reply comment
* no mentions with all the above
* unrelated mentions with all the above