### PR TITLE
Don't restrict min length for site domain in service requests

### DIFF
--- a/backend/src/api/ApiMiddleware.ts
+++ b/backend/src/api/ApiMiddleware.ts
@@ -91,7 +91,7 @@ export function validate<ReqBody, ResPayload>(schema: ObjectSchema<ReqBody>): AP
 }
 
 // TODO: have a single source of truth with frontend/src/Conf.ts
-const siteDomainMinLengthChars = 3;
+export const siteDomainMinLengthChars = 3; // restricted only during creation to allow select special names like "ai"
 const siteDomainMaxLengthChars = 15;
 const siteNameMinLengthChars = 3;
 const siteNameMaxLengthChars = 20;
@@ -100,5 +100,5 @@ export const joiUsername = Joi.string().regex(/^[a-zа-я0-9_-]{2,30}$/i);
 export const joiPassword = Joi.string().min(6);
 export const joiFormat = Joi.valid('html', 'source').default('html');
 
-export const joiSite = Joi.string().min(siteDomainMinLengthChars).max(siteDomainMaxLengthChars).regex(/^[a-z\d-]*$/i);
+export const joiSite = Joi.string().max(siteDomainMaxLengthChars).regex(/^[a-z\d-]*$/i);
 export const joiSiteName = Joi.string().min(siteNameMinLengthChars).max(siteNameMaxLengthChars);

--- a/backend/src/api/SiteController.ts
+++ b/backend/src/api/SiteController.ts
@@ -1,6 +1,13 @@
 import {Logger} from 'winston';
 import {Router} from 'express';
-import {APIRequest, APIResponse, joiSite, joiSiteName, validate} from './ApiMiddleware';
+import {
+    APIRequest,
+    APIResponse,
+    joiSite,
+    joiSiteName,
+    siteDomainMinLengthChars,
+    validate
+} from './ApiMiddleware';
 import SiteManager from '../managers/SiteManager';
 import {SiteSubscribeRequest, SiteSubscribeResponse} from './types/requests/SiteSubscribe';
 import {SiteRequest, SiteResponse} from './types/requests/Site';
@@ -53,7 +60,7 @@ export default class SiteController {
         });
 
         const siteCreateSchema = Joi.object<SiteCreateRequest>({
-            site: joiSite.required(),
+            site: joiSite.min(siteDomainMinLengthChars).required(),
             name: joiSiteName.required()
         });
 


### PR DESCRIPTION
Make `joiSite` validator not constrain min length beside during site creation. Allows for select few 2-letter names.