### PR TITLE
General mechanism that prohibits nesting of certain tags

### DIFF
--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -33,7 +33,7 @@ class ParserExtended extends Parser {
 
 export default class TheParser {
   private readonly allowedTags: Record<string, ((node: Element) => ParseResult) | boolean>
-  private disallowedTagNesting: Record<string, string | string[]>
+  private readonly disallowedTagNesting: Record<string, string | string[]>
 
   // Bump this version when introducing breaking changes to the parser.
   // Content will be re-parsed and saved on access when this version changes.
@@ -43,7 +43,7 @@ export default class TheParser {
   private readonly parserConfig: ParserConfig
   private readonly mediaHostingUrlOrigin: string
   private readonly mediaHostingUrlBunny: string
-  private blockTags: string[]
+  private readonly blockTags: string[]
 
   // Stack of tags that are currently being parsed, for internal use only
   private parseChildNodesStack: string[]

--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -33,6 +33,7 @@ class ParserExtended extends Parser {
 
 export default class TheParser {
   private readonly allowedTags: Record<string, ((node: Element) => ParseResult) | boolean>
+  private disallowedTagNesting: Record<string, string | string[]>
 
   // Bump this version when introducing breaking changes to the parser.
   // Content will be re-parsed and saved on access when this version changes.
@@ -42,6 +43,10 @@ export default class TheParser {
   private readonly parserConfig: ParserConfig
   private readonly mediaHostingUrlOrigin: string
   private readonly mediaHostingUrlBunny: string
+  private blockTags: string[]
+
+  // Stack of tags that are currently being parsed, for internal use only
+  private parseChildNodesStack: string[]
 
   constructor(parserConfig: ParserConfig) {
     this.parserConfig = parserConfig
@@ -68,6 +73,21 @@ export default class TheParser {
       u: true,
       strike: true,
     }
+
+    /* Tags that render as blocks, have special behavior for removing extra line breaks below them */
+    this.blockTags = ['blockquote', 'expand', 'pre']
+
+    /* Child tag -> list of disallowed parent tags */
+    this.disallowedTagNesting = {
+      pre: 'a' /* e.g. `pre` cannot be inside `a`*/,
+      a: 'a',
+      mailbox: ['a', 'mailbox', 'mail'],
+      mail: ['a', 'mailbox', 'mail'],
+      app: ['a', 'mailbox', 'mail'],
+      expand: ['a', 'mailbox', 'mail'],
+    }
+
+    this.parseChildNodesStack = []
   }
 
   private parseDocument(data: string, options?: ParserOptions & DomHandlerOptions): Document {
@@ -86,15 +106,29 @@ export default class TheParser {
       decodeEntities: false,
     })
 
+    this.parseChildNodesStack.length = 0 // clear stack, should not be necessary, but just in case
     const parseResult = this.parseChildNodes(doc.childNodes)
     parseResult.mentions = [...new Set(parseResult.mentions)]
     return parseResult
   }
 
+  private isDisallowedTagNesting(child: string): boolean {
+    const disallowed = this.disallowedTagNesting[child]
+    if (!disallowed) {
+      return false
+    }
+    if (Array.isArray(disallowed)) {
+      for (const parent of disallowed) {
+        if (this.parseChildNodesStack.includes(parent)) return true
+      }
+      return false
+    }
+    return this.parseChildNodesStack.includes(disallowed)
+  }
+
   private parseChildNodes(doc: ChildNode[]): ParseResult {
     const p = { text: '', mentions: [], urls: [], images: [] }
     let prevIsBlock = false // if previous node was block tag
-    const blockTags = ['blockquote', 'expand', 'pre']
     for (let node of doc) {
       if (prevIsBlock && node.type === 'text') {
         // remove a single newline after block tags, allow only a single one if multiple were present
@@ -104,12 +138,22 @@ export default class TheParser {
         } as ChildNode
       }
 
-      const res = this.parseNode(node)
+      const disallowed = node.type === 'tag' && this.isDisallowedTagNesting(node.tagName.toLowerCase())
+
+      if (!disallowed) {
+        this.parseChildNodesStack.push(node.type === 'tag' ? node.tagName.toLowerCase() : 'text')
+      }
+
+      const res = !disallowed ? this.parseNode(node) : this.parseSkippedNode(node)
       p.text += res.text
       p.mentions.push(...res.mentions)
       p.urls.push(...res.urls)
       p.images.push(...res.images)
-      prevIsBlock = node.type === 'tag' && blockTags.includes(node.tagName.toLowerCase())
+      prevIsBlock = node.type === 'tag' && this.blockTags.includes(node.tagName.toLowerCase())
+
+      if (!disallowed) {
+        this.parseChildNodesStack.pop()
+      }
     }
     return p
   }
@@ -387,6 +431,23 @@ export default class TheParser {
     return { ...res, text }
   }
 
+  extractTextRecursive(node: ChildNode): string {
+    if (node.type === 'text') {
+      return node.data
+    }
+    if (node.type === 'tag') {
+      return node.children.map((child) => this.extractTextRecursive(child)).join('')
+    }
+    return ''
+  }
+
+  parseSkippedNode(node: ChildNode): ParseResult {
+    if (node.type === 'tag') {
+      return this.parseChildNodes(node.children)
+    }
+    return { text: '', mentions: [], urls: [], images: [] }
+  }
+
   parseDisallowedTag(node: Element): ParseResult {
     const haveChild = node.children.length > 0
     let text = `<${node.name}`
@@ -406,7 +467,6 @@ export default class TheParser {
     if (!this.validUrl(url)) {
       return this.parseDisallowedTag(node)
     }
-    this.removeInnerMailTagsRec(node)
     const result = this.parseChildNodes(node.children)
     if (result.urls.length > 0 || result.mentions.length > 0) {
       return result
@@ -442,24 +502,6 @@ export default class TheParser {
     }
   }
 
-  removeInnerMailTagsRec(node: Element): Element {
-    // Iterate over all child nodes
-    for (let i = node.children.length - 1; i >= 0; i--) {
-      const child = node.children[i]
-
-      // If the child node is a mailbox tag, remove it
-      if (child.type === 'tag') {
-        if (child.name === 'mailbox' || child.name === 'mail') {
-          node.children.splice(i, 1)
-        } else {
-          // If the child node is not a mailbox tag, recursively call this function
-          this.removeInnerMailTagsRec(child)
-        }
-      }
-    }
-    return node
-  }
-
   static isValidBase64(str: string) {
     const regex = /^[A-Za-z0-9+/]*={0,3}$/
     return regex.test(str)
@@ -489,19 +531,11 @@ export default class TheParser {
     if (!secret || !TheParser.isValidBase64(secret)) {
       return this.parseDisallowedTag(node)
     }
-    this.removeInnerMailTagsRec(node)
 
     const result = this.parseChildNodes(node.children)
-    // render node.children back to html
-    const rawNodes = node.children
-      .map((n) =>
-        render(n, {
-          encodeEntities: false,
-        }),
-      )
-      .join('')
+    const innerText = this.extractTextRecursive(node)
 
-    const rawNodesBase64 = Buffer.from(rawNodes).toString('base64')
+    const rawNodesBase64 = Buffer.from(innerText).toString('base64')
     const text =
       `<span class="i i-mailbox-secure secret-mailbox" data-secret="${secret}" ` +
       `data-raw-text="${rawNodesBase64}">${result.text}</span>`
@@ -514,8 +548,6 @@ export default class TheParser {
     if (!secret || !TheParser.isValidBase64(secret)) {
       return this.parseDisallowedTag(node)
     }
-    this.removeInnerMailTagsRec(node)
-
     const result = this.parseChildNodes(node.children)
 
     const text = `<span class="i i-mail-secure secret-mail" data-secret="${secret}">${result.text}</span>`

--- a/backend/test/parser/TheParser.test.ts
+++ b/backend/test/parser/TheParser.test.ts
@@ -1,436 +1,404 @@
-
-import TheParser from "../../src/parser/TheParser";
+import TheParser from '../../src/parser/TheParser'
 
 const p = new TheParser({
-    mediaHosting: {
-        url: 'https://orbitar.media',
-        dimsAesKey: ''
-    },
-    siteDomain: 'orbitar.local'
-});
+  mediaHosting: {
+    url: 'https://orbitar.media',
+    dimsAesKey: '',
+  },
+  siteDomain: 'orbitar.local',
+})
 
 test('parse A tag', () => {
-    // already encoded
-    expect(
-        p.parse('<a href="https://ru.wikipedia.org/wiki/%D0%A1%D0%BB%D0%B0%D0%B2%D0%B0_%D0%A3%D0%BA%D1%80%D0%B0%D0%B8%D0%BD%D0%B5">тест</a>').text
-    ).toEqual('<a href="https://ru.wikipedia.org/wiki/%D0%A1%D0%BB%D0%B0%D0%B2%D0%B0_%D0%A3%D0%BA%D1%80%D0%B0%D0%B8%D0%BD%D0%B5" target="_blank">тест</a>');
+  // already encoded
+  expect(
+    p.parse(
+      '<a href="https://ru.wikipedia.org/wiki/%D0%A1%D0%BB%D0%B0%D0%B2%D0%B0_%D0%A3%D0%BA%D1%80%D0%B0%D0%B8%D0%BD%D0%B5">тест</a>',
+    ).text,
+  ).toEqual(
+    '<a href="https://ru.wikipedia.org/wiki/%D0%A1%D0%BB%D0%B0%D0%B2%D0%B0_%D0%A3%D0%BA%D1%80%D0%B0%D0%B8%D0%BD%D0%B5" target="_blank">тест</a>',
+  )
 
-    // should be encoded
-    expect(
-        p.parse('<a href="https://ru.wikipedia.org/wiki/42_Дракона_b">тест</a>').text
-    ).toEqual('<a href="https://ru.wikipedia.org/wiki/42_%D0%94%D1%80%D0%B0%D0%BA%D0%BE%D0%BD%D0%B0_b" target="_blank">тест</a>');
+  // should be encoded
+  expect(p.parse('<a href="https://ru.wikipedia.org/wiki/42_Дракона_b">тест</a>').text).toEqual(
+    '<a href="https://ru.wikipedia.org/wiki/42_%D0%94%D1%80%D0%B0%D0%BA%D0%BE%D0%BD%D0%B0_b" target="_blank">тест</a>',
+  )
 
-    // invalid url in A tag
-    expect(
-        p.parse('<a href="http://1.1.1.1.1">t</a>').text
-    ).toEqual('&lt;a href=&quot;http://1.1.1.1.1&quot;&gt;t&lt;/a&gt;');
+  // invalid url in A tag
+  expect(p.parse('<a href="http://1.1.1.1.1">t</a>').text).toEqual(
+    '&lt;a href=&quot;http://1.1.1.1.1&quot;&gt;t&lt;/a&gt;',
+  )
 
-    // invalid url in A tag that is valid if escaped
-    expect(
-        p.parse('<a href="http://1.1.1.1/ 1">t</a>').text
-    ).toEqual('<a href="http://1.1.1.1/%201" target="_blank">t</a>');
-});
+  // invalid url in A tag that is valid if escaped
+  expect(p.parse('<a href="http://1.1.1.1/ 1">t</a>').text).toEqual(
+    '<a href="http://1.1.1.1/%201" target="_blank">t</a>',
+  )
+})
 
 test('detect url in text', () => {
-    expect(
-        p.parse('Hello, \n' +
-            'http://hello.world test\n' +
-            'the end'
-        ).text
-    ).toEqual(
-        'Hello, <br />\n' +
-        '<a href="http://hello.world" target="_blank">http://hello.world</a> test<br />\n' +
-        'the end'
-    );
-});
+  expect(p.parse('Hello, \n' + 'http://hello.world test\n' + 'the end').text).toEqual(
+    'Hello, <br />\n' + '<a href="http://hello.world" target="_blank">http://hello.world</a> test<br />\n' + 'the end',
+  )
+})
 
 test('return valid youtube url', () => {
-  expect(
-      p.parse('https://www.youtube.com/watch?v=aboZctrHfK8'
-      ).text
-  ).toEqual(
-      `<a class="youtube-embed" href="https://www.youtube.com/watch?v=aboZctrHfK8" target="_blank"><img src="https://img.youtube.com/vi/aboZctrHfK8/0.jpg" alt="" data-youtube="https://www.youtube.com/embed/aboZctrHfK8"/></a>`
-  );
-});
+  expect(p.parse('https://www.youtube.com/watch?v=aboZctrHfK8').text).toEqual(
+    `<a class="youtube-embed" href="https://www.youtube.com/watch?v=aboZctrHfK8" target="_blank"><img src="https://img.youtube.com/vi/aboZctrHfK8/0.jpg" alt="" data-youtube="https://www.youtube.com/embed/aboZctrHfK8"/></a>`,
+  )
+})
 
 test('youtube shorts', () => {
-    expect(
-        p.parse('https://youtube.com/shorts/XeZorMhBlzQ?feature=share'
-        ).text
-    ).toEqual(
-        `<a class="youtube-embed" href="https://www.youtube.com/watch?v=XeZorMhBlzQ" target="_blank"><img src="https://img.youtube.com/vi/XeZorMhBlzQ/0.jpg" alt="" data-youtube="https://www.youtube.com/embed/XeZorMhBlzQ"/></a>`
-    );
-});
+  expect(p.parse('https://youtube.com/shorts/XeZorMhBlzQ?feature=share').text).toEqual(
+    `<a class="youtube-embed" href="https://www.youtube.com/watch?v=XeZorMhBlzQ" target="_blank"><img src="https://img.youtube.com/vi/XeZorMhBlzQ/0.jpg" alt="" data-youtube="https://www.youtube.com/embed/XeZorMhBlzQ"/></a>`,
+  )
+})
 
 test('vimeo player embed', () => {
-    expect(
-        p.parse('https://www.vimeo.com/123456789').text
-    ).toEqual(
-        `<a class="vimeo-embed" href="https://vimeo.com/123456789" target="_blank">` +
-        `<img src="https://b.orbitar.media/vimeo/123456789" alt="" data-vimeo="https://player.vimeo.com/video/123456789"/></a>`
-    );
-});
+  expect(p.parse('https://www.vimeo.com/123456789').text).toEqual(
+    `<a class="vimeo-embed" href="https://vimeo.com/123456789" target="_blank">` +
+      `<img src="https://b.orbitar.media/vimeo/123456789" alt="" data-vimeo="https://player.vimeo.com/video/123456789"/></a>`,
+  )
+})
 
 test('vimeo player illegal embed', () => {
-    expect(
-        p.parse('https://vimeo.com/user35789315?embedded=true&source=owner_name&owner=35789315').text
-    ).toEqual(
-        `<a href="https://vimeo.com/user35789315?embedded=true&source=owner_name&owner=35789315" target="_blank">https://vimeo.com/user35789315?embedded=true&amp;source=owner_name&amp;owner=35789315</a>`
-    );
-});
+  expect(p.parse('https://vimeo.com/user35789315?embedded=true&source=owner_name&owner=35789315').text).toEqual(
+    `<a href="https://vimeo.com/user35789315?embedded=true&source=owner_name&owner=35789315" target="_blank">https://vimeo.com/user35789315?embedded=true&amp;source=owner_name&amp;owner=35789315</a>`,
+  )
+})
 
 test('idiod video embed', () => {
-    expect(p.parse('https://idiod.video/8feuw2.mp4').text).toEqual(
-        `<a class="video-embed" href="https://idiod.video/8feuw2.mp4" target="_blank"><img src="https://idiod.video/preview/8feuw2.mp4" alt="" data-video="https://idiod.video/8feuw2.mp4"/></a>`
-    );
-});
+  expect(p.parse('https://idiod.video/8feuw2.mp4').text).toEqual(
+    `<a class="video-embed" href="https://idiod.video/8feuw2.mp4" target="_blank"><img src="https://idiod.video/preview/8feuw2.mp4" alt="" data-video="https://idiod.video/8feuw2.mp4"/></a>`,
+  )
+})
 
 test('orbitar video embed', () => {
-    expect(p.parse('https://orbitar.media/8feuw2.mp4').text).toEqual(
-        `<a class="video-embed" href="https://orbitar.media/8feuw2.mp4" target="_blank"><img src="https://b.orbitar.media/preview/8feuw2.mp4" alt="" data-video="https://b.orbitar.media/8feuw2.mp4/raw"/></a>`
-    );
-});
+  expect(p.parse('https://orbitar.media/8feuw2.mp4').text).toEqual(
+    `<a class="video-embed" href="https://orbitar.media/8feuw2.mp4" target="_blank"><img src="https://b.orbitar.media/preview/8feuw2.mp4" alt="" data-video="https://b.orbitar.media/8feuw2.mp4/raw"/></a>`,
+  )
+})
 
 test('orbitar video embed origin', () => {
-    expect(p.parse('https://origin.orbitar.media/8feuw2.mp4').text).toEqual(
-        `<a class="video-embed" href="https://b.orbitar.media/8feuw2.mp4" target="_blank"><img src="https://b.orbitar.media/preview/8feuw2.mp4" alt="" data-video="https://b.orbitar.media/8feuw2.mp4/raw"/></a>`
-    );
-});
+  expect(p.parse('https://origin.orbitar.media/8feuw2.mp4').text).toEqual(
+    `<a class="video-embed" href="https://b.orbitar.media/8feuw2.mp4" target="_blank"><img src="https://b.orbitar.media/preview/8feuw2.mp4" alt="" data-video="https://b.orbitar.media/8feuw2.mp4/raw"/></a>`,
+  )
+})
 
 test('raw orbitar video embed', () => {
-    expect(p.parse('https://orbitar.media/8feuw2.mp4/raw').text).toEqual(
-        `<a class="video-embed" href="https://orbitar.media/8feuw2.mp4/raw" target="_blank"><img src="https://b.orbitar.media/preview/8feuw2.mp4" alt="" data-video="https://b.orbitar.media/8feuw2.mp4/raw"/></a>`
-    );
-});
+  expect(p.parse('https://orbitar.media/8feuw2.mp4/raw').text).toEqual(
+    `<a class="video-embed" href="https://orbitar.media/8feuw2.mp4/raw" target="_blank"><img src="https://b.orbitar.media/preview/8feuw2.mp4" alt="" data-video="https://b.orbitar.media/8feuw2.mp4/raw"/></a>`,
+  )
+})
 
 test('origin orbitar video embed', () => {
-    expect(p.parse('https://origin.orbitar.media/8feuw2.mp4/raw').text).toEqual(
-        `<a class="video-embed" href="https://b.orbitar.media/8feuw2.mp4/raw" target="_blank"><img src="https://b.orbitar.media/preview/8feuw2.mp4" alt="" data-video="https://b.orbitar.media/8feuw2.mp4/raw"/></a>`
-    );
-});
+  expect(p.parse('https://origin.orbitar.media/8feuw2.mp4/raw').text).toEqual(
+    `<a class="video-embed" href="https://b.orbitar.media/8feuw2.mp4/raw" target="_blank"><img src="https://b.orbitar.media/preview/8feuw2.mp4" alt="" data-video="https://b.orbitar.media/8feuw2.mp4/raw"/></a>`,
+  )
+})
 
 test('mp4 video element', () => {
-    expect(p.parse('<video src="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4">').text).toEqual(
-        `<video  preload="metadata" controls="" width="500"><source src="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4" type="video/mp4"></video>`
-    );
-});
+  expect(
+    p.parse('<video src="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4">')
+      .text,
+  ).toEqual(
+    `<video  preload="metadata" controls="" width="500"><source src="https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/1080/Big_Buck_Bunny_1080_10s_1MB.mp4" type="video/mp4"></video>`,
+  )
+})
 
 test('coub embed', () => {
-    expect(p.parse('https://coub.com/view/1eyshv').text).toEqual(
-        `<a class="coub-embed" href="https://coub.com/view/1eyshv" target="_blank"><img src="https://b.orbitar.media/coub/1eyshv" alt="" data-coub="https://coub.com/embed/1eyshv"/></a>`
-    );
-});
+  expect(p.parse('https://coub.com/view/1eyshv').text).toEqual(
+    `<a class="coub-embed" href="https://coub.com/view/1eyshv" target="_blank"><img src="https://b.orbitar.media/coub/1eyshv" alt="" data-coub="https://coub.com/embed/1eyshv"/></a>`,
+  )
+})
 
 test('strip leading and trailing non-printable chars', () => {
-    const orig = Buffer.from([0x00, 0x01, 0x20, 0x34, 0x32, 0x16, 0x20, 0x0D, 0x0A]).toString('utf8');
-    const parsed = p.parse(orig).text;
-    expect(parsed).toEqual('42');
-});
+  const orig = Buffer.from([0x00, 0x01, 0x20, 0x34, 0x32, 0x16, 0x20, 0x0d, 0x0a]).toString('utf8')
+  const parsed = p.parse(orig).text
+  expect(parsed).toEqual('42')
+})
 
 test('remove line breaks at the beginning and the end', () => {
-    expect(
-        p.parse('Hello, \n' +
-            'world'
-        ).text
-    ).toEqual(
-        'Hello, <br />\n' +
-        'world'
-    );
+  expect(p.parse('Hello, \n' + 'world').text).toEqual('Hello, <br />\n' + 'world')
 
-    expect(
-        p.parse('\nHello, \n' +
-            'world' + '\n'
-        ).text).toEqual(
-        'Hello, <br />\n' +
-        'world'
-    );
+  expect(p.parse('\nHello, \n' + 'world' + '\n').text).toEqual('Hello, <br />\n' + 'world')
 
-    expect(
-        p.parse('\n\n\nHello, \n' +
-            'world' + '\n\n\n'
-        ).text).toEqual(
-        'Hello, <br />\n' +
-        'world'
-    );
-});
+  expect(p.parse('\n\n\nHello, \n' + 'world' + '\n\n\n').text).toEqual('Hello, <br />\n' + 'world')
+})
 
 test('remove extra line break after blockquote tag', () => {
-    expect(
-        p.parse('<blockquote>Hello</blockquote>\nworld'
-        ).text
-    ).toEqual(
-        '<blockquote>Hello</blockquote>world'
-    );
+  expect(p.parse('<blockquote>Hello</blockquote>\nworld').text).toEqual('<blockquote>Hello</blockquote>world')
 
-    expect(
-        p.parse('<blockquote>Hello</blockquote>\n\nworld'
-        ).text
-    ).toEqual(
-        '<blockquote>Hello</blockquote><br />\nworld'
-    );
+  expect(p.parse('<blockquote>Hello</blockquote>\n\nworld').text).toEqual('<blockquote>Hello</blockquote><br />\nworld')
 
-    expect(
-        p.parse('<blockquote>Hello</blockquote>\n\n\nworld'
-        ).text
-    ).toEqual(
-        '<blockquote>Hello</blockquote><br />\nworld'
-    );
+  expect(p.parse('<blockquote>Hello</blockquote>\n\n\nworld').text).toEqual(
+    '<blockquote>Hello</blockquote><br />\nworld',
+  )
 
-    expect(
-        p.parse('<blockquote>Hello\n<blockquote>world</blockquote>\n</blockquote>test').text
-    ).toEqual(
-        '<blockquote>Hello<br />\n<blockquote>world</blockquote></blockquote>test'
-    );
-});
+  expect(p.parse('<blockquote>Hello\n<blockquote>world</blockquote>\n</blockquote>test').text).toEqual(
+    '<blockquote>Hello<br />\n<blockquote>world</blockquote></blockquote>test',
+  )
+})
 
 test('remove extra line break after expand tag', () => {
-    expect(
-        p.parse('<expand title="Brave">New</expand>\nWorld'
-        ).text
-    ).toEqual(
-        '<details class="expand"><summary>Brave</summary>New<div role="button"></div></details>World'
-    );
+  expect(p.parse('<expand title="Brave">New</expand>\nWorld').text).toEqual(
+    '<details class="expand"><summary>Brave</summary>New<div role="button"></div></details>World',
+  )
 
-    expect(
-        p.parse('<expand title="Brave">New</expand>\n\nWorld'
-        ).text
-    ).toEqual(
-        '<details class="expand"><summary>Brave</summary>New<div role="button"></div></details><br />\nWorld'
-    );
+  expect(p.parse('<expand title="Brave">New</expand>\n\nWorld').text).toEqual(
+    '<details class="expand"><summary>Brave</summary>New<div role="button"></div></details><br />\nWorld',
+  )
 
-    expect(
-        p.parse('<expand title="Brave">New</expand>\n\n\nWorld'
-        ).text
-    ).toEqual(
-        '<details class="expand"><summary>Brave</summary>New<div role="button"></div></details><br />\nWorld'
-    );
+  expect(p.parse('<expand title="Brave">New</expand>\n\n\nWorld').text).toEqual(
+    '<details class="expand"><summary>Brave</summary>New<div role="button"></div></details><br />\nWorld',
+  )
 
-    expect(
-        p.parse('<expand title="Hello">World\n<expand title="Brave">New</expand>\n</expand>World'
-        ).text
-    ).toEqual(
-        '<details class="expand"><summary>Hello</summary>World<br />\n<details class="expand"><summary>Brave</summary>New<div role="button"></div></details><div role="button"></div></details>World'
-    );
-
-});
+  expect(p.parse('<expand title="Hello">World\n<expand title="Brave">New</expand>\n</expand>World').text).toEqual(
+    '<details class="expand"><summary>Hello</summary>World<br />\n<details class="expand"><summary>Brave</summary>New<div role="button"></div></details><div role="button"></div></details>World',
+  )
+})
 
 test('unwrap nested links', () => {
-    expect(
-        p.parse('<a href="https://test.com"><a href="https://test.com">test</a></a>').text
-    ).toEqual(
-        '<a href="https://test.com" target="_blank">test</a>'
-    );
+  expect(p.parse('<a href="https://test.com"><a href="https://test.com">test</a></a>').text).toEqual(
+    '<a href="https://test.com" target="_blank">test</a>',
+  )
 
-    expect(
-        p.parse('<a href="https://test.com">https://test2.com</a> test').text
-    ).toEqual(
-        '<a href="https://test2.com" target="_blank">https://test2.com</a> test'
-    );
-});
+  expect(p.parse('<a href="https://test.com">https://test2.com</a> test').text).toEqual(
+    '<a href="https://test2.com" target="_blank">https://test2.com</a> test',
+  )
+})
 
 test('mentions', () => {
-    // `<a href="${encodeURI(`/u/${token.data}`)}" target="_blank" class="mention">${htmlEscape(token.data)}</a>`;
+  // `<a href="${encodeURI(`/u/${token.data}`)}" target="_blank" class="mention">${htmlEscape(token.data)}</a>`;
 
-    function parse(text) {
-        const res = p.parse(text);
-        return [res.text, res.mentions];
-    }
+  function parse(text) {
+    const res = p.parse(text)
+    return [res.text, res.mentions]
+  }
 
-    expect(
-        parse('@test')
-    ).toEqual(
-        ['<a href="/u/test" target="_blank" class="mention">test</a>', ['test']]
-    );
+  expect(parse('@test')).toEqual(['<a href="/u/test" target="_blank" class="mention">test</a>', ['test']])
 
-    expect(
-        parse('@test test')
-    ).toEqual(
-        ['<a href="/u/test" target="_blank" class="mention">test</a> test', ['test']]
-    );
+  expect(parse('@test test')).toEqual(['<a href="/u/test" target="_blank" class="mention">test</a> test', ['test']])
 
-    expect(
-        parse('@test test @test')
-    ).toEqual(
-        ['<a href="/u/test" target="_blank" class="mention">test</a> test <a href="/u/test" target="_blank" class="mention">test</a>', ['test']]
-    );
+  expect(parse('@test test @test')).toEqual([
+    '<a href="/u/test" target="_blank" class="mention">test</a> test <a href="/u/test" target="_blank" class="mention">test</a>',
+    ['test'],
+  ])
 
-    expect(
-        parse('@test test @test1')
-    ).toEqual(
-        ['<a href="/u/test" target="_blank" class="mention">test</a> test <a href="/u/test1" target="_blank" class="mention">test1</a>', ['test', 'test1']]
-    );
+  expect(parse('@test test @test1')).toEqual([
+    '<a href="/u/test" target="_blank" class="mention">test</a> test <a href="/u/test1" target="_blank" class="mention">test1</a>',
+    ['test', 'test1'],
+  ])
 
-    // urls, text, mentions
-    expect(
-        parse('https://test.com @test test')
-    ).toEqual(
-        ['<a href="https://test.com" target="_blank">https://test.com</a> <a href="/u/test" target="_blank" class="mention">test</a> test', ['test']]
-    );
+  // urls, text, mentions
+  expect(parse('https://test.com @test test')).toEqual([
+    '<a href="https://test.com" target="_blank">https://test.com</a> <a href="/u/test" target="_blank" class="mention">test</a> test',
+    ['test'],
+  ])
 
-    // mentions in links take precedence
-    expect(
-        parse('<a href="https://test.com">@test</a>')
-    ).toEqual(
-        ['<a href="/u/test" target="_blank" class="mention">test</a>', ['test']]
-    );
-});
+  // mentions in links take precedence
+  expect(parse('<a href="https://test.com">@test</a>')).toEqual([
+    '<a href="/u/test" target="_blank" class="mention">test</a>',
+    ['test'],
+  ])
+})
 
 test('parse html comment', () => {
-    // returns escaped html comment as text
-    expect(
-        p.parse('<!-- test -->').text
-    ).toEqual('&lt;!-- test --&gt;');
+  // returns escaped html comment as text
+  expect(p.parse('<!-- test -->').text).toEqual('&lt;!-- test --&gt;')
 
-    expect(
-        p.parse('<!-- test -->test').text
-    ).toEqual('&lt;!-- test --&gt;test');
+  expect(p.parse('<!-- test -->test').text).toEqual('&lt;!-- test --&gt;test')
 
-    expect(
-        p.parse('test<!-- test -->').text
-    ).toEqual('test&lt;!-- test --&gt;');
+  expect(p.parse('test<!-- test -->').text).toEqual('test&lt;!-- test --&gt;')
 
-    expect(
-        p.parse('test<!-- test -->test').text
-    ).toEqual('test&lt;!-- test --&gt;test');
+  expect(p.parse('test<!-- test -->test').text).toEqual('test&lt;!-- test --&gt;test')
 
-    expect(
-        p.parse('test<!-- test -->test<!-- test -->test').text
-    ).toEqual('test&lt;!-- test --&gt;test&lt;!-- test --&gt;test');
-
-});
+  expect(p.parse('test<!-- test -->test<!-- test -->test').text).toEqual(
+    'test&lt;!-- test --&gt;test&lt;!-- test --&gt;test',
+  )
+})
 
 test('parse html comment with html tags', () => {
-    expect(
-        p.parse('<!-- <a href="http://test.com">test</a> -->').text
-    ).toEqual('&lt;!-- &lt;a href=&quot;http://test.com&quot;&gt;test&lt;/a&gt; --&gt;');
-});
+  expect(p.parse('<!-- <a href="http://test.com">test</a> -->').text).toEqual(
+    '&lt;!-- &lt;a href=&quot;http://test.com&quot;&gt;test&lt;/a&gt; --&gt;',
+  )
+})
 
 test('parse html directive', () => {
-    // returns escaped html directive as text
-    expect(
-        p.parse('<!DOCTYPE html>').text
-    ).toEqual('&lt;!DOCTYPE html&gt;');
+  // returns escaped html directive as text
+  expect(p.parse('<!DOCTYPE html>').text).toEqual('&lt;!DOCTYPE html&gt;')
 
-    expect(
-        p.parse('<!DOCTYPE html>test').text
-    ).toEqual('&lt;!DOCTYPE html&gt;test');
+  expect(p.parse('<!DOCTYPE html>test').text).toEqual('&lt;!DOCTYPE html&gt;test')
 
-    expect(
-        p.parse('test<!DOCTYPE html>').text
-    ).toEqual('test&lt;!DOCTYPE html&gt;');
+  expect(p.parse('test<!DOCTYPE html>').text).toEqual('test&lt;!DOCTYPE html&gt;')
 
-    expect(
-        p.parse('test<!DOCTYPE html>test').text
-    ).toEqual('test&lt;!DOCTYPE html&gt;test');
+  expect(p.parse('test<!DOCTYPE html>test').text).toEqual('test&lt;!DOCTYPE html&gt;test')
 
-    expect(
-        p.parse('test<!DOCTYPE html>test<!DOCTYPE html>test').text
-    ).toEqual('test&lt;!DOCTYPE html&gt;test&lt;!DOCTYPE html&gt;test');
+  expect(p.parse('test<!DOCTYPE html>test<!DOCTYPE html>test').text).toEqual(
+    'test&lt;!DOCTYPE html&gt;test&lt;!DOCTYPE html&gt;test',
+  )
 
-    expect(
-        p.parse('<?xml version="1.0" encoding="UTF-8"?>').text
-    ).toEqual('&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;');
+  expect(p.parse('<?xml version="1.0" encoding="UTF-8"?>').text).toEqual(
+    '&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;',
+  )
 
-    expect(
-        p.parse('<?xml version="1.0" encoding="UTF-8"?>test').text
-    ).toEqual('&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;test');
+  expect(p.parse('<?xml version="1.0" encoding="UTF-8"?>test').text).toEqual(
+    '&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;test',
+  )
 
-    expect(
-        p.parse('test<?xml version="1.0" encoding="UTF-8"?>').text
-    ).toEqual('test&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;');
-});
+  expect(p.parse('test<?xml version="1.0" encoding="UTF-8"?>').text).toEqual(
+    'test&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;',
+  )
+})
 
 test('parse malformed url', () => {
-    expect(
-        p.parse('<a href="https://test>test</a>%<img src="https://test"/>').text
-    ).toEqual('&lt;a href=&quot;https://test&gt;test&lt;/a&gt;%&lt;img src=&quot; https:=&quot;&quot; test&quot;=&quot;&quot;/&gt;&lt;/a&gt;');
-});
+  expect(p.parse('<a href="https://test>test</a>%<img src="https://test"/>').text).toEqual(
+    '&lt;a href=&quot;https://test&gt;test&lt;/a&gt;%&lt;img src=&quot; https:=&quot;&quot; test&quot;=&quot;&quot;/&gt;&lt;/a&gt;',
+  )
+})
 
 test('parse spoiler tag', () => {
-    expect(p.parse('<spoiler>Hello</spoiler>').text).toEqual(
-        '<span class="spoiler">Hello</span>'
-    );
-});
+  expect(p.parse('<spoiler>Hello</spoiler>').text).toEqual('<span class="spoiler">Hello</span>')
+})
 
 test('parse expand tag', () => {
-    // title
-    expect(p.parse('<expand title="Hello">world</expand>').text).toEqual(
-        '<details class="expand"><summary>Hello</summary>world<div role="button"></div></details>'
-    );
-    // empty title
-    expect(p.parse('<expand>Hello world</expand>').text).toEqual(
-        '<details class="expand"><summary>Открой меня</summary>Hello world<div role="button"></div></details>'
-    );
-});
+  // title
+  expect(p.parse('<expand title="Hello">world</expand>').text).toEqual(
+    '<details class="expand"><summary>Hello</summary>world<div role="button"></div></details>',
+  )
+  // empty title
+  expect(p.parse('<expand>Hello world</expand>').text).toEqual(
+    '<details class="expand"><summary>Открой меня</summary>Hello world<div role="button"></div></details>',
+  )
+})
 
 test('parse secret mailbox with valid secret attribute', () => {
-    const result = p.parse('<mailbox secret="12345">Hello</mailbox>');
-    expect(result.text).toEqual('<span class="i i-mailbox-secure secret-mailbox" data-secret="12345" data-raw-text="SGVsbG8=">Hello</span>');
-});
+  const result = p.parse('<mailbox secret="12345">Hello</mailbox>')
+  expect(result.text).toEqual(
+    '<span class="i i-mailbox-secure secret-mailbox" data-secret="12345" data-raw-text="SGVsbG8=">Hello</span>',
+  )
+})
 
 test('parse secret mailbox without secret attribute', () => {
-    const result = p.parse('<mailbox>Hello</mailbox>');
-    expect(result.text).toEqual('&lt;mailbox&gt;Hello&lt;/mailbox&gt;');
-});
+  const result = p.parse('<mailbox>Hello</mailbox>')
+  expect(result.text).toEqual('&lt;mailbox&gt;Hello&lt;/mailbox&gt;')
+})
 
 test('parse secret mailbox with empty secret attribute', () => {
-    const result = p.parse('<mailbox secret="">Hello</mailbox>');
-    expect(result.text).toEqual('&lt;mailbox secret=&quot;&quot;&gt;Hello&lt;/mailbox&gt;');
-});
+  const result = p.parse('<mailbox secret="">Hello</mailbox>')
+  expect(result.text).toEqual('&lt;mailbox secret=&quot;&quot;&gt;Hello&lt;/mailbox&gt;')
+})
 
 test('parse secret mailbox with nested tags', () => {
-    const result = p.parse('<mailbox secret="12345"><b>Hello</b></mailbox>');
-    expect(result.text).toEqual('<span class="i i-mailbox-secure secret-mailbox" data-secret="12345" data-raw-text="PGI+SGVsbG88L2I+"><b>Hello</b></span>');
-});
+  const result = p.parse('<mailbox secret="12345"><b>Hello</b></mailbox>')
+  expect(result.text).toEqual(
+    '<span class="i i-mailbox-secure secret-mailbox" data-secret="12345" data-raw-text="SGVsbG8="><b>Hello</b></span>',
+  )
+})
 
 test('parse secret mailbox with nested invalid tags', () => {
-    const result = p.parse('<mailbox secret="12345"><invalid>Hello</invalid></mailbox>');
-    expect(result.text).toEqual('<span class="i i-mailbox-secure secret-mailbox" data-secret="12345" data-raw-text="PGludmFsaWQ+SGVsbG88L2ludmFsaWQ+">&lt;invalid&gt;Hello&lt;/invalid&gt;</span>');
-});
+  const result = p.parse('<mailbox secret="12345"><invalid>Hello</invalid></mailbox>')
+  expect(result.text).toEqual(
+    '<span class="i i-mailbox-secure secret-mailbox" data-secret="12345" data-raw-text="SGVsbG8=">&lt;invalid&gt;Hello&lt;/invalid&gt;</span>',
+  )
+})
 
 test('parse secret mailbox with Russian text', () => {
-    const result = p.parse('<mailbox secret="12345">Привет</mailbox>');
-    expect(result.text).toEqual('<span class="i i-mailbox-secure secret-mailbox" data-secret="12345" data-raw-text="0J/RgNC40LLQtdGC">Привет</span>');
-});
+  const result = p.parse('<mailbox secret="12345">Привет</mailbox>')
+  expect(result.text).toEqual(
+    '<span class="i i-mailbox-secure secret-mailbox" data-secret="12345" data-raw-text="0J/RgNC40LLQtdGC">Привет</span>',
+  )
+})
 
 test('parse secret mailbox with nested mailbox', () => {
-    const result = p.parse('<mailbox secret="12345"><mailbox secret="67890">Hello</mailbox></mailbox>');
-    expect(result.text).toEqual('<span class="i i-mailbox-secure secret-mailbox" data-secret="12345" data-raw-text=""></span>');
-});
+  const result = p.parse('<mailbox secret="12345"><mailbox secret="67890">Hello</mailbox></mailbox>')
+  expect(result.text).toEqual(
+    '<span class="i i-mailbox-secure secret-mailbox" data-secret="12345" data-raw-text="SGVsbG8=">Hello</span>',
+  )
+})
+
+test('disallowed tags nesting', () => {
+  // pre cannot be inside a
+  expect(p.parse('<a href="https://test.com"><pre>test</pre></a>').text).toEqual(
+    '<a href="https://test.com" target="_blank">test</a>',
+  )
+
+  // a cannot be inside a
+  expect(p.parse('<a href="https://test.com"><a href="https://test2.com">test</a></a>').text).toEqual(
+    '<a href="https://test.com" target="_blank">test</a>',
+  )
+
+  // mailbox cannot be inside a, mailbox, or mail
+  expect(p.parse('<a href="https://test.com"><mailbox secret="12345">test</mailbox></a>').text).toEqual(
+    '<a href="https://test.com" target="_blank">test</a>',
+  )
+
+  expect(p.parse('<mailbox secret="12345"><mailbox secret="67890">test</mailbox></mailbox>').text).toEqual(
+    '<span class="i i-mailbox-secure secret-mailbox" data-secret="12345" data-raw-text="dGVzdA==">test</span>',
+  )
+
+  expect(p.parse('<mail secret="12345"><mailbox secret="67890">test</mailbox></mail>').text).toEqual(
+    '<span class="i i-mail-secure secret-mail" data-secret="12345">test</span>',
+  )
+
+  // mail cannot be inside a, mailbox, or mail
+  expect(p.parse('<mail secret="12345"><mail secret="67890">test</mail></mail>').text).toEqual(
+    '<span class="i i-mail-secure secret-mail" data-secret="12345">test</span>',
+  )
+
+  // app cannot be inside a, mailbox, or mail
+  expect(p.parse('<a href="https://test.com"><app>test-client-id</app></a>').text).toEqual(
+    '<a href="https://test.com" target="_blank">test-client-id</a>',
+  )
+
+  // expand can be nested in expand
+  expect(p.parse('<expand title="outer"><expand title="inner">test</expand></expand>').text).toEqual(
+    '<details class="expand"><summary>outer</summary><details class="expand"><summary>inner</summary>test<div role="button"></div></details><div role="button"></div></details>',
+  )
+
+  // expand cannot be inside a
+  expect(p.parse('<a href="https://test.com"><expand title="test">test</expand></a>').text).toEqual(
+    '<a href="https://test.com" target="_blank">test</a>',
+  )
+})
 
 test('base64 validation', () => {
-    expect(TheParser.isValidBase64('')).toEqual(true);
-    expect(TheParser.isValidBase64('SGVsbG8')).toEqual(true);
-    expect(TheParser.isValidBase64('SGVsbG8=')).toEqual(true);
-    expect(TheParser.isValidBase64('SGVsbG8==')).toEqual(true);
-    expect(TheParser.isValidBase64('SGVsbG8===')).toEqual(true);
+  expect(TheParser.isValidBase64('')).toEqual(true)
+  expect(TheParser.isValidBase64('SGVsbG8')).toEqual(true)
+  expect(TheParser.isValidBase64('SGVsbG8=')).toEqual(true)
+  expect(TheParser.isValidBase64('SGVsbG8==')).toEqual(true)
+  expect(TheParser.isValidBase64('SGVsbG8===')).toEqual(true)
 
-    expect(TheParser.isValidBase64('=SGVsbG8')).toEqual(false);
-    expect(TheParser.isValidBase64('"SGVsbG8=')).toEqual(false);
-});
+  expect(TheParser.isValidBase64('=SGVsbG8')).toEqual(false)
+  expect(TheParser.isValidBase64('"SGVsbG8=')).toEqual(false)
+})
 
 describe('processInternalUrl', () => {
-    test('valid internal url', () => {
-        const url = 'https://orbitar.local/s/site/p123';
-        const result = p.processInternalUrl(url);
-        expect(result).toEqual('<span role="button" class="expand-button i i-expand" data-post-id="123"></span><a href="https://orbitar.local/s/site/p123" target="_blank">https://orbitar.local/s/site/p123</a>');
-    });
+  test('valid internal url', () => {
+    const url = 'https://orbitar.local/s/site/p123'
+    const result = p.processInternalUrl(url)
+    expect(result).toEqual(
+      '<span role="button" class="expand-button i i-expand" data-post-id="123"></span><a href="https://orbitar.local/s/site/p123" target="_blank">https://orbitar.local/s/site/p123</a>',
+    )
+  })
 
-    test('invalid internal url', () => {
-        const url = 'https://invalid.com/s/site/p123';
-        const result = p.processInternalUrl(url);
-        expect(result).toEqual(false);
-    });
+  test('invalid internal url', () => {
+    const url = 'https://invalid.com/s/site/p123'
+    const result = p.processInternalUrl(url)
+    expect(result).toEqual(false)
+  })
 
-    test('internal url with comment id', () => {
-        const url = 'https://orbitar.local/s/site/p123#456';
-        const result = p.processInternalUrl(url);
-        expect(result).toEqual('<span role="button" class="expand-button i i-expand" data-post-id="123" data-comment-id="456"></span><a href="https://orbitar.local/s/site/p123#456" target="_blank">https://orbitar.local/s/site/p123#456</a>');
-    });
+  test('internal url with comment id', () => {
+    const url = 'https://orbitar.local/s/site/p123#456'
+    const result = p.processInternalUrl(url)
+    expect(result).toEqual(
+      '<span role="button" class="expand-button i i-expand" data-post-id="123" data-comment-id="456"></span><a href="https://orbitar.local/s/site/p123#456" target="_blank">https://orbitar.local/s/site/p123#456</a>',
+    )
+  })
 
-    test('internal url without comment id', () => {
-        const url = 'https://orbitar.local/s/site/p123';
-        const result = p.processInternalUrl(url);
-        expect(result).toEqual('<span role="button" class="expand-button i i-expand" data-post-id="123"></span><a href="https://orbitar.local/s/site/p123" target="_blank">https://orbitar.local/s/site/p123</a>');
-    });
-});
+  test('internal url without comment id', () => {
+    const url = 'https://orbitar.local/s/site/p123'
+    const result = p.processInternalUrl(url)
+    expect(result).toEqual(
+      '<span role="button" class="expand-button i i-expand" data-post-id="123"></span><a href="https://orbitar.local/s/site/p123" target="_blank">https://orbitar.local/s/site/p123</a>',
+    )
+  })
+})


### PR DESCRIPTION
Previously there was an ad-hoc functionality that removed nesting of mailboxes (in `removeInnerMailTagsRec`).

This PR adds a more general mechanism for prohibiting nesting of certain tags, and adds more rules, like `app` inside of `a`, or `pre` inside of `a`.

### Testing

manual + unit tests