### PR TITLE
Improve notifications behavior: clear read only, cosmetic changes

### DIFF
--- a/backend/src/api/types/requests/NotificationsReadAll.ts
+++ b/backend/src/api/types/requests/NotificationsReadAll.ts
@@ -1,4 +1,6 @@
 export type NotificationsReadAllRequest = Record<string, never>;
 export type NotificationsReadAllResponse = Record<string, never>;
-export type NotificationsHideAllRequest = Record<string, never>;
+export type NotificationsHideAllRequest = {
+    readOnly: boolean;
+};
 export type NotificationsHideAllResponse = Record<string, never>;

--- a/backend/src/db/repositories/NotificationsRepository.ts
+++ b/backend/src/db/repositories/NotificationsRepository.ts
@@ -70,8 +70,11 @@ export default class NotificationsRepository {
         });
     }
 
-    async setReadAndHideAll(forUserId: number) {
-        await this.db.query('update notifications set hidden=1, `read`=1 where user_id=:user_id', {
+    async setReadAndHideAll(forUserId: number, readOnly = false) {
+        await this.db.query(`
+            update notifications set hidden=1, \`read\`=1 where user_id=:user_id
+                ${readOnly ? 'and `read`=1' : ''}
+            `, {
             user_id: forUserId
         });
     }

--- a/backend/src/managers/NotificationManager.ts
+++ b/backend/src/managers/NotificationManager.ts
@@ -212,8 +212,8 @@ export default class NotificationManager {
         this.userCache.deleteUserStatsCache(forUserId);
     }
 
-    async setHiddenAll(forUserId: number) {
-        await this.notificationsRepository.setReadAndHideAll(forUserId);
+    async setHiddenAll(forUserId: number, readOnly: boolean) {
+        await this.notificationsRepository.setReadAndHideAll(forUserId, readOnly);
         this.userCache.deleteUserStatsCache(forUserId);
     }
 

--- a/frontend/src/API/NotificationsAPI.ts
+++ b/frontend/src/API/NotificationsAPI.ts
@@ -43,7 +43,9 @@ export type NotificationsHideRequest =  NotificationsReadRequest;
 export type NotificationsHideResponse = Record<string, never>;
 export type NotificationsReadAllRequest = Record<string, never>;
 export type NotificationsReadAllResponse = Record<string, never>;
-export type NotificationsHideAllRequest = Record<string, never>;
+export type NotificationsHideAllRequest = {
+    readOnly: boolean;
+};
 export type NotificationsHideAllResponse = Record<string, never>;
 
 export type WebPushSubscribeRequest = {
@@ -74,8 +76,9 @@ export default class NotificationsAPI {
         });
     }
 
-    hideAll(): Promise<NotificationsReadAllResponse> {
+    hideAll(readOnly: boolean): Promise<NotificationsReadAllResponse> {
         return this.api.request<NotificationsHideAllRequest, NotificationsHideAllResponse>('/notifications/hide/all', {
+            readOnly
         });
     }
 

--- a/frontend/src/API/NotificationsAPIHelper.ts
+++ b/frontend/src/API/NotificationsAPIHelper.ts
@@ -34,8 +34,8 @@ export default class NotificationsAPIHelper {
         return await this.api.readAll();
     }
 
-    async hideAll() {
-        return await this.api.hideAll();
+    async hideAll(readOnly = false) {
+        return await this.api.hideAll(readOnly);
     }
 
     async list(auth?: string): Promise<{ webPushRegistered: boolean, notifications: NotificationInfo[] }> {

--- a/frontend/src/Components/NotificationsPopup.tsx
+++ b/frontend/src/Components/NotificationsPopup.tsx
@@ -169,7 +169,7 @@ export default function NotificationsPopup(props: NotificationsPopupProps) {
                     })}
                 </div>
                 <div className={styles.buttons}>
-                    <button className={styles.buttonClear} onClick={handleClearAll}>Очистить прочтенные</button>
+                    <button className={styles.buttonClear} onClick={handleClearAll}>Очистить прочитанные</button>
                     <button className={styles.buttonRead} onClick={handleReadAll}>Прочитать все</button>
                     {/*TODO <button className={styles.buttonAll} disabled={true}>Все чпяки</button>*/}
                 </div>

--- a/frontend/src/Components/NotificationsPopup.tsx
+++ b/frontend/src/Components/NotificationsPopup.tsx
@@ -1,4 +1,5 @@
 import styles from './NotificationsPopup.module.scss';
+import feedStyles from '../Pages/FeedPage.module.scss';
 import {ReactComponent as CommentIcon} from '../Assets/notifications/comment.svg';
 import {ReactComponent as MentionIcon} from '../Assets/notifications/mention.svg';
 import {ReactComponent as CloseIcon} from '../Assets/close.svg';
@@ -107,18 +108,33 @@ export default function NotificationsPopup(props: NotificationsPopupProps) {
     };
 
     const handleClearAll = () => {
-        app.setVisibleNotificationsCount(0);
-        app.setUnreadNotificationsCount(0);
-        api.notifications.hideAll()
+        const filteredNotifications = notifications?.filter(n => !n.read);
+
+        // Update the state with the filtered notifications
+        setNotifications(filteredNotifications);
+
+        const remainingCount = filteredNotifications?.length || 0;
+        app.setVisibleNotificationsCount(remainingCount);
+        app.setUnreadNotificationsCount(remainingCount);
+
+        api.notifications.hideAll(true)
             .then()
             .catch(() => toast.error('Не удалось скрыть уведомления'));
-        if (props.onClose) {
+
+        if (remainingCount === 0 && props.onClose) {
             props.onClose();
         }
     };
 
     const handleReadAll = () => {
         app.setUnreadNotificationsCount(0);
+
+        const readNotifications = notifications?.map(n => {
+            n.read = true;
+            return n;
+        });
+        setNotifications(readNotifications);
+
         api.notifications.readAll()
             .then()
             .catch(() => toast.error('Не удалось пометить уведомления как прочитанные'));
@@ -127,6 +143,7 @@ export default function NotificationsPopup(props: NotificationsPopupProps) {
     const a = (n: NotificationInfo) => n.source.byUser.gender === UserGender.she ? 'а' : '';
 
     return (
+        !notifications && <div className={feedStyles.loading}/> ||
         <>
             <div className={styles.overlay} onClick={props.onClose}/>
             <div className={styles.container}>
@@ -152,7 +169,7 @@ export default function NotificationsPopup(props: NotificationsPopupProps) {
                     })}
                 </div>
                 <div className={styles.buttons}>
-                    <button className={styles.buttonClear} onClick={handleClearAll}>Очистить</button>
+                    <button className={styles.buttonClear} onClick={handleClearAll}>Очистить прочтенные</button>
                     <button className={styles.buttonRead} onClick={handleReadAll}>Прочитать все</button>
                     {/*TODO <button className={styles.buttonAll} disabled={true}>Все чпяки</button>*/}
                 </div>


### PR DESCRIPTION
Changes:
* show loading bar when opening notifications popup
* change the "clear all" button to "clear all read"
* don't close the popup when not all notifications are cleared
* reflect the changes after the button press in the list

![notif](https://user-images.githubusercontent.com/2865203/230750939-a1a7b751-edba-4b81-8c07-7e6b8224a507.gif)

![notif2](https://user-images.githubusercontent.com/2865203/230750944-93fad6de-4b60-49c6-af3f-37c989653b9a.gif)

