### PR TITLE
Updating proc-macro2 v1.0.47 -> v1.0.66 to fix build regression

### DIFF
--- a/.github/workflows/build-docker-dev.yml
+++ b/.github/workflows/build-docker-dev.yml
@@ -11,6 +11,7 @@ on:
       - docker-compose.local.yml
       - docker-compose.ssl.dev.yml
       - docker-compose.ssl.local.yml
+  workflow_dispatch:
 
 jobs:
   build-docker:

--- a/feed/Cargo.lock
+++ b/feed/Cargo.lock
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
(see https://github.com/rust-lang/rust/issues/113152)

fixes this failure:
https://github.com/spaceshelter/orbitar/actions/runs/5695439646