### PR TITLE
Fix long migration names leading to out-of-order application

### DIFF
--- a/backend/migrations/20221021345323-fix-migrations.js
+++ b/backend/migrations/20221021345323-fix-migrations.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db, callback) {
+    db.runSql("UPDATE migrations SET name = '/20221021345324-translation' WHERE name = '/22102134532452-translation'", [], callback);
+    db.runSql("UPDATE migrations SET name = '/20221026349872-fix-content-source-title' WHERE name = '/21026349872934-fix-content-source-title'", [], callback);
+
+  return null;
+};
+
+exports.down = function(db, callback) {
+    db.runSql("UPDATE migrations SET name = '/22102134532452-translation' WHERE name = '/20221021345324-translation'", [], callback);
+    db.runSql("UPDATE migrations SET name = '/21026349872934-fix-content-source-title' WHERE name = '/20221026349872-fix-content-source-title'", [], callback);
+    return null;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/backend/migrations/20221021345324-translation.js
+++ b/backend/migrations/20221021345324-translation.js
@@ -21,8 +21,7 @@ exports.up = async function (db) {
     const result = await db.connection.promise().query(`
         select name from migrations where name = '/20221021345324-translation' or name = '/22102134532452-translation';
     `);
-
-    if (result.length > 0) {
+    if (result[0].length > 0) {
         return;
     }
 

--- a/backend/migrations/20221021345324-translation.js
+++ b/backend/migrations/20221021345324-translation.js
@@ -15,6 +15,17 @@ exports.setup = function (options, seedLink) {
 };
 
 exports.up = async function (db) {
+    // skip if name '/20221021345324-translation' or '/22102134532452-translation'
+    // exists in migrations table
+    // temporary hack to fix migration order
+    const result = await db.connection.promise().query(`
+        select name from migrations where name = '/20221021345324-translation' or name = '/22102134532452-translation';
+    `);
+
+    if (result.length > 0) {
+        return;
+    }
+
     // add field language to table comments and posts
     const defaultLang = process.env.DEFAULT_TL_LANGUAGE || 'ru';
 

--- a/backend/migrations/20221026349872-fix-content-source-title.js
+++ b/backend/migrations/20221026349872-fix-content-source-title.js
@@ -19,6 +19,7 @@ exports.up = async function (db) {
     await db.runSql(`
         UPDATE content_source
         SET title = (SELECT title FROM posts WHERE posts.content_source_id = content_source.content_source_id)
+        WHERE title IS NULL or title = '';
     `);
 };
 


### PR DESCRIPTION
Two db migrations mistakenly had the longer names, that were being trimmed internally during the migration process (using some weird logic), leading to them being in the end of the migration list.

This change renames the migration files, ensuring the backward-compatibility for the existing systems.