### PR TITLE
Optimize long page performance

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,6 +40,7 @@
         "react-hook-form": "^7.29.0",
         "react-hotkeys-hook": "^4.3.8",
         "react-icons": "^4.3.1",
+        "react-intersection-observer": "^9.13.0",
         "react-outside-click-handler": "^1.3.0",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.0",
@@ -14723,6 +14724,20 @@
         "react": "*"
       }
     },
+    "node_modules/react-intersection-observer": {
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.13.0.tgz",
+      "integrity": "sha512-y0UvBfjDiXqC8h0EWccyaj4dVBWMxgEx0t5RGNzQsvkfvZwugnKwxpu70StY4ivzYuMajavwUDjH4LJyIki9Lw==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -29400,6 +29415,12 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
       "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "requires": {}
+    },
+    "react-intersection-observer": {
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.13.0.tgz",
+      "integrity": "sha512-y0UvBfjDiXqC8h0EWccyaj4dVBWMxgEx0t5RGNzQsvkfvZwugnKwxpu70StY4ivzYuMajavwUDjH4LJyIki9Lw==",
       "requires": {}
     },
     "react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "react-hook-form": "^7.29.0",
     "react-hotkeys-hook": "^4.3.8",
     "react-icons": "^4.3.1",
+    "react-intersection-observer": "^9.13.0",
     "react-outside-click-handler": "^1.3.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.0",

--- a/frontend/src/API/use/useInterpreter.ts
+++ b/frontend/src/API/use/useInterpreter.ts
@@ -1,5 +1,5 @@
 import {useAPI} from '../../AppState/AppState';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {TranslateModes} from '../PostAPI';
 import googleTranslate from '../../Utils/googleTranslate';
 import {toast} from 'react-toastify';
@@ -14,9 +14,8 @@ export type AltContentType = 'translate' | TranslateModes;
 export const ANNOTATE_LIMIT = 1024;
 export const ALT_TRANSLATE_LIMIT = 2048;
 
