### PR TITLE
Disables eslint and prettier for docker builds

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /backend
 COPY package*.json ./
 RUN npm install
 COPY . .
+ENV DISABLE_ESLINT_PLUGIN=true
 RUN npm install && npm run build && rm -rf src
 
 FROM node:18

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,6 +13,7 @@ ARG VAPID_PUBLIC_KEY
 ENV REACT_APP_VAPID_PUBLIC_KEY=${VAPID_PUBLIC_KEY}
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
+ENV DISABLE_ESLINT_PLUGIN=true
 RUN npm run build && cp -r build/ /build
 WORKDIR /build
 RUN rm -rf /frontend-build


### PR DESCRIPTION
Currently docker build fails: 
https://github.com/spaceshelter/orbitar/actions/runs/13425988885/job/37508927447

because it's running prettier with default settings.

this is not needed for docker builds, and we have a separate job to lint the code, so disabling it explicitly


### Testing

```
 docker compose -f  docker-compose.local.yml build --no-cache frontend backend
 ```
 
 fails before the change, passes after
 
 also see
[![build-docker](https://github.com/spaceshelter/orbitar/actions/workflows/build-docker-dev.yml/badge.svg?branch=disable-eslint-for-docker-builds)](https://github.com/spaceshelter/orbitar/actions/runs/13426544475)