### PR TITLE
Fix the size of the post rating buttons

### DIFF
--- a/frontend/src/Components/RatingSwitch.module.scss
+++ b/frontend/src/Components/RatingSwitch.module.scss
@@ -1,7 +1,7 @@
-.rating {
+div.rating {
   display: flex;
   align-items: center;
-  font-size: 13px;
+  font-size: 14px;
 
   .value {
     min-width: 32px;


### PR DESCRIPTION
The issue:
<img width="418" alt="Image" src="https://github.com/user-attachments/assets/398a69c5-ea68-4b80-ab04-a50fb9e4029a" />
post rating buttons are shrunk after the recent changes


Root cause:

`RatingSwitch.module.scss` `.rating button`
<img width="342" alt="Image" src="https://github.com/user-attachments/assets/13fb11a2-e26d-433c-a33e-a40afc184a5f" />

and `PostComponent.module.scss` `.controls button` 
<img width="264" alt="Image" src="https://github.com/user-attachments/assets/36cb5f36-7ba1-4374-af10-fff91ab4508b" />
have the same specificity


If worked previously somehow, but after codebase reformatting the order (?) changed, and the issue emerged.

I made `.rating button` more specific and also bumped font size from 13px to 14px, to make it consistent with the font size of the number of comments in the same line.