### PR TITLE
Add a button that drops all sessions and resets the password

### DIFF
--- a/backend/migrations/20230405759375-sessions-user-id.js
+++ b/backend/migrations/20230405759375-sessions-user-id.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+    dbm = options.dbmigrate;
+    type = dbm.dataType;
+    seed = seedLink;
+};
+
+exports.up = async function(db) {
+    await db.runSql(`
+        alter table orbitar_db.sessions add column user_id int;
+    `);
+
+    await db.runSql(`
+        UPDATE orbitar_db.sessions SET user_id = CAST(JSON_EXTRACT(data, '$.userId') AS UNSIGNED); 
+    `);
+
+    await db.runSql(`
+        DELETE FROM orbitar_db.sessions
+        WHERE user_id NOT IN (SELECT user_id FROM orbitar_db.users); 
+    `);
+
+    await db.runSql(`
+        ALTER TABLE orbitar_db.sessions
+        MODIFY COLUMN user_id INT NOT NULL;
+    `);
+
+    await db.runSql(`
+        ALTER TABLE orbitar_db.sessions
+        ADD CONSTRAINT fk_sessions_users
+        FOREIGN KEY (user_id) REFERENCES orbitar_db.users(user_id);
+    `);
+
+    return null;
+};
+
+exports.down = async function(db) {
+    await db.runSql(`
+        ALTER TABLE orbitar_db.sessions
+        DROP FOREIGN KEY fk_sessions_users;
+        
+        ALTER TABLE orbitar_db.sessions
+        DROP COLUMN user_id;
+    `);
+    return null;
+};
+
+exports._meta = {
+    "version": 1
+};

--- a/backend/src/api/AuthController.ts
+++ b/backend/src/api/AuthController.ts
@@ -184,7 +184,7 @@ export default class AuthController {
         const userId = request.session.data.userId;
         try {
             await this.userManager.dropPassword(userId);
-            await request.session.destroyAll();
+            await request.session.destroyAllForCurrentUser();
             return response.success({});
         } catch (err) {
             this.logger.error('Failed to drop password and sessions', {user_id: userId});

--- a/backend/src/api/AuthController.ts
+++ b/backend/src/api/AuthController.ts
@@ -182,6 +182,10 @@ export default class AuthController {
         }
 
         const userId = request.session.data.userId;
+        if (this.userManager.isBarmaliniUser(userId)) {
+            return response.error('barmalini-user', 'Barmalini user cannot drop password and sessions');
+        }
+
         try {
             await this.userManager.dropPassword(userId);
             await request.session.destroyAllForCurrentUser();

--- a/backend/src/api/AuthController.ts
+++ b/backend/src/api/AuthController.ts
@@ -18,6 +18,9 @@ import {
 type SignOutRequest = Record<string, unknown>;
 type SignOutResponse = Record<string, unknown>;
 
+type DropPasswordAndSessionsRequest = Record<string, unknown>;
+type DropPasswordAndSessionsResponse = Record<string, unknown>;
+
 export default class AuthController {
     public router = Router();
     private userManager: UserManager;
@@ -62,6 +65,7 @@ export default class AuthController {
 
         this.router.post('/auth/signin', signInLimiter, validate(signInSchema), (req, res) => this.signin(req, res));
         this.router.post('/auth/reset-password', resetPaswsordLimiter, validate(resetPasswordSchema), (req, res) => this.resetPaswsord(req, res));
+        this.router.post('/auth/drop-password-and-sessions', (req, res) => this.dropPasswordAndSessions(req, res));
         this.router.post('/auth/new-password', resetPaswsordLimiter, validate(newPasswordSchema), (req, res) => this.setNewPassword(req, res));
         this.router.post('/auth/check-reset-password-code', validate(checkResetPasswordCodeSchema), (req, res) => this.checkIfPasswordResetCodeExists(req, res));
         this.router.post('/auth/signout', (req, res) => this.signout(req, res));
@@ -167,6 +171,24 @@ export default class AuthController {
             return response.success({});
         }
         catch (err) {
+            return response.error('unknown', 'Unknown error', 500);
+        }
+    }
+
+    async dropPasswordAndSessions(request: APIRequest<DropPasswordAndSessionsRequest>,
+                                  response: APIResponse<DropPasswordAndSessionsResponse>) {
+        if (!request.session.data.userId) {
+            return response.authRequired();
+        }
+
+        const userId = request.session.data.userId;
+        try {
+            await this.userManager.dropPassword(userId);
+            await request.session.destroyAll();
+            return response.success({});
+        } catch (err) {
+            this.logger.error('Failed to drop password and sessions', {user_id: userId});
+            this.logger.error(err);
             return response.error('unknown', 'Unknown error', 500);
         }
     }

--- a/backend/src/api/UserController.ts
+++ b/backend/src/api/UserController.ts
@@ -151,7 +151,8 @@ export default class UserController {
                 trialProgress,
                 numberOfPosts,
                 numberOfComments,
-                numberOfInvitesAvailable
+                numberOfInvitesAvailable,
+                isBarmalini: this.userManager.isBarmaliniUser(profileInfo.id)
             });
         } catch (error) {
             this.logger.error('Could not get user profile', {username});

--- a/backend/src/api/types/requests/UserProfile.ts
+++ b/backend/src/api/types/requests/UserProfile.ts
@@ -16,6 +16,7 @@ export type UserProfileResponse = {
     numberOfInvitesAvailable?: number;
 
     invites: UserProfileEntity[];
+    isBarmalini?: boolean;
 };
 
 export type TrialProgressDebugInfo = {

--- a/backend/src/db/repositories/UserRepository.ts
+++ b/backend/src/db/repositories/UserRepository.ts
@@ -268,4 +268,8 @@ export default class UserRepository {
             { offset }
         );
     }
+
+    async dropPassword(userId: number) {
+        return this.db.query(`update users set password = '' where user_id = :user_id`, {user_id: userId});
+    }
 }

--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -672,4 +672,8 @@ export default class UserManager {
             return item.v;
         });
     }
+
+    async dropPassword(userId: number) {
+        await this.userRepository.dropPassword(userId);
+    }
 }

