### PR TITLE
Add cache clearing for oauth apps cards

### DIFF
--- a/frontend/src/API/AuthAPIHelper.ts
+++ b/frontend/src/API/AuthAPIHelper.ts
@@ -29,6 +29,7 @@ export default class AuthAPIHelper {
       await this.api.signOut()
       this.appState.setUserInfo(undefined)
       this.appState.setAppLoadingState(AppLoadingState.unauthorized)
+      this.appState.clearCachesOnLogout()
     } catch (error) {
       console.log('ERROR SIGN IN', error)
       throw new Error('Could not sign out')
@@ -49,6 +50,7 @@ export default class AuthAPIHelper {
       await this.api.dropPasswordAndSessions()
       this.appState.setUserInfo(undefined)
       this.appState.setAppLoadingState(AppLoadingState.unauthorized)
+      this.appState.clearCachesOnLogout()
     } catch (error) {
       console.log('ERROR DROPPING PASSWORD AND SESSIONS', error)
       throw error

--- a/frontend/src/API/OAuth2Api.ts
+++ b/frontend/src/API/OAuth2Api.ts
@@ -131,6 +131,10 @@ export default class OAuth2Api {
     return this.batchedCache.getClient(clientId)
   }
 
+  clearClientCache() {
+    this.batchedCache.clearCache()
+  }
+
   async getClientsBatch(clientIds: string[]): Promise<OAuth2GetClientsBatchResponse> {
     return await this.api.request<OAuth2GetClientsBatchRequest, OAuth2GetClientsBatchResponse>(
       `/oauth2/clients-batch`,
@@ -262,6 +266,13 @@ class OAuthClientBatchedCache {
     }, this.debounceTime)
 
     return prom
+  }
+
+  /**
+   * Clear the cache
+   */
+  public clearCache() {
+    this.cache.clear()
   }
 
   /**

--- a/frontend/src/AppState/AppState.tsx
+++ b/frontend/src/AppState/AppState.tsx
@@ -114,6 +114,10 @@ export class AppState {
         this.userInfo = value;
     }
 
+    clearCachesOnLogout() {
+        this.api.oauth2Api.clearClientCache()
+    }
+
     @action
     setUserRestrictions(value: UserRestrictionsResponse) {
         this.userRestrictions = value;

--- a/frontend/src/Components/OAuth2AppCardModalComponent.tsx
+++ b/frontend/src/Components/OAuth2AppCardModalComponent.tsx
@@ -160,13 +160,12 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
       const authWindow = window.open(client.initialAuthorizationUrl, '_blank')
       if (authWindow) {
         const handleFocus = () => {
-          window.removeEventListener('focus', handleFocus)
           api.oauth2Api.clearClientCache()
           api.oauth2Api.getClientCached(client.clientId).then((updatedClient) => {
             props.onClientUpdate?.(updatedClient)
           })
         }
-        window.addEventListener('focus', handleFocus)
+        window.addEventListener('focus', handleFocus, { once: true })
       }
     }
   }

--- a/frontend/src/Components/OAuth2AppCardModalComponent.tsx
+++ b/frontend/src/Components/OAuth2AppCardModalComponent.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, useState } from 'react'
+import React, { MouseEventHandler, useEffect, useState } from 'react'
 
 import classNames from 'classnames'
 import { confirmAlert } from 'react-confirm-alert'
@@ -34,16 +34,26 @@ export function OAuthEmbeddedAppComponent(props: OAuthEmbeddedAppComponentProps)
   const appState = useAppState()
   const [client, setClient] = React.useState<OAuth2ClientEntity | null>(null)
   const [error, setError] = React.useState<string | null>(null)
+  const [openFullView, setOpenFullView] = React.useState(false)
 
-  const handleFullView = () => {
-    client &&
+  useEffect(() => {
+    if (client && openFullView) {
       appState.setModal(
         <OAuth2AppCardModalComponent
           client={client}
           disallowEditing={true}
-          onClose={() => appState.setModal(undefined)}
+          onClose={() => {
+            appState.setModal(undefined)
+            setOpenFullView(false)
+          }}
+          onClientUpdate={setClient}
         />,
       )
+    }
+  }, [client, openFullView])
+
+  const handleFullView = () => {
+    setOpenFullView(true)
   }
 
   React.useEffect(() => {
@@ -147,7 +157,17 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
 
   const handleInstallClick = () => {
     if (client.initialAuthorizationUrl) {
-      window.open(client.initialAuthorizationUrl, '_blank')
+      const authWindow = window.open(client.initialAuthorizationUrl, '_blank')
+      if (authWindow) {
+        const handleFocus = () => {
+          window.removeEventListener('focus', handleFocus)
+          api.oauth2Api.clearClientCache()
+          api.oauth2Api.getClientCached(client.clientId).then((updatedClient) => {
+            props.onClientUpdate?.(updatedClient)
+          })
+        }
+        window.addEventListener('focus', handleFocus)
+      }
     }
   }
 

--- a/frontend/src/Components/OAuth2AppCardModalComponent.tsx
+++ b/frontend/src/Components/OAuth2AppCardModalComponent.tsx
@@ -137,6 +137,7 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
     api.oauth2Api
       .updateClientLogo(client.clientId, url)
       .then(() => {
+        api.oauth2Api.clearClientCache()
         props.onClientUpdate?.({ ...client, logoUrl: url })
       })
       .catch(() => {
@@ -174,6 +175,7 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
       api.oauth2Api
         .unauthorizeClient(client.clientId)
         .then((updatedClient) => {
+          api.oauth2Api.clearClientCache()
           props.onClientUpdate?.(updatedClient)
         })
         .catch(() => {
@@ -192,6 +194,7 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
               <UserProfileClientAppsCreateForm
                 editingClient={client}
                 onClientEditSuccess={(newClient) => {
+                  api.oauth2Api.clearClientCache()
                   props.onClientUpdate?.(newClient)
                   setEditing(false)
                 }}


### PR DESCRIPTION
fixes minor bugs:
1. when logging out / in without page refresh the embedded app cards showed installation status for the previous user
2. make sure that embedded app cards reflect the latest changes made in settings


additionally, install / uninstall now updates the app state, and even the embedded app card:

https://github.com/user-attachments/assets/224cf0f1-bcd4-443d-a5b1-8125f61ccfda

