### PR TITLE
Fix autocut not triggering, trigger blur and autocut for the personally downvoted posts and comments

### DIFF
--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -3,7 +3,7 @@ import styles from './CommentComponent.module.scss';
 import RatingSwitch from './RatingSwitch';
 import React, {useMemo, useState} from 'react';
 import {CreateCommentComponentRestricted} from './CreateCommentComponent';
-import ContentComponent from './ContentComponent';
+import ContentComponent, {LARGE_AUTO_CUT} from './ContentComponent';
 import {useAPI} from '../AppState/AppState';
 import {toast} from 'react-toastify';
 import {SignatureComponent} from './SignatureComponent';
@@ -113,7 +113,9 @@ export default function CommentComponent(props: CommentProps) {
                             <HistoryComponent initial={{ content, date: created }} history={{ id: props.comment.id, type: 'comment' }} onClose={toggleHistory} />
                         :
                             <div className={styles.content}>
-                                <ContentComponent className={styles.commentContent} content={content} lowRating={props.comment.rating <= Conf.COMMENT_LOW_RATING_THRESHOLD} autoCut={props.comment.rating <= Conf.COMMENT_LOW_RATING_THRESHOLD} />
+                                <ContentComponent className={styles.commentContent} content={content}
+                                                  lowRating={props.comment.rating <= Conf.COMMENT_LOW_RATING_THRESHOLD || props.comment.vote === -1}
+                                                  autoCut={(props.comment.rating <= Conf.COMMENT_LOW_RATING_THRESHOLD || props.comment.vote === -1) ? LARGE_AUTO_CUT : undefined} />
                             </div>
                     )
                 :

--- a/frontend/src/Components/ContentComponent.module.scss
+++ b/frontend/src/Components/ContentComponent.module.scss
@@ -10,8 +10,9 @@
   &.cut {
     overflow: hidden;
     -webkit-mask-image: -webkit-gradient(linear, left 70%, left 90%, from(rgba(0,0,0,1)), to(rgba(0,0,0,0)));
-    mask-image: linear-gradient(to bottom, rgba(0,0,0,1) 70%, rgba(0,0,0,0) 90%);
+    mask-image: linear-gradient(to top, rgba(0,0,0,0) 50px, rgba(0,0,0,1) 100px);
   }
+
   b, i, u, strike, blockquote{
     color: var(--fg);
   }

--- a/frontend/src/Components/ContentComponent.module.scss
+++ b/frontend/src/Components/ContentComponent.module.scss
@@ -8,7 +8,6 @@
   }
 
   &.cut {
-    max-height: 650px;
     overflow: hidden;
     -webkit-mask-image: -webkit-gradient(linear, left 70%, left 90%, from(rgba(0,0,0,1)), to(rgba(0,0,0,0)));
     mask-image: linear-gradient(to bottom, rgba(0,0,0,1) 70%, rgba(0,0,0,0) 90%);

--- a/frontend/src/Components/PostComponent.tsx
+++ b/frontend/src/Components/PostComponent.tsx
@@ -24,7 +24,7 @@ interface PostComponentProps {
     showSite?: boolean;
     buttons?: React.ReactNode;
     onChange?: (id: number, post: Partial<PostInfo>) => void;
-    autoCut?: boolean;
+    autoCut?: number;
     onEdit?: (post: PostInfo, text: string, title?: string) => Promise<PostInfo | undefined>;
     dangerousHtmlTitle?: boolean;
     hideRating?: boolean;
@@ -156,7 +156,9 @@ export default function PostComponent(props: PostComponentProps) {
                                         props.dangerousHtmlTitle ? <span dangerouslySetInnerHTML={{__html: title}} /> : title
                                     }</PostLink></div>}
                                     <div className={styles.content}>
-                                        <ContentComponent className={styles.content} content={content} autoCut={props.autoCut} lowRating={rating <= Conf.POST_LOW_RATING_THRESHOLD} />
+                                        <ContentComponent className={styles.content} content={content}
+                                                          autoCut={props.autoCut}
+                                                          lowRating={rating <= Conf.POST_LOW_RATING_THRESHOLD || props.post.vote === -1} />
                                     </div>
                                 </>
                         )

--- a/frontend/src/Components/UserProfilePosts.tsx
+++ b/frontend/src/Components/UserProfilePosts.tsx
@@ -6,6 +6,7 @@ import Paginator from '../Components/Paginator';
 import {useLocation, useSearchParams} from 'react-router-dom';
 import {useFeed} from '../API/use/useFeed';
 import {useDebouncedCallback} from 'use-debounce';
