### PR TITLE
Revert latest scroll changes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -100,7 +100,7 @@ const ReadyContainer = observer(() => {
                 menuState={menuState}
                 onMenuToggle={handleMenuToggle}
             />
-            <div id="app" className={styles.container}>
+            <div className={styles.container}>
                 <div className={styles.innerContainer}>
                     <Outlet />
                 </div>

--- a/frontend/src/Components/UserProfileComments.tsx
+++ b/frontend/src/Components/UserProfileComments.tsx
@@ -83,8 +83,7 @@ export default function UserProfileComments(props: UserProfileCommentsProps) {
     }, [page, reloadIdx, filter]);
 
     useEffect(() => {
-        const element = document.querySelector('#app');
-        element && element.scrollIntoView({block: 'start'});
+        window.scrollTo({ top: 0 });
     }, [page]);
 
     const params = filter ? {filter} : undefined;

--- a/frontend/src/Components/UserProfilePosts.tsx
+++ b/frontend/src/Components/UserProfilePosts.tsx
@@ -47,8 +47,7 @@ export default function UserProfilePosts(props: UserProfilePostsProps) {
 
   const { posts, loading, pages, error, updatePost } = useFeed(props.username, 'user-profile', page, perpage, undefined, undefined, filter || '');
     useEffect(() => {
-        const element = document.querySelector('#app');
-        element && element.scrollIntoView({block: 'start'});
+        window.scrollTo({ top: 0 });
     }, [page]);
 
     const params = filter ? {filter} : undefined;

--- a/frontend/src/Components/UserProfileSettings.tsx
+++ b/frontend/src/Components/UserProfileSettings.tsx
@@ -21,8 +21,7 @@ type UserProfileSettingsProps = {
 
 export default function UserProfileSettings(props: UserProfileSettingsProps) {
   useEffect(() => {
-      const element = document.querySelector('#app');
-      element && element.scrollIntoView({block: 'start'});
+    window.scrollTo({ top: 0 });
   }, []);
 
   const api = useAPI();

--- a/frontend/src/Pages/FeedPage.tsx
+++ b/frontend/src/Pages/FeedPage.tsx
@@ -46,8 +46,7 @@ const FeedPage = observer(() => {
     const {posts, loading, pages, error, updatePost, setLoading} = useFeed(site, feedType, page, perpage, setSorting, sorting);
 
     useEffect(() => {
-        const element = document.querySelector('#app');
-        element && element.scrollIntoView({block: 'start'});
+        window.scrollTo({ top: 0 });
     }, [page]);
 
     useEffect(() => {

--- a/frontend/src/Pages/WatchPage.tsx
+++ b/frontend/src/Pages/WatchPage.tsx
@@ -24,8 +24,7 @@ export default function WatchPage() {
 
     const { posts, loading, pages, error, updatePost } = useFeed(siteName, isAll ? 'watch-all' : 'watch', page, perpage);
     useEffect(() => {
-        const element = document.querySelector('#app');
-        element && element.scrollIntoView({block: 'start'});
+        window.scrollTo({ top: 0 });
     }, [page]);
 
     document.title = 'Новые комментарии';

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -10,10 +10,10 @@ html,body {
   -moz-osx-font-smoothing: grayscale;
   background: var(--bg);
   color: var(--fg);
+  overflow-y: scroll;
 }
 #root {
   height: 100%;
-  overflow-y: scroll;
 }
 
 input[type="text"], input[type="password"], input[type="email"], input[type="search"], textarea {

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -2,6 +2,10 @@
 
 // TODO add css reset
 
+html {
+  overflow-y: scroll;
+}
+
 html,body {
   height: 100%;
   margin: 0;
@@ -10,7 +14,6 @@ html,body {
   -moz-osx-font-smoothing: grayscale;
   background: var(--bg);
   color: var(--fg);
-  overflow-y: scroll;
 }
 #root {
   height: 100%;


### PR DESCRIPTION
Basically, this PR:
* reverts #303 and #304 
* slightly changes #296  (sets `overflow-y: scroll;` to `html` only)

Basically, this is a compromise. The slight gap in the Topbar (mentioned in #303) will be present, but layout shift are gone.

Most importantly, this fixes three regressions:
* scroll position when using "back" navigation
* Home/End gestures/hotkeys
* Scrollbar style

