### PR TITLE
Increase size of the language column to char(3)

### DIFF
--- a/backend/migrations/20240818123456-language-col-size.js
+++ b/backend/migrations/20240818123456-language-col-size.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+    dbm = options.dbmigrate;
+    type = dbm.dataType;
+    seed = seedLink;
+};
+
+exports.up = async function (db) {
+    // increase language size to char(3)
+    await db.runSql(`
+        ALTER TABLE posts MODIFY COLUMN language char(3) null default 'ru'
+    `);
+    await db.runSql(`
+        ALTER TABLE comments MODIFY COLUMN language char(3) null default 'ru'
+    `);
+};
+
+exports.down = async function (db) {
+    // decrease language size to char(2)
+    await db.runSql(`
+        ALTER TABLE posts MODIFY COLUMN language char(2) null default 'ru'
+    `);
+    await db.runSql(`
+        ALTER TABLE comments MODIFY COLUMN language char(2) null default 'ru'
+    `);
+};
+
+exports._meta = {
+    "version": 1
+};


### PR DESCRIPTION
Apparently language codes returned by fasttext [could be 3 chars long](https://www.loc.gov/standards/iso639-2/php/code_list.php).

### Testing

try to create a comment with this exact content:
```
уаб уаб уаааааааааб...
```