### PR TITLE
Linux dev workaround

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,6 +16,8 @@ services:
       - caddy_config:/config
     # Default caddy command borrowed from https://github.com/caddyserver/caddy-docker/blob/master/Dockerfile.tmpl
     command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile", "--watch"]
+    extra_hosts:
+        - "host.docker.internal:host-gateway"
 
   mysql:
     platform: linux/amd64

--- a/docker-compose.ssl.dev.yml
+++ b/docker-compose.ssl.dev.yml
@@ -17,6 +17,8 @@ services:
       - caddy_config:/config
     # Default caddy command borrowed from https://github.com/caddyserver/caddy-docker/blob/master/Dockerfile.tmpl
     command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile", "--watch"]
+    extra_hosts:
+        - "host.docker.internal:host-gateway"
 
   mysql:
     platform: linux/amd64


### PR DESCRIPTION
When developing on Linux, Docker does not automatically redirect host ports to the containers, and thus caddy can't connect to backend that is running locally.

Here's the workaround that fixes it.
https://stackoverflow.com/questions/31324981/how-to-access-host-port-from-docker-container/61424570#61424570

This PR implements it.

Tested on MacOS and Asahi Linux aarch64, the problem exists on Linux, does not exist on MacOS, mitigated by this patch on Linux, does not affect MacOS.