### PR TITLE
Fix nav shift

### DIFF
--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -10,10 +10,10 @@ html,body {
   -moz-osx-font-smoothing: grayscale;
   background: var(--bg);
   color: var(--fg);
-  overflow-y: scroll;
 }
 #root {
   height: 100%;
+  overflow-y: scroll;
 }
 
 input[type="text"], input[type="password"], input[type="email"], input[type="search"], textarea {


### PR DESCRIPTION
Fix navigation shift after applying `overflow-y: scroll` to `body`

Before:
<img width="226" alt="Screenshot 2023-04-11 at 00 59 50" src="https://user-images.githubusercontent.com/3425688/231010687-0fb3986f-d9a4-4849-9db1-8ef602bc6984.png">

After:
<img width="258" alt="Screenshot 2023-04-11 at 00 59 35" src="https://user-images.githubusercontent.com/3425688/231010675-3a607532-1673-4d34-bc6c-eac5ea42644f.png">
