### PR TITLE
Fix rating popup position behaviour

### DIFF
--- a/frontend/src/Components/CommentComponent.module.scss
+++ b/frontend/src/Components/CommentComponent.module.scss
@@ -139,7 +139,7 @@ $smallShift: 8px;
         border-left: none;
     }
 
-    .unreadOnly :local(.comment):not(.isNew) > .commentBody {
+    .unreadOnly :local(.comment):not(.isNew) > .commentBody:not(:has(.ratingPopup)) {
         opacity: 0.4;
         transition: opacity 500ms;
     }

--- a/frontend/src/Components/RatingSwitch.module.scss
+++ b/frontend/src/Components/RatingSwitch.module.scss
@@ -130,3 +130,7 @@ a.username {
 .listMinus {
     border-right: 1px solid var(--bg);
 }
+
+.ratingWrapper {
+    position: relative;
+}

--- a/frontend/src/Components/RatingSwitch.tsx
+++ b/frontend/src/Components/RatingSwitch.tsx
@@ -225,7 +225,7 @@ const RatingList = React.forwardRef((props: RatingListProps, ref: ForwardedRef<H
     }
 
     return (
-        <div ref={ref} className={styles.list} onMouseDown={popupMouseDownHandler}>
+        <div ref={ref} className={` ${styles.list} ratingPopup`} onMouseDown={popupMouseDownHandler}>
             <div className={styles.listUp}>
                 <div className={listStyles.join(' ')}>{props.rating}</div>
                 <div className={styles.listDetails}>

--- a/frontend/src/Components/RatingSwitch.tsx
+++ b/frontend/src/Components/RatingSwitch.tsx
@@ -36,7 +36,6 @@ export default function RatingSwitch(props: RatingSwitchProps) {
         if (!ratingRef.current || !popupRef.current) {
             return;
         }
-        const [popupEl, ratingEl] = [popupRef.current, ratingRef.current];
         if (!showPopup) {
             return;
         }
@@ -52,27 +51,17 @@ export default function RatingSwitch(props: RatingSwitchProps) {
                 });
         }
 
+        const [popupEl, ratingEl] = [popupRef.current, ratingRef.current];
+
         const rect = ratingEl.getBoundingClientRect();
-        const x = rect.x;
         const y = rect.y + document.documentElement.scrollTop || 0;
-        const [w, h] = [ratingEl.clientWidth, ratingEl.clientHeight];
-        const [pw, ph] = [popupEl.clientWidth, popupEl.clientHeight];
+        const rh = ratingEl.clientHeight;
+        const ph = popupEl.clientHeight;
 
-        let ny = y + h + 8;
-        if (ny + ph > document.documentElement.scrollHeight) {
-            ny = y - 8 - ph;
-        }
-        let nx = x;
-        if (nx + 8 + pw > document.documentElement.scrollWidth) {
-            if (x+w+8>pw) {
-                nx = x + w - pw;
-            } else {
-                nx = 8;
-            }
-        }
-
-        popupEl.style.left = (nx) + 'px';
-        popupEl.style.top = (ny) + 'px';
+        const isTotalHeightMoreThanPageHeight  = y + rh + ph > document.documentElement.scrollHeight;
+        isTotalHeightMoreThanPageHeight
+            ? popupEl.style.bottom = 30 + 'px'
+            : popupEl.style.top = 30 + 'px';
 
         const clickHandler = (e: MouseEvent) => {
             e.stopPropagation();
@@ -164,7 +153,7 @@ export default function RatingSwitch(props: RatingSwitchProps) {
     };
 
     return (
-        <>
+        <div className={styles.ratingWrapper}>
             <div ref={ratingRef} className={styles.rating}>
                 {props.double && <button {...buttonExtraProps} className={minus2Styles.join(' ')} onClick={handleVote(-2)}></button>}
                 <button {...buttonExtraProps} className={minusStyles.join(' ')} onClick={handleVote(-1)}></button>
@@ -173,7 +162,7 @@ export default function RatingSwitch(props: RatingSwitchProps) {
                 {props.double && <button {...buttonExtraProps} className={plus2Styles.join(' ')} onClick={handleVote(2)}></button>}
             </div>
             {showPopup && <RatingList ref={popupRef} vote={state.vote || 0} rating={state.rating} votes={votes} hidePopup={hide}></RatingList>}
-        </>
+        </div>
     );
 }
 

--- a/frontend/src/Components/RatingSwitch.tsx
+++ b/frontend/src/Components/RatingSwitch.tsx
@@ -59,9 +59,11 @@ export default function RatingSwitch(props: RatingSwitchProps) {
         const ph = popupEl.clientHeight;
 
         const isTotalHeightMoreThanPageHeight  = y + rh + ph > document.documentElement.scrollHeight;
-        isTotalHeightMoreThanPageHeight
-            ? popupEl.style.bottom = 30 + 'px'
-            : popupEl.style.top = 30 + 'px';
+        if(isTotalHeightMoreThanPageHeight){
+            popupEl.style.bottom = '30px';
+        } else {
+            popupEl.style.top = '30px';
+        }
 
         const clickHandler = (e: MouseEvent) => {
             e.stopPropagation();


### PR DESCRIPTION
Instead of positioning the popup relative to the page, we position it relative to the rating block

Fixed:
1. bug when popup stays still on scrolling page
2. bug when popup moves on page resize (old bug)
3. bug when popup moves and renders incorrectly on changing the page font size (old bug)

Before:
[popup_before.webm](https://user-images.githubusercontent.com/3425688/231578629-59abe6f8-c81f-4a51-aab1-e18f38eff9f1.webm)


After:
[popup_after.webm](https://user-images.githubusercontent.com/3425688/231578655-42bf945c-7085-46b9-9d05-df2c87447c85.webm)