--- a/backend/src/session/Session.ts
+++ b/backend/src/session/Session.ts
@@ -147,7 +147,7 @@ export default class Session {
         this.response.setHeader(Session.SESSION_HEADER, '-');
     }
 
-    async destroyAll() {
+    async destroyAllForCurrentUser() {
         if (!this.id || !this.data?.userId) return;
         const userSessions = sessionsByUser.get(this.data.userId);
         if (userSessions) {

--- a/backend/src/session/Session.ts
+++ b/backend/src/session/Session.ts
@@ -5,6 +5,26 @@ import {Logger} from 'winston';
 import {config} from '../config';
 
 const sessionStorage: Record<string, { created: Date, data: SessionData}> = {};
+const sessionsByUser: Map<number, Set<string>> = new Map();
+
+function addToUserSessions(userId: number, sessionId: string) {
+    // add to user index
+    const userSessions = sessionsByUser.get(userId);
+    if (userSessions) {
+        userSessions.add(sessionId);
+    } else {
+        const userSessions = new Set([sessionId]);
+        sessionsByUser.set(userId, userSessions);
+    }
+}
+
+function deleteFromUserSessions(userId: number, sessionId: string) {
+    // remove from user index
+    const userSessions = sessionsByUser.get(userId);
+    if (userSessions) {
+        userSessions.delete(sessionId);
+    }
+}
 
 export default class Session {
     private request: Request;
@@ -56,6 +76,7 @@ export default class Session {
                         created: this.created,
                         data: this.data
                     };
+                    addToUserSessions(this.data.userId, this.id);
                     this.response.setHeader(Session.SESSION_HEADER, this.id);
                     return;
                 }
@@ -113,7 +134,9 @@ export default class Session {
         this.data.clear();
         this.data = new SessionData('');
         delete sessionStorage[this.id];
-
+        if (this.data.userId) {
+            deleteFromUserSessions(this.data.userId, this.id);
+        }
         this.logger.verbose(`Session ${this.id} removed from DB`, { session: this.id });
 
         await this.db.query('delete from sessions where id=:id', {
@@ -121,6 +144,25 @@ export default class Session {
         });
 
         this.id = undefined;
+        this.response.setHeader(Session.SESSION_HEADER, '-');
+    }
+
+    async destroyAll() {
+        if (!this.id || !this.data?.userId) return;
+        const userSessions = sessionsByUser.get(this.data.userId);
+        if (userSessions) {
+            sessionsByUser.delete(this.data.userId);
+            for (const sessionId of userSessions) {
+                delete sessionStorage[sessionId];
+            }
+        }
+        await this.db.query('delete from sessions where user_id=:userId', {
+            userId: this.data.userId
+        });
+        this.data.clear();
+        this.data = new SessionData('');
+        this.id = undefined;
+
         this.response.setHeader(Session.SESSION_HEADER, '-');
     }
 
@@ -132,10 +174,17 @@ export default class Session {
         };
         const stringData = JSON.stringify(data);
 
-        await this.db.query('insert into sessions (id, data) values (:id, :data) on duplicate key update data=:data', {
-            id: this.id,
-            data: stringData
-        });
+        await this.db.query(
+            `insert into sessions (id, user_id, data)
+             values (:id, :user_id, :data)
+                 on duplicate key update
+                        user_id=:user_id,
+                        data=:data`
+            , {
+                id: this.id,
+                user_id: this.data.userId,
+                data: stringData
+            });
 
         this.logger.verbose(`Session ${this.id} stored to DB`, { session: this.id, data: data });
     }

--- a/frontend/src/API/AuthAPI.ts
+++ b/frontend/src/API/AuthAPI.ts
@@ -24,6 +24,8 @@ type SignOutRequest = Record<string, unknown>;
 type SignOutResponse = Record<string, unknown>;
 
 type ResetPasswordRequest = {email: string;};
+type ResetPasswordAndSessionsRequest = Record<string, unknown>;
+type ResetPasswordAndSessionsResponse = Record<string, unknown>;
 type ResetPasswordResponse = {result: boolean;};
 type CheckResetPasswordCodeRequest = {code: string;};
 type SetNewPasswordRequest = {password: string; code: string;};
@@ -54,6 +56,10 @@ export default class AuthAPI {
         return await this.api.request<ResetPasswordRequest, ResetPasswordResponse>('/auth/reset-password', {
             email
         });
+    }
+
+    async dropPasswordAndSessions() {
+        return await this.api.request<ResetPasswordAndSessionsRequest, ResetPasswordAndSessionsResponse>('/auth/drop-password-and-sessions', {});
     }
 
     async setNewPassword(password: string, code: string): Promise<ResetPasswordResponse> {

--- a/frontend/src/API/AuthAPIHelper.ts
+++ b/frontend/src/API/AuthAPIHelper.ts
@@ -46,6 +46,17 @@ export default class AuthAPIHelper {
         }
     }
 
+    async dropPasswordAndSessions() {
+        try {
+            await this.api.dropPasswordAndSessions();
+            this.appState.setUserInfo(undefined);
+            this.appState.setAppLoadingState(AppLoadingState.unauthorized);
+        } catch (error) {
+            console.log('ERROR DROPPING PASSWORD AND SESSIONS', error);
+            throw error;
+        }
+    }
+
     async setNewPassword(password: string, code: string) {
         try {
             return await this.api.setNewPassword(password, code);

--- a/frontend/src/API/UserAPI.ts
+++ b/frontend/src/API/UserAPI.ts
@@ -25,6 +25,7 @@ type UserProfileResponse = {
     numberOfPosts: number;
     numberOfComments: number;
     numberOfInvitesAvailable?: number;
+    isBarmalini?: boolean;
 };
 type UserProfilePostsRequest = {
     username: string;

--- a/frontend/src/API/UserAPIHelper.ts
+++ b/frontend/src/API/UserAPIHelper.ts
@@ -13,6 +13,7 @@ export type UserProfileResult = {
     numberOfPosts: number;
     numberOfComments: number;
     numberOfInvitesAvailable?: number;
+    isBarmalini?: boolean;
 };
 
 export default class UserAPIHelper {

--- a/frontend/src/Components/Buttons.module.scss
+++ b/frontend/src/Components/Buttons.module.scss
@@ -1,4 +1,5 @@
 .logoutButton,
+.settingsButton,
 .themeButton {
   background: var(--dim1);
   color: var(--fgSoft);
@@ -12,7 +13,7 @@
   fill: var(--fgSoft);
 }
 
-.logoutButton:hover,
+.logoutButton:hover, .settingsButton:hover,
 .themeButton.dynamic:hover
 {
   fill: var(--fg);

--- a/frontend/src/Components/UserProfileSettings.module.scss
+++ b/frontend/src/Components/UserProfileSettings.module.scss
@@ -12,3 +12,7 @@
 .barmalini .password {
   cursor: pointer;
 }
+
+.dropSessions {
+    color: var(--danger);
+}

--- a/frontend/src/Components/UserProfileSettings.tsx
+++ b/frontend/src/Components/UserProfileSettings.tsx
@@ -16,6 +16,7 @@ type UserProfileSettingsProps = {
   onChange: any;
   gender: UserGender;
   barmaliniAccess?: boolean;
+  isBarmalini?: boolean;
 };
 
 export default function UserProfileSettings(props: UserProfileSettingsProps) {
@@ -100,9 +101,9 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
             </div>
             {props.barmaliniAccess && <BarmaliniAccess/>}
             <div>
-            {<button className={classNames(buttonStyles.settingsButton, styles.dropSessions)} onClick={handleResetSessions}>
+            {!props.isBarmalini && <button className={classNames(buttonStyles.settingsButton, styles.dropSessions)} onClick={handleResetSessions}>
                 <span className={classNames('i i-ghost' )}/> Сброс пароля и сессий </button>}
-            {<button className={buttonStyles.logoutButton} onClick={handleLogout}><LogoutIcon/> Выйти </button>}
+                <button className={buttonStyles.logoutButton} onClick={handleLogout}><LogoutIcon/> Выйти </button>
             </div>
         </>
     );

--- a/frontend/src/Components/UserProfileSettings.tsx
+++ b/frontend/src/Components/UserProfileSettings.tsx
@@ -49,7 +49,7 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
     };
 
   const handleLogout = confirmWrapper(
-      'Вы действительно хотите выйти? Текущая сессия будет сброшена. Вы будете вынуждены войти в аккаунт заново.', () => {
+      'Вы действительно хотите выйти? Вы будете вынуждены войти в аккаунт заново.', () => {
           api.auth.signOut().then(() => {
               navigate(location.pathname);
           });
@@ -58,7 +58,7 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
   const handleResetSessions = confirmWrapper(
       `Вы действительно хотите сбросить пароль и все сессии?
       Вы будете разлогинены на ВСЕХ устройствах, текущий пароль больше не будет работать.
-      Вам нужно будет сменить пароль (через почту) и войти в аккаунт заново.`, () => {
+      На почту использованную при регистрации (у вас же всё ещё есть доступ к ней?) придет ссылка для сброса пароля через которую вы сможете войти в аккаунт заново и установить новый пароль.`, () => {
           api.auth.dropPasswordAndSessions().then(() => {
               navigate(location.pathname);
           });

--- a/frontend/src/Pages/UserPage.tsx
+++ b/frontend/src/Pages/UserPage.tsx
@@ -139,7 +139,11 @@ export const UserPage = observer(() => {
                     {isComments && <UserProfileComments username={user.username} />}
                     {isInvites && <UserProfileInvites username={user.username} onInvitesChange={handleInvitesChange} />}
                     {isKarma && <UserProfileKarma username={user.username} profile={profile} />}
-                    {isSettings && <UserProfileSettings gender={user.gender} onChange={refreshProfile} barmaliniAccess={restrictions?.canVoteKarma} />}
+                    {isSettings && <UserProfileSettings
+                        gender={user.gender} onChange={refreshProfile}
+                        barmaliniAccess={restrictions?.canVoteKarma && !profile.isBarmalini}
+                        isBarmalini={profile.isBarmalini}
+                    />}
                 </div>
             </div>
         );


### PR DESCRIPTION
Button view:
<img width="438" alt="image" src="https://user-images.githubusercontent.com/2865203/230266829-e17d45fc-eb08-4fa6-80c0-5f03878c944f.png">


Confirmation:
<img width="594" alt="image" src="https://user-images.githubusercontent.com/2865203/230266864-d6af608a-bd6a-4198-80fd-d010b179c48b.png">

Also added similar confirmation to the "Logout":
<img width="522" alt="image" src="https://user-images.githubusercontent.com/2865203/230266900-0e5352ef-bd97-4689-b350-ca9526e5a9cf.png">


### Summary of the changes:
* introduced the new field `sessions.user_id`, populated it, added foreign key
* added a local cache for all sessions of the user
* added a button in the profile/settings to drop all sessions and reset password

Tested locally.