### PR TITLE
Undo prettier crlf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# images
+*.gif binary
+*.ico binary
+*.png binary
+*.jpg binary

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -8,7 +8,6 @@ tabWidth: 2
 bracketSpacing: true
 bracketSameLine: false
 arrowParens: "always"
-endOfLine: "lf"
 quoteProps: "as-needed"
 plugins:
   - "@ianvs/prettier-plugin-sort-imports"


### PR DESCRIPTION
On Windows `git checkout` converts text file line endings to crlf. Prettier on every local debug run will update all files and complain.
This is not required as git on Windows will automatically convert crlf back to lf on commit. 

This is, however, governed by `git config --local core.autocrlf=true`. 

Instead of asking everyone to set this option, we can configure this in `.gitattributes`.