### PR TITLE
Catch exceptions when storing cache to localStorage 

### DIFF
--- a/frontend/src/API/use/useCache.ts
+++ b/frontend/src/API/use/useCache.ts
@@ -54,7 +54,11 @@ function setCachedValue<T>(name: string, deps: unknown[], value: T) {
         }
     }
 
-    localStorage.setItem('cache:'+name, JSON.stringify(cached));
+    try {
+        localStorage.setItem('cache:' + name, JSON.stringify(cached));
+    } catch (e) {
+        console.error('Error while saving cache', e);
+    }
 }
 
 export function useCache<T>(name: string, deps: unknown[]): [T | undefined, ((value: T) => void)] {


### PR DESCRIPTION
Should help with `quota exceeded` exception some users are facing:
![image](https://user-images.githubusercontent.com/2865203/232625800-f42a915c-8f5b-4dd7-9640-e8c342df51fe.png)
