### PR TITLE
Fix scroll to comment (ugly way)

### DIFF
--- a/frontend/src/Pages/PostPage.tsx
+++ b/frontend/src/Pages/PostPage.tsx
@@ -68,46 +68,71 @@ export default function PostPage() {
     };
 
     useEffect(() => {
+        console.log('>>> scrolling to comment', location.hash, comments);
+
         if (!comments) {
+            console.log('no comments');
             return;
         }
 
-        let scrollToComment: HTMLDivElement | null | undefined;
+        let commentToScrollTo: HTMLDivElement | null | undefined;
         let commentId: number | undefined;
         if (location.hash) {
             commentId = parseInt(location.hash.substring(1));
-            scrollToComment = document.querySelector<HTMLDivElement>(`[data-comment-id="${commentId}"]`);
-        }
-        else if (unreadOnly) {
+            commentToScrollTo = document.querySelector<HTMLDivElement>(`[data-comment-id="${commentId}"]`);
+            console.log('scrollToComment', commentToScrollTo);
+        } else if (unreadOnly) {
             // find first new comment
-             scrollToComment = document.querySelector<HTMLDivElement>(`.isNew`);
-             commentId = scrollToComment?.dataset.commentId ? parseInt(scrollToComment.dataset.commentId) : undefined;
+             commentToScrollTo = document.querySelector<HTMLDivElement>(`.isNew`);
+             commentId = commentToScrollTo?.dataset.commentId ? parseInt(commentToScrollTo.dataset.commentId) : undefined;
+             console.log('unreadOnly', commentToScrollTo, commentId);
         }
         // do nothing if element is focused already
-        if (!scrollToComment || scrollToComment.className.indexOf(styles.focusing) >= 0 ||
-            (scrolledToComment && scrolledToComment.postId === postId && scrolledToComment.commentId === commentId)
+        if (!commentToScrollTo || commentToScrollTo.className.indexOf(styles.focusing) >= 0 ||
+            (scrolledToComment?.postId === postId && scrolledToComment?.commentId === commentId)
         ) {
+            console.log('do nothing', scrolledToComment, {postId, commentId}, commentToScrollTo);
+            // debug condition
+            if (!commentToScrollTo) {
+                console.log('no commentToScrollTo');
+            }
+            if (commentToScrollTo && commentToScrollTo.className.indexOf(styles.focusing) >= 0) {
+                console.log('focusing');
+            }
+            if (scrolledToComment?.postId === postId && scrolledToComment?.commentId === commentId) {
+                console.log('already scrolled', scrolledToComment, {postId, commentId});
+            }
+            setScrolledToComment(commentId && commentToScrollTo ? {postId, commentId} : undefined);
             return;
         }
 
-        const commentBody = scrollToComment.querySelector<HTMLDivElement>('.commentBody');
+        const commentBody = commentToScrollTo.querySelector<HTMLDivElement>('.commentBody');
         if (!commentBody) {
+            console.log('no commentBody', commentToScrollTo);
             return;
         }
         const containerNode = containerRef.current;
         // disable anchoring for all post&comments and anchor the comment
         containerNode?.classList.add(styles.focusing);
-        scrollToComment.classList.add(styles.focused);
+        commentToScrollTo.classList.add(styles.focused);
         commentBody.classList.add(styles.highlight);
 
-        commentId && setScrolledToComment({postId, commentId});
+        setScrolledToComment(commentId && commentToScrollTo? {postId, commentId} : undefined);
 
-        scrollUnderTopbar(commentBody);
+        console.log('scrolling to comment', commentToScrollTo);
+        scrollUnderTopbar(() => {
+            console.log(commentId);
+            const commentToScrollTo = document.querySelector<HTMLDivElement>(`[data-comment-id="${commentId}"]`);
+            console.log(commentToScrollTo);
+            const res = commentToScrollTo?.querySelector<HTMLDivElement>('.commentBody') || null;
+            console.log(res);
+            return res;
+        });
 
         return () => {
             commentBody.classList.remove(styles.highlight);
             containerNode?.classList.remove(styles.focusing);
-            scrollToComment?.classList.remove(styles.focused);
+            commentToScrollTo?.classList.remove(styles.focused);
         };
     }, [location.hash, comments, unreadOnly, postId]);
 

--- a/frontend/src/Utils/utils.ts
+++ b/frontend/src/Utils/utils.ts
@@ -4,20 +4,51 @@ export function pluralize(count: number, words: string[]) {
     return count + ' ' + words[ (count % 100 > 4 && count % 100 < 20) ? 2 : cases[ Math.min(count % 10, 5)] ];
 }
 
-export function scrollUnderTopbar(el: HTMLElement, toBottom?: boolean) {
-    if(!el) {
-        return;
+function isElementInView(el: HTMLElement, toBottom = false): boolean {
+    const rect = el.getBoundingClientRect();
+    const windowHeight = window.innerHeight || document.documentElement.clientHeight;
+    console.log('isElementInView', rect, windowHeight, toBottom);
+    if (toBottom) {
+        // Check if the bottom of the element is visible
+        return rect.bottom <= windowHeight && rect.bottom >= 0;
+    } else {
+        // Check if the top of the element is visible
+        return rect.top <= windowHeight && rect.top >= 0;
     }
+}
 
-    // do not use `smooth` here - it is too slow and element won't focus into view correctly
-    el.scrollIntoView({behavior: 'auto', block: toBottom ? 'end' : 'start' });
-    // compensate for topbar height - otherwise element will be partially covered
-    const topbarHeight = document.getElementById('topbar')?.clientHeight;
+export function scrollUnderTopbar(el: HTMLElement | (() => HTMLElement | null), toBottom?: boolean) {
+    console.log('scrollUnderTopbar', el, toBottom);
 
-    if (topbarHeight) {
-        window.scrollBy({top: -topbarHeight - 10});
-    }
+    const scroll = (el: HTMLElement) => {
+        el.scrollIntoView({ behavior: 'auto', block: toBottom ? 'end' : 'start' });
+        const topbarHeight = document.getElementById('topbar')?.clientHeight;
 
+        if (topbarHeight) {
+            window.scrollBy({ top: -topbarHeight - 10 });
+        }
+    };
+
+    let attempts = 5;
+    const tryScroll = (check: boolean) => {
+        const el0 = typeof el === 'function' ? el() : el;
+        if (!el0) {
+            console.log('no element');
+            return;
+        }
+        console.log('tryScroll', check, attempts, 'containsEl:', document.body.contains(el0),
+            'in view:', isElementInView(el0, toBottom));
+        if (!check || document.body.contains(el0) && !isElementInView(el0, toBottom)) {
+            console.log('scrolling');
+            scroll(el0);
+        }
+        attempts--;
+        if (attempts > 0) {
+            setTimeout(() => tryScroll(true), 200);
+        }
+    };
+
+    tryScroll(false);
 }
 
 // see https://stackoverflow.com/a/30106551/1349366


### PR DESCRIPTION
Fixes scroll to comment behavior (basically, but retrying). The solution is ugly, and doesn't address the issue with `.focused` being removed prematurely by react rerender.

A better solution would be to reactify scrolling logic (by moving the `.focused` class setting, and scrolling logic into comment component).