### PR TITLE
Tighten restrictions for "exiled" users: allow to see only their own content

### DIFF
--- a/backend/src/api/PostController.ts
+++ b/backend/src/api/PostController.ts
@@ -166,6 +166,9 @@ export default class PostController {
             }
 
             const restrictions = await this.userManager.getUserRestrictions(userId);
+            if (restrictions.restrictedToPostId !== false && rawPost.author !== userId) {
+                return response.error('access-denied', 'You don\'t have permission to view this post', 403);
+            }
 
             const {posts: [post], users} = await this.enricher.enrichRawPosts([rawPost]);
             if (!restrictions.canEditOwnContent) {
@@ -213,6 +216,11 @@ export default class PostController {
         const { id, title, format, content } = request.body;
 
         try {
+            const restrictions = await this.userManager.getUserRestrictions(userId);
+            if (!restrictions.canEditOwnContent) {
+                return response.error('access-denied', 'Access-denied', 403);
+            }
+
             const postInfo = await this.postManager.editPost(userId, id, title, content, format);
             if (!postInfo) {
                 return response.error('no-comment', 'Post not found');
@@ -400,6 +408,12 @@ export default class PostController {
                 return response.error('no-comment', 'Comment not found');
             }
 
+            const restrictions = await this.userManager.getUserRestrictions(userId);
+            if (restrictions.restrictedToPostId && restrictions.restrictedToPostId !== commentInfo.post) {
+                // simplification, but currently getComment is used only for editing, so it's ok
+                return response.error('access-denied', `Commenting restricted to post #${restrictions.restrictedToPostId}`, 403);
+            }
+
             const {allComments: [comment], users} = await this.enricher.enrichRawComments([commentInfo], {}, format,
                 () => false
             );
@@ -478,6 +492,11 @@ export default class PostController {
         const { id, type, format } = request.body;
 
         try {
+            const restrictions = await this.userManager.getUserRestrictions(userId);
+            if (restrictions.restrictedToPostId !== false) {
+                return response.error('access-denied', 'Access-denied', 403);
+            }
+
             const historyInfos = await this.postManager.getHistory(userId, id, type, format);
 
             const history: HistoryEntity[] = historyInfos.map(h => ({

--- a/backend/src/api/PostController.ts
+++ b/backend/src/api/PostController.ts
@@ -476,6 +476,12 @@ export default class PostController {
         }
         const {id, type} = request.body;
         try {
+            const restrictions = await this.userManager.getUserRestrictions(request.session.data.userId);
+            if (restrictions.restrictedToPostId !== false) {
+                // simplification, just disallows the translation
+                return response.error('access-denied', `Translation is not allowed.`, 403);
+            }
+
             return response.success(await this.translationManager.translateEntity(id, type));
         } catch (err) {
             this.logger.error(err);

--- a/backend/src/api/SearchController.ts
+++ b/backend/src/api/SearchController.ts
@@ -111,6 +111,11 @@ export default class SearchController {
             search_direction
         } = request.body;
         try {
+            const restrictions = await this.userManager.getUserRestrictions(userId);
+            if (restrictions.restrictedToPostId !== false) {
+                return response.error('error', 'User is restricted', 403);
+            }
+
             const result = await this.searchManager.search(
                 term,
                 scope,

--- a/backend/src/api/UserController.ts
+++ b/backend/src/api/UserController.ts
@@ -112,7 +112,7 @@ export default class UserController {
             }
 
             if (await this.userIsRestrictedToOwnContent(userId, profileInfo.id)) {
-                return response.error(ERROR_CODES.NOT_FOUND, 'User not found', 404);
+                return response.error(ERROR_CODES.NO_PERMISSION, 'No permissions to view this profile', 403);
             }
 
             const invites = await this.userManager.getInvites(profileInfo.id);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -111,7 +111,7 @@ const userManager = new UserManager(credentialsRepository, userRepository, voteR
     userCache, theParser, notificationManager, redis.client, config.site, logger.child({ service: 'USER' }));
 const inviteManager = new InviteManager(inviteRepository, theParser, userManager);
 const siteManager = new SiteManager(siteRepository, userManager);
-const feedManager = new FeedManager(bookmarkRepository, postRepository, userRepository, siteManager, theParser, logger.child({ service: 'FEED' }));
+const feedManager = new FeedManager(bookmarkRepository, postRepository, userManager, siteManager, theParser, logger.child({ service: 'FEED' }));
 const translationManager = new TranslationManager(translationRepository, postRepository, theParser, logger.child({ service: 'TRANSL' }));
 const postManager = new PostManager(bookmarkRepository, commentRepository, postRepository, feedManager, notificationManager, siteManager, userManager, translationManager, theParser);
 const voteManager = new VoteManager(voteRepository, postManager, userManager, redis.client);

--- a/backend/src/db/repositories/UserRepository.ts
+++ b/backend/src/db/repositories/UserRepository.ts
@@ -154,7 +154,7 @@ export default class UserRepository {
         return await this.db.fetchAll<{ user_id: number }>('select user_id from user_sites where site_id=:site_id and feed_main=1', { site_id: siteId });
     }
 
-    async getUserUnreadComments(forUserId: number): Promise<number> {
+    async getUserUnreadComments(forUserId: number, ownOnly = false): Promise<number> {
         const res = await this.db.fetchOne<{ cnt: string }>(`
           select sum(p.comments - ub.read_comments) cnt
             from
@@ -163,6 +163,7 @@ export default class UserRepository {
             where
               ub.user_id = :user_id
               and watch = 1
+              ${ownOnly ? 'and p.author_id = :user_id' : ''}
         `, {
             user_id: forUserId
         });

--- a/backend/src/managers/PostManager.ts
+++ b/backend/src/managers/PostManager.ts
@@ -62,7 +62,7 @@ export default class PostManager {
         return this.postRepository.getPost(postId);
     }
 
-    async getPostsByUserTotal(userId: number, filter: string): Promise<number> {
+    async getPostsByUserTotal(userId: number, filter = ''): Promise<number> {
         if (!this.numberOfPostsCache[userId]) {
             this.numberOfPostsCache[userId] = new ContentNumberCache();
         }

--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -137,7 +137,9 @@ export default class UserManager {
             return cached;
         }
 
-        const unreadComments = await this.userRepository.getUserUnreadComments(forUserId);
+        const restrictions = await this.getUserRestrictions(forUserId);
+        const unreadComments = await this.userRepository.getUserUnreadComments(forUserId,
+            restrictions.restrictedToPostId !== false);
         const notifications = await this.notificationManager.getNotificationsCounts(forUserId);
 
         const stats = {


### PR DESCRIPTION
Now when user loses all permissions, their access to the content is limited only by their own posts:
* Can still see the list of subsites
* All feeds (including feeds by subsite) show only user's posts (every feed is the same)
* Feed sorting still works
* "Fire" works, but is limited to user's own posts
* Cannot see other people's profiles
* Doesn't have access to other people's posts, even by direct links