### PR TITLE
Fix malformed url parsing

### DIFF
--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -440,9 +440,9 @@ export default class TheParser {
         return { ...result, text } ;
     }
 
-    validUrl(url: string) {
+    validUrl(url: string): boolean {
         try {
-            return encodeURI(decodeURI(url)).match(urlRegexExact);
+            return encodeURI(decodeURI(url)).match(urlRegexExact) !== null;
         } catch (e) {
             return false;
         }

--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -441,6 +441,10 @@ export default class TheParser {
     }
 
     validUrl(url: string) {
-        return encodeURI(decodeURI(url)).match(urlRegexExact);
+        try {
+            return encodeURI(decodeURI(url)).match(urlRegexExact);
+        } catch (e) {
+            return false;
+        }
     }
 }

--- a/backend/test/parser/TheParser.test.ts
+++ b/backend/test/parser/TheParser.test.ts
@@ -331,6 +331,12 @@ test('parse html directive', () => {
     ).toEqual('test&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;');
 });
 
+test('parse malformed url', () => {
+    expect(
+        p.parse('<a href="https://test>test</a>%<img src="https://test"/>').text
+    ).toEqual('&lt;a href=&quot;https://test&gt;test&lt;/a&gt;%&lt;img src=&quot; https:=&quot;&quot; test&quot;=&quot;&quot;/&gt;&lt;/a&gt;');
+});
+
 test('parse spoiler tag', () => {
     expect(p.parse('<spoiler>Hello</spoiler>').text).toEqual(
         '<span class="spoiler">Hello</span>'


### PR DESCRIPTION
Parser fails when testing malformed URLs for validity.

Minimal test:
```
<a href="https://test>test</a>%<img src="https://test"/>
```

Produces:
```
URI malformed
URIError: URI malformed
    at decodeURI (<anonymous>)
    at TheParser.validUrl (orbitar/backend/src/parser/TheParser.ts:444:26)
    at TheParser.parseA (orbitar/backend/src/parser/TheParser.ts:357:19)
    at a (orbitar/backend/src/parser/TheParser.ts:43:31)
    at TheParser.parseNode (orbitar/backend/src/parser/TheParser.ts:112:24)
    at TheParser.parseChildNodes (orbitar/backend/src/parser/TheParser.ts:91:30)
    at TheParser.parse (orbitar/backend/src/parser/TheParser.ts:73:34)
    at Object.<anonymous> (orbitar/backend/test/parser/TheParser.test.ts:336:11)
    at Promise.then.completed (orbitar/backend/node_modules/jest-circus/build/utils.js:333:28)
    at new Promise (<anonymous>)
```