### PR TITLE
Fix error when first time subscribing to a subsite

### DIFF
--- a/backend/src/api/SiteController.ts
+++ b/backend/src/api/SiteController.ts
@@ -107,6 +107,7 @@ export default class SiteController {
         }
         catch (error) {
             this.logger.error('Could not change subscription', { site, main, bookmarks, error });
+            this.logger.error(error);
             return response.error('error', 'Unknown error', 500);
         }
     }

--- a/backend/src/managers/FeedManager.ts
+++ b/backend/src/managers/FeedManager.ts
@@ -328,7 +328,7 @@ export default class FeedManager {
 
         await this.siteManager.siteSubscribe(userId, site.id, main, bookmarks);
 
-        if ((!!existingSubscription.feed_main) !== main) {
+        if ((!!existingSubscription?.feed_main) !== main) {
             this.logger.info(`Clearing feed cache for user ${userId} after subscribing to ${siteName}`);
             this.userSubscriptionsCache.delete(userId);
         }


### PR DESCRIPTION
A trivial bug with 'undefined' access, when previous subscription record does not exist.