### PR TITLE
Fix watch feed notification about the posts from exiled users

### DIFF
--- a/backend/src/managers/FeedManager.ts
+++ b/backend/src/managers/FeedManager.ts
@@ -347,7 +347,8 @@ export default class FeedManager {
         return { main, bookmarks };
     }
 
-    async postFanOut(subsite_id: number, post_id: number, createdAt: Date | undefined, updatedAt: Date | undefined) {
+    async postFanOut(subsite_id: number, post_id: number, createdAt: Date | undefined, updatedAt: Date | undefined,
+                     onlyDbUpdate= false) {
         this.confirmedPostsExist = true;
         if (!this.initialized || !this.minDate) {
             return;
@@ -355,11 +356,13 @@ export default class FeedManager {
         const batch = [];
         let dbUpdateJob;
 
-        if (createdAt) {
+        if (createdAt && !onlyDbUpdate) {
             batch.push({subsite: `${subsite_id}:new`, posts: [{id: post_id, ts: this.offsetPostTs(createdAt)}]});
         }
         if (updatedAt) {
-            batch.push({subsite: `${subsite_id}:live`, posts: [{id: post_id, ts: this.offsetPostTs(updatedAt)}]});
+            if (!onlyDbUpdate) {
+                batch.push({subsite: `${subsite_id}:live`, posts: [{id: post_id, ts: this.offsetPostTs(updatedAt)}]});
+            }
             dbUpdateJob = (async () => {
                 this.logger.profile(`postFanOut/setUpdated:${post_id}`);
                 await this.bookmarkRepository.setUpdated(post_id, updatedAt);

--- a/backend/src/managers/FeedManager.ts
+++ b/backend/src/managers/FeedManager.ts
@@ -348,7 +348,7 @@ export default class FeedManager {
     }
 
     async postFanOut(subsite_id: number, post_id: number, createdAt: Date | undefined, updatedAt: Date | undefined,
-                     onlyDbUpdate= false) {
+                     onlyDbUpdate = false) {
         this.confirmedPostsExist = true;
         if (!this.initialized || !this.minDate) {
             return;

--- a/backend/src/managers/PostManager.ts
+++ b/backend/src/managers/PostManager.ts
@@ -271,13 +271,12 @@ export default class PostManager {
         await this.bookmarkRepository.setWatch(postId, userId, true);
         this.userManager.clearUserStatsCache();
 
-        if (fanOutAndNotifications) {
-            // fan out in background
-            this.feedManager.postFanOut(commentRaw.site_id, commentRaw.post_id,
-                undefined,
-                commentRaw.created_at
-            ).then().catch();
-        }
+        // fan out in background
+        this.feedManager.postFanOut(commentRaw.site_id, commentRaw.post_id,
+            undefined,
+            commentRaw.created_at,
+            /*onlyDbUpdate=*/!fanOutAndNotifications
+        ).then().catch();
 
         const comments = await this.convertRawCommentsWithPostData(userId, [commentRaw], format);
         delete this.numberOfCommentsCache[userId];


### PR DESCRIPTION
#315 prevents post bumps from exiled users, but it also stops posts from being moved to the top of the "watch" feed, when such posts are watched.

This PR fixes that. Now comments from exiled users won't bump the main feed for everybody, but they will bump the posts in the "Watch"/"fireplace" feed.