### PR TITLE
Purge cloudflare cache

### DIFF
--- a/.github/workflows/deploy-universal.yml
+++ b/.github/workflows/deploy-universal.yml
@@ -182,3 +182,17 @@ jobs:
       - name: Deploy
         working-directory: /orbitar
         run: docker-compose -f docker-compose.ssl.local.yml up -d
+
+      - name: Purge Cloudflare Cache
+        env:
+            CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
+            CLOUDFLARE_BEARER_TOKEN: ${{ secrets.CLOUDFLARE_BEARER_TOKEN }}
+        if: env.CLOUDFLARE_ZONE != '' && env.CLOUDFLARE_BEARER_TOKEN != ''
+        run: |
+          curl --request POST \
+            --url https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE }}/purge_cache \
+            --header 'Content-Type: application/json' \
+            --header 'Authorization: Bearer ${{ secrets.CLOUDFLARE_BEARER_TOKEN }}' \
+            --data '{
+            "purge_everything": true
+          }'


### PR DESCRIPTION
Takes secrets from the environment. Skips step if secrets are not available.

Tested during staging deploy:
https://github.com/spaceshelter/orbitar/actions/runs/5095398411/jobs/9160299195

(I temporarily added secrets to Staging env, now they are removed)

```
Run curl --request POST \
  curl --request POST \
    --url https://api.cloudflare.com/client/v4/zones/***/purge_cache \
    --header 'Content-Type: application/json' \
    --header 'Authorization: ***' \
    --data '{
    "purge_everything": true
  }'
  shell: /usr/bin/bash -e {0}
  env:
    CLOUDFLARE_ZONE: ***
    CLOUDFLARE_BEARER_TOKEN: ***
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
{
  "result": {
    "id": "***"
  },
  "success": true,
  "errors": [],
  "messages": []
}
```