### PR TITLE
Make mp4 video stream links direct

### DIFF
--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -383,8 +383,10 @@ export default class TheParser {
         const orbitarMediaPoster = () => {
             if (url.startsWith(this.mediaHostingConfig.url)) {
                 const match = url.match(/.*\/([^.]+\.mp4)(\/raw)?$/);
+                // add origin subdomain to `mediaHostingConfig.url`
+                const origin = this.mediaHostingConfig.url.replace(/^https?:\/\//, 'https://origin.');
                 return match && [`${this.mediaHostingConfig.url}/preview/${encodeURI(match[1])}`,
-                    `${this.mediaHostingConfig.url}/${encodeURI(match[1])}/raw`];
+                    `${origin}/${encodeURI(match[1])}/raw`];
             }
         };
         const dumpVideoPoster = () => {

--- a/backend/test/parser/TheParser.test.ts
+++ b/backend/test/parser/TheParser.test.ts
@@ -84,6 +84,12 @@ test('raw orbitar video embed', () => {
     );
 });
 
+test('origin orbitar video embed', () => {
+    expect(p.parse('https://origin.orbitar.media/8feuw2.mp4/raw').text).toEqual(
+        `<a class="video-embed" href="https://orbitar.media/8feuw2.mp4/raw" target="_blank"><img src="https://orbitar.media/preview/8feuw2.mp4" alt="" data-video="https://origin.orbitar.media/8feuw2.mp4/raw"/></a>`
+    );
+});
+
 test('mp4 video element', () => {
     expect(p.parse('<video src="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4">').text).toEqual(
         `<video  preload="metadata" controls="" width="500"><source src="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4" type="video/mp4"></video>`

--- a/backend/test/parser/TheParser.test.ts
+++ b/backend/test/parser/TheParser.test.ts
@@ -74,13 +74,13 @@ test('idiod video embed', () => {
 
 test('orbitar video embed', () => {
     expect(p.parse('https://orbitar.media/8feuw2.mp4').text).toEqual(
-        `<a class="video-embed" href="https://orbitar.media/8feuw2.mp4" target="_blank"><img src="https://orbitar.media/preview/8feuw2.mp4" alt="" data-video="https://orbitar.media/8feuw2.mp4/raw"/></a>`
+        `<a class="video-embed" href="https://orbitar.media/8feuw2.mp4" target="_blank"><img src="https://orbitar.media/preview/8feuw2.mp4" alt="" data-video="https://origin.orbitar.media/8feuw2.mp4/raw"/></a>`
     );
 });
 
 test('raw orbitar video embed', () => {
     expect(p.parse('https://orbitar.media/8feuw2.mp4/raw').text).toEqual(
-        `<a class="video-embed" href="https://orbitar.media/8feuw2.mp4/raw" target="_blank"><img src="https://orbitar.media/preview/8feuw2.mp4" alt="" data-video="https://orbitar.media/8feuw2.mp4/raw"/></a>`
+        `<a class="video-embed" href="https://orbitar.media/8feuw2.mp4/raw" target="_blank"><img src="https://orbitar.media/preview/8feuw2.mp4" alt="" data-video="https://origin.orbitar.media/8feuw2.mp4/raw"/></a>`
     );
 });
 


### PR DESCRIPTION
Bypass CDN for video player streams to save on traffic.

Basically just adds `origin.` prefix to media hosting video urls. 

Images and and video previews remain unchanged.