### PR TITLE
use client-side Google Translate

### DIFF
--- a/backend/src/managers/TranslationManager.ts
+++ b/backend/src/managers/TranslationManager.ts
@@ -29,6 +29,7 @@ export async function getLanguage(text: string): Promise<{lang: string, prob: nu
     }
 }
 
+// DEPRECATED
 export default class TranslationManager {
 
     private translationRepository: TranslationRepository;

--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -31,6 +31,8 @@ export default function CommentComponent(props: CommentProps) {
     const [editingText, setEditingText] = useState<false | string>(false);
     const [showHistory, setShowHistory] = useState(false);
     const [translation, setTranslation] = useState<string | false | undefined>(undefined);
+    const [cachedTranslation, setCachedTranslation] = useState<string | undefined>(undefined);
+
     const api = useAPI();
 
     const handleAnswerSwitch = (e: React.MouseEvent) => {
@@ -81,12 +83,15 @@ export default function CommentComponent(props: CommentProps) {
     const translate = async () => {
         if (translation) {
             setTranslation(undefined);
+        } else if(cachedTranslation){
+            setTranslation(cachedTranslation);
         } else {
             setTranslation(false);
             try {
                 const html = await googleTranslate(props.comment.content);
 
                 setTranslation(html);
+                setCachedTranslation(html);
             } catch(err) {
                 setTranslation(undefined);
                 toast.error('Не удалось перевести');

--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -9,6 +9,7 @@ import {toast} from 'react-toastify';
 import {SignatureComponent} from './SignatureComponent';
 import {HistoryComponent} from './HistoryComponent';
 import Conf from '../Conf';
+import googleTranslate from '../Utils/googleTranslate';
 
 const defaultLanguage = process.env.DEFAULT_LANGUAGE || 'ru';
 
@@ -77,17 +78,19 @@ export default function CommentComponent(props: CommentProps) {
         }
     };
 
-    const translate = () => {
+    const translate = async () => {
         if (translation) {
             setTranslation(undefined);
         } else {
             setTranslation(false);
-            api.postAPI.translate(props.comment.id, 'comment')
-                .then(res => setTranslation(res.html))
-                .catch(() => {
-                    setTranslation(undefined);
-                    toast.error('Не удалось перевести');
-                });
+            try {
+                const html = await googleTranslate(props.comment.content);
+
+                setTranslation(html);
+            } catch(err) {
+                setTranslation(undefined);
+                toast.error('Не удалось перевести');
+            }
         }
     };
 

--- a/frontend/src/Components/PostComponent.tsx
+++ b/frontend/src/Components/PostComponent.tsx
@@ -16,6 +16,7 @@ import CreateCommentComponent from './CreateCommentComponent';
 import { HistoryComponent } from './HistoryComponent';
 import {SignatureComponent} from './SignatureComponent';
 import Conf from '../Conf';
+import googleTranslate from '../Utils/googleTranslate';
 
 const defaultLanguage = process.env.DEFAULT_LANGUAGE || 'ru';
 
@@ -78,17 +79,23 @@ export default function PostComponent(props: PostComponentProps) {
         setShowOptions(false);
     };
 
-    const translate = () => {
+    const translate = async () => {
         if (translation) {
             setTranslation(undefined);
         } else {
             setTranslation(false);
-            api.postAPI.translate(id, 'post')
-                .then(res => setTranslation(res))
-                .catch(() => {
-                    setTranslation(undefined);
-                    toast.error('Не удалось перевести');
+            try {
+                const title = await googleTranslate(props.post.title);
+                const html = await googleTranslate(props.post.content);
+
+                setTranslation({
+                    title,
+                    html
                 });
+            } catch(err) {
+                setTranslation(undefined);
+                toast.error('Не удалось перевести');
+            }
         }
     };
 

--- a/frontend/src/Components/PostComponent.tsx
+++ b/frontend/src/Components/PostComponent.tsx
@@ -38,6 +38,7 @@ export default function PostComponent(props: PostComponentProps) {
     const [editingTitle, setEditingTitle] = useState<string>(props.post.title || '');
     const [showHistory, setShowHistory] = useState(false);
     const [translation, setTranslation] = useState<{title: string, html: string} | false | undefined>(undefined);
+    const [cachedTranslation, setCachedTranslation] = useState<{title: string, html: string} | undefined>(undefined);
 
     const handleVote = useMemo(() => {
         return (value: number, vote?: number) => {
@@ -82,6 +83,8 @@ export default function PostComponent(props: PostComponentProps) {
     const translate = async () => {
         if (translation) {
             setTranslation(undefined);
+        } else if(cachedTranslation){
+            setTranslation(cachedTranslation);
         } else {
             setTranslation(false);
             try {
@@ -89,6 +92,10 @@ export default function PostComponent(props: PostComponentProps) {
                 const html = await googleTranslate(props.post.content);
 
                 setTranslation({
+                    title,
+                    html
+                });
+                setCachedTranslation({
                     title,
                     html
                 });

--- a/frontend/src/Utils/googleTranslate.ts
+++ b/frontend/src/Utils/googleTranslate.ts
@@ -1,0 +1,16 @@
+export default async function googleTranslate(str: string | undefined) {
+    if(!str) {
+        return '';
+    }
+    const response = await fetch('https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=ru&dt=t&dt=bd&dj=1', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({q: str})
+
+    });
+    const json = await response.json();
+    const sentences = (json.sentences as Array<{trans: string}>).map(sentence => sentence.trans);
+    return sentences.join('');
+}


### PR DESCRIPTION
Replace translation implementation with client-side Google Translate - no backend, no quotas, no payments.
Tested locally but @ZMSkG would like to test it when it will be on staging

![recording](https://i.imgur.com/kCmc1D8.gif)