### PR TITLE
Add updating post to fetch new comments when attempting to scroll...

### DIFF
--- a/frontend/src/API/use/usePost.ts
+++ b/frontend/src/API/use/usePost.ts
@@ -17,7 +17,7 @@ type UsePost = {
     editPost(title: string, content: string): Promise<PostInfo>;
     setVote(value: number): void;
     setCommentVote(commentId: number, vote: number): void;
-    reload(showUnreadOnly?: boolean): void;
+    reload(showUnreadOnly?: boolean): Promise<void>;
     updatePost(partial: Partial<PostInfo>): void;
 };
 
@@ -150,7 +150,7 @@ export function usePost(siteName: string, postId: number, showUnreadOnly?: boole
             // reset error
             setError(undefined);
             // request post
-            api.post.get(postId)
+            return api.post.get(postId)
                 .then(result => {
                     setPost(result.post);
                     setSite(result.site);

--- a/frontend/src/Pages/PostPage.tsx
+++ b/frontend/src/Pages/PostPage.tsx
@@ -20,6 +20,10 @@ export default function PostPage() {
     const unreadOnly = search.get('new') !== null;
     const {post, comments, anonymousUser, postComment, editComment, editPost, error, reload, updatePost} = usePost(site, postId, unreadOnly);
 
+    // indicates that scrollToComment wasn't able to find the comment, and we've tried fetching it
+    // needed to prevent infinite loop
+    const [fetchingComment, setFetchingComment] = useState<number | undefined>(undefined);
+
     useEffect(() => {
         let docTitle = `Пост #${postId}`;
         if (post) {
@@ -59,6 +63,11 @@ export default function PostPage() {
         if (location.hash) {
             commentId = parseInt(location.hash.substring(1));
             scrollToComment = document.querySelector<HTMLDivElement>(`[data-comment-id="${commentId}"]`);
+
+            if (!scrollToComment && fetchingComment !== commentId) {
+                reload(unreadOnly).then(() => setFetchingComment(commentId));
+                return;
+            }
         }
         else if (unreadOnly) {
             // find first new comment
@@ -98,7 +107,7 @@ export default function PostPage() {
             containerNode?.classList.remove(styles.focusing);
             scrollToComment?.classList.remove(styles.focused);
         };
-    }, [location.hash, comments, unreadOnly, postId]);
+    }, [location.hash, comments, unreadOnly, postId, fetchingComment]);
 
     const handlePostEdit = async (post: PostInfo, text: string, title?: string): Promise<PostInfo | undefined> => {
         return await editPost(title || '', text);


### PR DESCRIPTION
…to a comment that is not fetched yet.

Demo:
![notif-demo](https://github.com/spaceshelter/orbitar/assets/2865203/81e94036-b520-434c-9ca8-3e9ecc0fe615)


Tested some common scrolling scenarios, including scrolling to not existing hash.