### PR TITLE
Fix rating popup transparency in FF

### DIFF
--- a/frontend/src/Components/CommentComponent.module.scss
+++ b/frontend/src/Components/CommentComponent.module.scss
@@ -139,11 +139,16 @@ $smallShift: 8px;
         border-left: none;
     }
 
-    .unreadOnly :local(.comment):not(.isNew) > .commentBody:not(:has(.ratingPopup)) {
+    .unreadOnly :local(.comment):not(.isNew) > .commentBody > :not(:last-child),
+    .unreadOnly :local(.comment):not(.isNew) > .commentBody > :last-child > :not(:first-child),
+    .unreadOnly :local(.comment):not(.isNew) > .commentBody > :last-child > :first-child > * > :first-child {
         opacity: 0.4;
         transition: opacity 500ms;
     }
-    .unreadOnly :local(.comment):not(.isNew) > .commentBody:hover {
+
+    .unreadOnly :local(.comment):not(.isNew) > .commentBody:hover > :not(:last-child),
+    .unreadOnly :local(.comment):not(.isNew) > .commentBody:hover > :last-child > :not(:first-child),
+    .unreadOnly :local(.comment):not(.isNew) > .commentBody:hover > :last-child > :first-child > * > :first-child {
         opacity: inherit;
         transition: opacity 500ms;
     }

--- a/frontend/src/Components/RatingSwitch.tsx
+++ b/frontend/src/Components/RatingSwitch.tsx
@@ -227,7 +227,7 @@ const RatingList = React.forwardRef((props: RatingListProps, ref: ForwardedRef<H
     }
 
     return (
-        <div ref={ref} className={` ${styles.list} ratingPopup`} onMouseDown={popupMouseDownHandler}>
+        <div ref={ref} className={styles.list} onMouseDown={popupMouseDownHandler}>
             <div className={styles.listUp}>
                 <div className={listStyles.join(' ')}>{props.rating}</div>
                 <div className={styles.listDetails}>


### PR DESCRIPTION
Unfortunately, the modern Firefox browser does not provide full support for `:has` pseudo-class.
The solution is to replace `:has` whit 3 ugly long selectors.