### PR TITLE
misc: Expand user bio field to fit in fancier HTML bio's

### DIFF
--- a/backend/src/api/UserController.ts
+++ b/backend/src/api/UserController.ts
@@ -62,7 +62,7 @@ export default class UserController {
         });
 
         const bioSchema = Joi.object<UserSaveBioRequest>({
-            bio: Joi.string().required().max(1024)
+            bio: Joi.string().required().max(1024 * 4)
         });
 
         const genderSchema = Joi.object<UserSaveGenderRequest>({


### PR DESCRIPTION
Motivation – myself and some friends of mine struggled with fancier bio formatting, including links and stuff, to be saved because of this limit. I checked the DB schema, and it appears to be fine as its `TEXT` type with no size constraint.