### PR TITLE
Fix hidden menu tab order and search

### DIFF
--- a/frontend/src/Components/SiteSidebar.tsx
+++ b/frontend/src/Components/SiteSidebar.tsx
@@ -52,9 +52,10 @@ export const SiteSidebar = observer((props: SidebarProps) => {
         }
     }, [subscriptions]);
 
+    const sidebarOpened = props.menuState === 'close';
     return (
-        <div className={classNames(styles.sidebar, {
-            [styles.open]: props.menuState === 'close',
+        <div {...(sidebarOpened ? {} : {hidden: true, tabIndex: -1})} className={classNames(styles.sidebar, {
+            [styles.open]: sidebarOpened,
         })}>
             <div className={styles.fade} onClick={menuToggle}></div>
             <div className={styles.container}>


### PR DESCRIPTION
It is a bit annoying that when the menu is hidden and you are using browser page search then menu items are still counted by the browser as searchable elements and it shows that your search has results but you don't see them because they are in the menu that is hidden.

This also fixes the problem navigating with tab key, when the menu is hidden it is now excluded from tab order