### PR TITLE
fix bug when scrollTo top wont working with overflow-y: scroll

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -100,7 +100,7 @@ const ReadyContainer = observer(() => {
                 menuState={menuState}
                 onMenuToggle={handleMenuToggle}
             />
-            <div className={styles.container}>
+            <div id="app" className={styles.container}>
                 <div className={styles.innerContainer}>
                     <Outlet />
                 </div>

--- a/frontend/src/Components/UserProfileComments.tsx
+++ b/frontend/src/Components/UserProfileComments.tsx
@@ -83,7 +83,8 @@ export default function UserProfileComments(props: UserProfileCommentsProps) {
     }, [page, reloadIdx, filter]);
 
     useEffect(() => {
-        window.scrollTo({ top: 0 });
+        const element = document.querySelector('#app');
+        element && element.scrollIntoView({block: 'start'});
     }, [page]);
 
     const params = filter ? {filter} : undefined;

--- a/frontend/src/Components/UserProfilePosts.tsx
+++ b/frontend/src/Components/UserProfilePosts.tsx
@@ -47,7 +47,8 @@ export default function UserProfilePosts(props: UserProfilePostsProps) {
 
   const { posts, loading, pages, error, updatePost } = useFeed(props.username, 'user-profile', page, perpage, undefined, undefined, filter || '');
     useEffect(() => {
-        window.scrollTo({ top: 0 });
+        const element = document.querySelector('#app');
+        element && element.scrollIntoView({block: 'start'});
     }, [page]);
 
     const params = filter ? {filter} : undefined;

--- a/frontend/src/Components/UserProfileSettings.tsx
+++ b/frontend/src/Components/UserProfileSettings.tsx
@@ -21,7 +21,8 @@ type UserProfileSettingsProps = {
 
 export default function UserProfileSettings(props: UserProfileSettingsProps) {
   useEffect(() => {
-    window.scrollTo({ top: 0 });
+      const element = document.querySelector('#app');
+      element && element.scrollIntoView({block: 'start'});
   }, []);
 
   const api = useAPI();

--- a/frontend/src/Pages/FeedPage.tsx
+++ b/frontend/src/Pages/FeedPage.tsx
@@ -46,7 +46,8 @@ const FeedPage = observer(() => {
     const {posts, loading, pages, error, updatePost, setLoading} = useFeed(site, feedType, page, perpage, setSorting, sorting);
 
     useEffect(() => {
-        window.scrollTo({ top: 0 });
+        const element = document.querySelector('#app');
+        element && element.scrollIntoView({block: 'start'});
     }, [page]);
 
     useEffect(() => {

--- a/frontend/src/Pages/WatchPage.tsx
+++ b/frontend/src/Pages/WatchPage.tsx
@@ -24,7 +24,8 @@ export default function WatchPage() {
 
     const { posts, loading, pages, error, updatePost } = useFeed(siteName, isAll ? 'watch-all' : 'watch', page, perpage);
     useEffect(() => {
-        window.scrollTo({ top: 0 });
+        const element = document.querySelector('#app');
+        element && element.scrollIntoView({block: 'start'});
     }, [page]);
 
     document.title = 'Новые комментарии';


### PR DESCRIPTION
Fixed behavior when changing the page (profile comments for example) prevents scrolling the page to the top
Now we will scroll to the `#app` element