+import {LARGE_AUTO_CUT} from './ContentComponent';
 
 type UserProfilePostsProps = {
   username: string;
@@ -60,7 +61,8 @@ export default function UserProfilePosts(props: UserProfilePostsProps) {
                  <>
                     {error && <div className={styles.error}>{styles.error}</div> }
                     {posts && <div className={styles.posts}>
-                        {posts.map(post => <PostComponent key={post.id} post={post} showSite={true} onChange={updatePost} autoCut={true} />)}
+                        {posts.map(post => <PostComponent key={post.id} post={post} showSite={true} onChange={updatePost}
+                                                          autoCut={LARGE_AUTO_CUT} />)}
                     </div>}
                     <div className={styles.paginatorContainer}>
                       <Paginator page={page} pages={pages} base={`/u/${props.username}/posts`} queryStringParams={params} />

--- a/frontend/src/Pages/FeedPage.tsx
+++ b/frontend/src/Pages/FeedPage.tsx
@@ -9,6 +9,7 @@ import {APIError} from '../API/APIBase';
 import {FeedSorting} from '../Types/FeedSortingSettings';
 import classNames from 'classnames';
 import {observer} from 'mobx-react-lite';
+import {LARGE_AUTO_CUT, SMALL_AUTO_CUT} from '../Components/ContentComponent';
 
 const FeedPage = observer(() => {
     const { site, siteInfo } = useAppState();
@@ -86,7 +87,8 @@ const FeedPage = observer(() => {
                     (error[1] as APIError)?.code === 'no-site' ? <>Нет такого сайта. <Link to='/sites/create'>Создать</Link>?</> : error[0]
                 }</div> }
                 {posts && <div className={styles.posts}>
-                    {posts.map(post => <PostComponent key={post.id} post={post} showSite={siteInfo?.site !== post.site} onChange={updatePost} autoCut={true} />)}
+                    {posts.map(post => <PostComponent key={post.id} post={post} showSite={siteInfo?.site !== post.site} onChange={updatePost}
+                                                      autoCut={post.vote === -1 ? SMALL_AUTO_CUT : LARGE_AUTO_CUT} />)}
                 </div>}
 
                 <div className={styles.paginatorContainer}>

--- a/frontend/src/Pages/SearchPage.tsx
+++ b/frontend/src/Pages/SearchPage.tsx
@@ -10,6 +10,7 @@ import PostComponent from '../Components/PostComponent';
 import {UserGender} from '../Types/UserInfo';
 import classNames from 'classnames';
 import {useCache} from '../API/use/useCache';
+import {LARGE_AUTO_CUT} from '../Components/ContentComponent';
 
 type SearchForm = {
     term: string;
@@ -44,7 +45,7 @@ function SearchResult(props: {
                                    comments: 0,
                                    newComments: 0,
                                }}
-                               showSite={true} autoCut={true} dangerousHtmlTitle={true} hideRating={true}/> :
+                               showSite={true} autoCut={LARGE_AUTO_CUT} dangerousHtmlTitle={true} hideRating={true}/> :
                 <CommentComponent key={resultItem.comment_id}
                                   comment={{
                                       id: resultItem.comment_id,

--- a/frontend/src/Pages/WatchPage.tsx
+++ b/frontend/src/Pages/WatchPage.tsx
@@ -4,6 +4,7 @@ import PostComponent from '../Components/PostComponent';
 import Paginator from '../Components/Paginator';
 import {Link, useMatch, useSearchParams} from 'react-router-dom';
 import {useFeed} from '../API/use/useFeed';
+import {LARGE_AUTO_CUT, SMALL_AUTO_CUT} from '../Components/ContentComponent';
 
 export default function WatchPage() {
     let siteName = 'main';
@@ -38,7 +39,8 @@ export default function WatchPage() {
                 {error && <div className={styles.error}>{styles.error}</div> }
                 {posts && <div className={styles.posts}>
                     {posts.length === 0 && <div>Здесь ничего нет. Вероятно, вы уже всё прочитали!</div>}
-                    {posts.map(post => <PostComponent key={post.id} post={post} showSite={true} onChange={updatePost} autoCut={true} />)}
+                    {posts.map(post => <PostComponent key={post.id} post={post} showSite={true} onChange={updatePost}
+                                                      autoCut={post.vote === -1 ? SMALL_AUTO_CUT : LARGE_AUTO_CUT} />)}
                 </div>}
 
                 <Paginator page={page} pages={pages} base={isAll ? '/watch/all' : '/watch'} />

--- a/frontend/src/Services/ObserverService.ts
+++ b/frontend/src/Services/ObserverService.ts
@@ -2,9 +2,15 @@ type IntersectionCallback = (entry: IntersectionObserverEntry) => void;
 type ElementCallbacks = WeakMap<Element, Set<IntersectionCallback>>;
 
 const INTERSECTION_RATIO = .5;
-let intersectionObserver: IntersectionObserver;
-let onShown: ElementCallbacks;
-let onHidden: ElementCallbacks;
+const intersectionObserver: IntersectionObserver = new IntersectionObserver(
+    handleIntersections,
+    {
+        rootMargin: '0px',
+        threshold: 0.5,
+    },
+);
+const onShown: ElementCallbacks = new WeakMap();
+const onHidden: ElementCallbacks = new WeakMap();
 
 function handleIntersections(entries: IntersectionObserverEntry[]) {
     entries.forEach((entry) => {
@@ -29,18 +35,6 @@ function addEventListener(callbacks: ElementCallbacks, el: Element, cb: Intersec
 function removeEventListener(callbacks: ElementCallbacks, el: Element, cb: IntersectionCallback) {
     const cbs = callbacks.get(el);
     cbs && cbs.delete(cb);
-}
-
-export function createObserverService() {
-    onShown = new WeakMap();
-    onHidden = new WeakMap();
-    intersectionObserver = new IntersectionObserver(
-        handleIntersections,
-        {
-            rootMargin: '0px',
-            threshold: 0.5,
-        },
-    );
 }
 
 export function observeOnShown(el: Element, callback: IntersectionCallback) {


### PR DESCRIPTION
Changes:
* fix bug when autocut was not triggered
* when YOU downvote the content, it's automatically blurred and cut (same behaviour as when it has rating <= -3)
* posts that YOU downvoted in the feed are collapsed to 200px height (as an alternative for the ignore on the post level)
* fixed bug in recreation of the observer maps: https://github.com/spaceshelter/orbitar/blob/d665eb841670f32b064e7f1c0fda70405af62bb3/frontend/src/Services/ObserverService.ts#L35

Collapsed post in the feed:
<img width="458" alt="image" src="https://user-images.githubusercontent.com/2865203/230745356-b136c2fd-780c-45f2-9172-cb0e5be0351b.png">


Downvoted comment:
<img width="623" alt="image" src="https://user-images.githubusercontent.com/2865203/230745374-7ec01874-cefd-4123-99e8-7dcc833fd4b4.png">