### PR TITLE
Close the image zoom pop-up upon a back gesture

### DIFF
--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -655,10 +655,9 @@ function ZoomComponent(props: ZoomComponentProps) {
 
         // Event listener to handle back navigation
         const handleBack = (event: PopStateEvent) => {
-            // console.log('Handling back event');
             // preventing default back action if the new state isn't the popup
             if (!event.state.popupOpen) {
-                // console.log('Preventing the default back action');
+                // Preventing the default back action
                 event.preventDefault();
                 // Call the function to close the overlay
                 props.onExit();
@@ -667,19 +666,18 @@ function ZoomComponent(props: ZoomComponentProps) {
 
         // make sure we're only adding the event listener once
         if (!window.history.state.popupOpen) {
-            // console.log('Push a new entry onto the history stack')
+            // Pushing a new entry onto the history stack
             window.history.pushState({popupOpen: true}, '');
-            // console.log('Adding event listener');
+            // Adding event listener
             window.addEventListener('popstate', handleBack);
         }
 
         // Cleanup function to restore the state
         return () => {
-            // console.log('Removing event listener');
+            // Removing event listener
             window.removeEventListener('popstate', handleBack);
             // Try to move back in history stack if the popup was open
             if (window.history.state && window.history.state.popupOpen) {
-                // console.log('Popping history');
                 window.history.back();
             }
         };

--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -651,6 +651,32 @@ function ZoomComponent(props: ZoomComponentProps) {
     const defaultTranslateY = (window.innerHeight - props.height * defaultScale) / 2;
     useHotkeys('esc', props.onExit);
 
+    useEffect(() => {
+        // Push a new entry onto the history stack
+        window.history.pushState({ popupOpen: true }, '');
+
+        // Event listener to handle back navigation
+        const handleBack = (event: PopStateEvent) => {
+            if (event.state && event.state.popupOpen) {
+                // Prevent the default back action
+                event.preventDefault();
+                // Call the function to close the overlay
+                props.onExit();
+            }
+        };
+
+        window.addEventListener('popstate', handleBack);
+
+        // Cleanup function to restore the state
+        return () => {
+            window.removeEventListener('popstate', handleBack);
+            // Try to move back in history stack if the popup was open
+            if (window.history.state && window.history.state.popupOpen) {
+                window.history.back();
+            }
+        };
+    }, []); // Ensure this effect runs only once upon mounting and unmounting
+
     return (
         <div className={overlayStyles.overlay}
             onClick={(e) => {

--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -652,10 +652,7 @@ function ZoomComponent(props: ZoomComponentProps) {
     useHotkeys('esc', props.onExit);
 
     useEffect(() => {
-        if (!window.history.state.popupOpen) {
-            // console.log('Push a new entry onto the history stack')
-            window.history.pushState({popupOpen: true}, '');
-        }
+
         // Event listener to handle back navigation
         const handleBack = (event: PopStateEvent) => {
             // console.log('Handling back event');
@@ -667,8 +664,14 @@ function ZoomComponent(props: ZoomComponentProps) {
                 props.onExit();
             }
         };
-        // console.log('Adding event listener');
-        window.addEventListener('popstate', handleBack);
+
+        // make sure we're only adding the event listener once
+        if (!window.history.state.popupOpen) {
+            // console.log('Push a new entry onto the history stack')
+            window.history.pushState({popupOpen: true}, '');
+            // console.log('Adding event listener');
+            window.addEventListener('popstate', handleBack);
+        }
 
         // Cleanup function to restore the state
         return () => {

--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -652,30 +652,35 @@ function ZoomComponent(props: ZoomComponentProps) {
     useHotkeys('esc', props.onExit);
 
     useEffect(() => {
-        // Push a new entry onto the history stack
-        window.history.pushState({ popupOpen: true }, '');
-
+        if (!window.history.state.popupOpen) {
+            // console.log('Push a new entry onto the history stack')
+            window.history.pushState({popupOpen: true}, '');
+        }
         // Event listener to handle back navigation
         const handleBack = (event: PopStateEvent) => {
-            if (event.state && event.state.popupOpen) {
-                // Prevent the default back action
+            // console.log('Handling back event');
+            // preventing default back action if the new state isn't the popup
+            if (!event.state.popupOpen) {
+                // console.log('Preventing the default back action');
                 event.preventDefault();
                 // Call the function to close the overlay
                 props.onExit();
             }
         };
-
+        // console.log('Adding event listener');
         window.addEventListener('popstate', handleBack);
 
         // Cleanup function to restore the state
         return () => {
+            // console.log('Removing event listener');
             window.removeEventListener('popstate', handleBack);
             // Try to move back in history stack if the popup was open
             if (window.history.state && window.history.state.popupOpen) {
+                // console.log('Popping history');
                 window.history.back();
             }
         };
-    }, []); // Ensure this effect runs only once upon mounting and unmounting
+    }, []);
 
     return (
         <div className={overlayStyles.overlay}

--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -652,31 +652,13 @@ function ZoomComponent(props: ZoomComponentProps) {
     useHotkeys('esc', props.onExit);
 
     useEffect(() => {
-
-        // Event listener to handle back navigation
-        const handleBack = (event: PopStateEvent) => {
-            // preventing default back action if the new state isn't the popup
-            if (!event.state.popupOpen) {
-                // Preventing the default back action
-                event.preventDefault();
-                // Call the function to close the overlay
-                props.onExit();
-            }
-        };
-
-        // make sure we're only adding the event listener once
+        const handleBack = (event: PopStateEvent) => props.onExit();
         if (!window.history.state.popupOpen) {
-            // Pushing a new entry onto the history stack
             window.history.pushState({popupOpen: true}, '');
-            // Adding event listener
-            window.addEventListener('popstate', handleBack);
         }
-
-        // Cleanup function to restore the state
+        window.addEventListener('popstate', handleBack);
         return () => {
-            // Removing event listener
             window.removeEventListener('popstate', handleBack);
-            // Try to move back in history stack if the popup was open
             if (window.history.state && window.history.state.popupOpen) {
                 window.history.back();
             }


### PR DESCRIPTION
On mobile devices, when the zoomed image pop-up is open, a natural way of closing it is a "back" gesture (swipe from the right edge of the screen to the left). But as of now, this gesture performs back navigation, bringing you out of the thread instead of closing the pop-up, which can be quite frustrating, especially in cases where a large thread with many unread messages was opened.

This pull request tackles the issue by pushing a new state to the history stack when the preview is open (ZoomComponent object is created and displayed) and setting up a custom popStateEvent listener that prevents the default action handler of the back event and closes the preview instead. Once the preview is closed (ZoomComponent object is destroyed), the listener is deleted and the additional state item is removed from the history stack.