-export function useInterpreter(originalContent: string, originalTitle: string | undefined, id: number, type: 'post' | 'comment') {
+export function useInterpreter(contentRef: React.RefObject<HTMLDivElement>, originalContent: string, originalTitle: string | undefined, id: number, type: 'post' | 'comment') {
     const api = useAPI();
-    const contentRef = useRef<HTMLDivElement>(null);
     const [currentMode, setCurrentMode] = React.useState<AltContentType | undefined>();
     const [cachedTitleTranslation, setCachedTitleTranslation] = useState<string | undefined>();
     const [cachedContentTranslation, setCachedContentTranslation] = useState<string | undefined>();
@@ -149,7 +148,7 @@ export function useInterpreter(originalContent: string, originalTitle: string | 
             }
         }
 
-    }, [currentMode]);
+    }, [currentMode, contentRef]);
 
     return {contentRef, currentMode, inProgress, altTitle, altContent, translate, annotate, altTranslate,
         calcShowAltTranslate, calcShowAnnotate

--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -2,7 +2,7 @@ import {CommentInfo, PostLinkInfo} from '../Types/PostInfo';
 import styles from './CommentComponent.module.scss';
 import postStyles from './PostComponent.module.scss';
 import RatingSwitch from './RatingSwitch';
-import React, {useMemo, useState} from 'react';
+import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {CreateCommentComponentRestricted} from './CreateCommentComponent';
 import ContentComponent, {LARGE_AUTO_CUT} from './ContentComponent';
 import {ReactComponent as OptionsIcon} from '../Assets/options.svg';
@@ -14,6 +14,7 @@ import Conf from '../Conf';
 import {useInterpreter} from '../API/use/useInterpreter';
 import OutsideClickHandler from 'react-outside-click-handler';
 import {AltTranslateButton, AnnotateButton, TranslateButton} from './ContentButtons';
+import {InviewContext} from '../Pages/PostPage';
 
 interface CommentProps {
     comment: CommentInfo;
@@ -33,22 +34,8 @@ export default function CommentComponent(props: CommentProps) {
     const [answerOpen, setAnswerOpen] = useState(false);
     const [editingText, setEditingText] = useState<false | string>(false);
     const [showHistory, setShowHistory] = useState(false);
-    const [showOptions, setShowOptions] = useState(false);
-
-    const api = useAPI();
-    const {currentMode, inProgress, contentRef, altContent, translate, annotate, altTranslate,
-        calcShowAnnotate, calcShowAltTranslate
-    } = useInterpreter(props.comment.content, undefined, props.comment.id, 'comment');
-
-    const handleAnswerSwitch = (e: React.MouseEvent) => {
-        e.preventDefault();
-        setAnswerOpen(!answerOpen);
-    };
-
-    const toggleOptions = () => {
-        setShowOptions(!showOptions);
-    };
-
+    const [altContent, setAltContent] = useState<string | undefined>(undefined);
+    const contentRef = useRef<HTMLDivElement>(null);
     const handleAnswer = async (text: string, post?: PostLinkInfo, comment?: CommentInfo) => {
         if (!post) {
             return undefined;
@@ -71,23 +58,6 @@ export default function CommentComponent(props: CommentProps) {
         }
     };
 
-    const handleVote = useMemo(() => {
-        return (value: number, vote?: number) => {
-            props.comment.rating = value;
-            props.comment.vote = vote;
-        };
-    }, [props.comment]);
-
-    const handleEdit = async () => {
-        try {
-            const comment = await api.postAPI.getComment(props.comment.id, 'source');
-            setEditingText(comment.comment.content);
-        }
-        catch (e) {
-            console.log('Get comment error:', e);
-            toast.error('Не удалось включить редактирование');
-        }
-    };
 
     const toggleHistory = () => {
         setShowHistory(!showHistory);
@@ -99,6 +69,8 @@ export default function CommentComponent(props: CommentProps) {
     const depth = props.depth || 0;
     const maxDepth = props.maxTreeDepth || 0;
     const isFlat = depth > maxDepth;
+    const isInView = useContext(InviewContext);
+
     return (
         <div className={`comment ${styles.comment} ${props.comment.isNew ? ' isNew': ''} ${isFlat?' isFlat':''}`} data-comment-id={props.comment.id}>
             <div className='commentBody' ref={contentRef}>
@@ -122,42 +94,17 @@ export default function CommentComponent(props: CommentProps) {
                         comment={props.comment}
                         open={true} text={editingText} onAnswer={handleEditComplete} />
                 }
-
-                <div className={styles.controls}>
-                    {!props.hideRating &&
-                    <div className={styles.control}>
-                        <RatingSwitch type="comment" id={props.comment.id} rating={{ vote: props.comment.vote, value: props.comment.rating }} onVote={handleVote} />
-                    </div>}
-                    {props.comment.canEdit && props.onEdit && <div className={styles.control}><button onClick={handleEdit} className='i i-edit' /></div>}
-
-                    <div className={styles.control + ' ' + postStyles.options}>
-                        {currentMode === 'translate' &&
-                            <div className={styles.control}>
-                                <TranslateButton iconOnly={true} isActive={true} inProgress={inProgress} onClick={translate} />
-                            </div>}
-                        {currentMode === 'altTranslate' &&
-                            <div className={styles.control}>
-                                <AltTranslateButton iconOnly={true} isActive={true} inProgress={inProgress} onClick={altTranslate}/>
-                            </div>}
-                        {currentMode === 'annotate' &&
-                            <div className={styles.control}>
-                                <AnnotateButton iconOnly={true} isActive={true} inProgress={inProgress} onClick={annotate} />
-                            </div>}
-
-                        <button onClick={toggleOptions} className={styles.options + ' ' + (showOptions ? styles.active : '')}><OptionsIcon /></button>
-                        {showOptions &&
-                            <OutsideClickHandler onOutsideClick={() => setShowOptions(false)}>
-                            <div className={postStyles.optionsList}>
-                                <TranslateButton inProgress={inProgress} onClick={() => {setShowOptions(false);translate();}} isActive={currentMode === 'translate'} />
-                                {calcShowAltTranslate() &&
-                                    <AltTranslateButton inProgress={inProgress} onClick={() => {setShowOptions(false);altTranslate();}} isActive={currentMode === 'altTranslate'}/>}
-                                {calcShowAnnotate() &&
-                                    <AnnotateButton inProgress={inProgress} onClick={() => {setShowOptions(false);annotate();}} isActive={currentMode === 'annotate'} />}
-                            </div>
-                            </OutsideClickHandler>}
-                    </div>
-                    {props.onAnswer && <div className={styles.control}><button onClick={handleAnswerSwitch}>{!answerOpen ? 'Ответить' : 'Не отвечать'}</button></div>}
-                </div>
+                {isInView && <Controls {...{
+                    contentRef,
+                    comment: props.comment,
+                    setEditingText,
+                    hideRating: props.hideRating,
+                    onEdit: props.onEdit,
+                    onAnswer: props.onAnswer,
+                    answerOpen,
+                    setAnswerOpen,
+                    setAltContent
+                }}/>}
             </div>
             {(props.comment.answers || answerOpen) ?
                 <div className={styles.answers + (isFlat?' isFlat':'')}>
@@ -174,4 +121,91 @@ export default function CommentComponent(props: CommentProps) {
 
         </div>
     );
+}
+
+interface ControlsProps {
+    contentRef: React.RefObject<HTMLDivElement>;
+    comment: CommentInfo;
+    setEditingText: (text: string) => void;
+    hideRating?: boolean;
+    onEdit?: (text: string, comment: CommentInfo) => Promise<CommentInfo | undefined>;
+    onAnswer?: (text: string, post?: PostLinkInfo, comment?: CommentInfo) => Promise<CommentInfo | undefined>;
+    answerOpen: boolean;
+    setAnswerOpen: (value: boolean) => void;
+    setAltContent: (value: string | undefined) => void;
+}
+
+function Controls({contentRef, comment, setEditingText, hideRating, onEdit, onAnswer, answerOpen, setAnswerOpen, setAltContent}: ControlsProps) {
+    const api = useAPI();
+
+    const handleVote = useMemo(() => {
+        return (value: number, vote?: number) => {
+            comment.rating = value;
+            comment.vote = vote;
+        };
+    }, [comment]);
+    const handleEdit = async () => {
+        try {
+            const commentResponse = await api.postAPI.getComment(comment.id, 'source');
+            setEditingText(commentResponse.comment.content);
+        }
+        catch (e) {
+            console.log('Get comment error:', e);
+            toast.error('Не удалось включить редактирование');
+        }
+    };
+
+    const [showOptions, setShowOptions] = useState(false);
+    const toggleOptions = () => {
+        setShowOptions(!showOptions);
+    };
+
+
+    const {currentMode, inProgress, altContent, translate, annotate, altTranslate,
+        calcShowAnnotate, calcShowAltTranslate
+    } = useInterpreter(contentRef, comment.content, undefined, comment.id, 'comment');
+    const handleAnswerSwitch = (e: React.MouseEvent) => {
+        e.preventDefault();
+        setAnswerOpen(!answerOpen);
+    };
+    useEffect(() => setAltContent(altContent), [altContent]);
+
+    return (
+      <div className={styles.controls}>
+        {!hideRating &&
+          <div className={styles.control}>
+              <RatingSwitch type="comment" id={comment.id} rating={{ vote: comment.vote, value: comment.rating }} onVote={handleVote} />
+          </div>}
+        {comment.canEdit && onEdit && <div className={styles.control}><button onClick={handleEdit} className='i i-edit' /></div>}
+
+        <div className={styles.control + ' ' + postStyles.options}>
+            {currentMode === 'translate' &&
+              <div className={styles.control}>
+                  <TranslateButton iconOnly={true} isActive={true} inProgress={inProgress} onClick={translate} />
+              </div>}
+            {currentMode === 'altTranslate' &&
+              <div className={styles.control}>
+                  <AltTranslateButton iconOnly={true} isActive={true} inProgress={inProgress} onClick={altTranslate}/>
+              </div>}
+            {currentMode === 'annotate' &&
+              <div className={styles.control}>
+                  <AnnotateButton iconOnly={true} isActive={true} inProgress={inProgress} onClick={annotate} />
+              </div>}
+
+            <button onClick={toggleOptions} className={styles.options + ' ' + (showOptions ? styles.active : '')}><OptionsIcon /></button>
+            {showOptions &&
+              <OutsideClickHandler onOutsideClick={() => setShowOptions(false)}>
+                  <div className={postStyles.optionsList}>
+                      <TranslateButton inProgress={inProgress} onClick={() => {setShowOptions(false);translate();}} isActive={currentMode === 'translate'} />
+                      {calcShowAltTranslate() &&
+                        <AltTranslateButton inProgress={inProgress} onClick={() => {setShowOptions(false);altTranslate();}} isActive={currentMode === 'altTranslate'}/>}
+                      {calcShowAnnotate() &&
+                        <AnnotateButton inProgress={inProgress} onClick={() => {setShowOptions(false);annotate();}} isActive={currentMode === 'annotate'} />}
+                  </div>
+              </OutsideClickHandler>}
+        </div>
+        {onAnswer && <div className={styles.control}><button onClick={handleAnswerSwitch}>{!answerOpen ? 'Ответить' : 'Не отвечать'}</button></div>}
+    </div>
+    );
+
 }

--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useContext, useEffect, useRef, useState} from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import styles from './ContentComponent.module.scss';
@@ -16,6 +16,7 @@ import {
     useAppState
 } from '../AppState/AppState';
 import {FakeRoot} from '../index';
+import {InviewContext} from '../Pages/PostPage';
 
 interface ContentComponentProps extends React.ComponentPropsWithRef<'div'> {
     content: string;
@@ -562,10 +563,11 @@ export default function ContentComponent(props: ContentComponentProps) {
         }
         return false;
     };
+    const isInView = useContext(InviewContext);
 
     useEffect(() => {
         const content = contentDiv.current;
-        if (!content) {
+        if (!content || !isInView) {
             return;
         }
 
@@ -609,7 +611,7 @@ export default function ContentComponent(props: ContentComponentProps) {
             };
         }
 
-    }, [props.content, contentDiv, props.autoCut, props.lowRating]);
+    }, [isInView, props.content, contentDiv, props.autoCut, props.lowRating]);
 
     useEffect(() => {
         if (!props.autoCut && cut) {

--- a/frontend/src/Components/PostComponent.tsx
+++ b/frontend/src/Components/PostComponent.tsx
@@ -1,6 +1,6 @@
 import styles from './PostComponent.module.scss';
 import RatingSwitch from './RatingSwitch';
-import React, {useMemo, useState} from 'react';
+import React, {useMemo, useRef, useState} from 'react';
 import {PostInfo} from '../Types/PostInfo';
 import ContentComponent from './ContentComponent';
 import {ReactComponent as CommentsIcon} from '../Assets/comments.svg';
@@ -31,6 +31,7 @@ interface PostComponentProps {
 
 
 export default function PostComponent(props: PostComponentProps) {
+    const contentRef = useRef<HTMLDivElement>(null);
     const api = useAPI();
     const currentUsername = useAppState().userInfo?.username;
     const [showOptions, setShowOptions] = useState(false);
@@ -38,8 +39,8 @@ export default function PostComponent(props: PostComponentProps) {
     const [editingTitle, setEditingTitle] = useState<string>(props.post.title || '');
     const [showHistory, setShowHistory] = useState(false);
     const {currentMode, altTitle, altContent, inProgress,
-        contentRef, translate, annotate, altTranslate, calcShowAltTranslate, calcShowAnnotate
-    } = useInterpreter(props.post.content, props.post.title, props.post.id, 'post');
+         translate, annotate, altTranslate, calcShowAltTranslate, calcShowAnnotate
+    } = useInterpreter(contentRef, props.post.content, props.post.title, props.post.id, 'post');
 
     const handleVote = useMemo(() => {
         return (value: number, vote?: number) => {

--- a/frontend/src/Pages/PostPage.tsx
+++ b/frontend/src/Pages/PostPage.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {createContext, useEffect, useMemo, useRef, useState} from 'react';
 import styles from './PostPage.module.css';
 import {Link, useLocation, useParams, useSearchParams} from 'react-router-dom';
 import {CommentInfo, PostInfo, PostLinkInfo} from '../Types/PostInfo';
@@ -9,6 +9,11 @@ import {usePost} from '../API/use/usePost';
 import {useAppState} from '../AppState/AppState';
 import Username from '../Components/Username';
 import {scrollUnderTopbar} from '../Utils/utils';
+import {InView} from 'react-intersection-observer';
+
+const THREAD_GROUP_SIZE = 10;
+
+export const InviewContext = createContext<boolean>(false);
 
 export default function PostPage() {
     const params = useParams<{postId: string}>();
@@ -20,6 +25,18 @@ export default function PostPage() {
     const containerRef = useRef<HTMLDivElement>(null);
     const unreadOnly = search.get('new') !== null;
     const {post, comments, anonymousUser, postComment, editComment, editPost, error, reload, updatePost} = usePost(site, postId, unreadOnly);
+
+    // Group top-level threads to render some content inside only when they are in view
+    const groupedComments = useMemo(() => {
+        if (!comments) {
+            return;
+        }
+        const groups: CommentInfo[][] = [];
+        for (let i = 0; i < comments.length; i += THREAD_GROUP_SIZE) {
+            groups.push(comments.slice(i, i + THREAD_GROUP_SIZE));
+        }
+        return groups;
+    }, [comments]);
 
     useEffect(() => {
         let docTitle = `Пост #${postId}`;
@@ -108,11 +125,21 @@ export default function PostPage() {
                         {anonymousUser && <div className={styles.anon}><span className={'i i-anon'}></span> Внимание, анонимность!<br/>Комментарии в этом посте публикуются лица <Username user={anonymousUser}/>.</div>}
                         <div className={styles.postButtons}><Link to={`${baseRoute}p${post.id}`} className={unreadOnly ? '' : 'bold'}>все комментарии</Link> • <Link to={`${baseRoute}p${post.id}?new`} className={unreadOnly ? 'bold' : ''}>только новые</Link></div>
                         <div className={styles.comments + (unreadOnly ? ' unreadOnly' : '')}>
-                            {comments ?
-                                comments.map(comment =>
-                                    <CommentComponent maxTreeDepth={12} key={comment.id} comment={comment}
-                                                      onAnswer={handleAnswer} unreadOnly={unreadOnly} onEdit={handleCommentEdit}
-                                                      currentUsername={userInfo?.username} />
+                            {groupedComments ?
+                                groupedComments.map((comments, ii) =>
+                                  <InView key={ii} threshold={0.01} triggerOnce={true}>
+                                      {({ inView, ref, entry }) => (
+                                        <div ref={ref}>
+                                            <InviewContext.Provider value={inView}>
+                                              {comments.map(comment =>
+                                                <CommentComponent maxTreeDepth={12} key={comment.id} comment={comment}
+                                                                  onAnswer={handleAnswer} unreadOnly={unreadOnly} onEdit={handleCommentEdit}
+                                                                  currentUsername={userInfo?.username} />
+                                              )}
+                                            </InviewContext.Provider>
+                                        </div>
+                                      )}
+                                  </InView>
                                 )
                                 :
                                 (


### PR DESCRIPTION
For very long posts it may take a VERY long time to show up and render.
Trying to solve that by reducing number of elements rendered on page load and render then only when parent thread comes into view. unfortunately `IntersectionObserver` is not performant enough to watch every comment individually so I'm grouping top level threads into groups of 10 and watching its visibility - once any part of the thread group will become visible - whole thread group will render completely.
Some data (10 samples for each group) for post with 3600 comments: 
![image](https://github.com/user-attachments/assets/ed097759-ed49-4e55-97ee-4a8eb5b21ba8)
Further optimizations: lazy-load images only when thread comes into view
Render less elements - I tried rendering only comment content by default (so user can search the page) but UX is a bit chunky - if you scroll the page using page scroll you will see flash when component rerenders - doesn't feel good - may need extra effort