### PR TITLE
Distinguish between NULL and empty scope

### DIFF
--- a/backend/src/api/OAuth2Controller.ts
+++ b/backend/src/api/OAuth2Controller.ts
@@ -111,7 +111,7 @@ const updateLogoUrlSchema = Joi.object<OAuth2ClientUpdateLogoUrlRequest>({
 })
 
 const verifyScopesSchema = Joi.object({
-  scopes: Joi.string().required(),
+  scopes: Joi.string().required().allow(''),
 })
 
 export default class OAuth2Controller {

--- a/backend/src/db/repositories/OAuth2Repository.ts
+++ b/backend/src/db/repositories/OAuth2Repository.ts
@@ -190,7 +190,7 @@ export default class OAuth2Repository {
   async resetConsentScope(clientId: string, userId: number): Promise<boolean> {
     return await this.db
       .query<ResultSetHeader>(
-        `update oauth_consents set scope = '' where user_id = :user_id and client_id = :client_id`,
+        `update oauth_consents set scope = NULL where user_id = :user_id and client_id = :client_id`,
         { user_id: userId, client_id: clientId },
       )
       .then((result) => result.affectedRows > 0)

--- a/backend/src/db/repositories/OAuth2Repository.ts
+++ b/backend/src/db/repositories/OAuth2Repository.ts
@@ -12,7 +12,7 @@ export default class OAuth2Repository {
       oauth_clients.*,
       oauth_consents.scope as scopes,
       oauth_consents.last_revoked_ts as last_revoked_ts,
-      (select count(oauth_consents.user_id) from oauth_consents where client_id = oauth_clients.client_id and scope != '') as installations_count 
+      (select count(oauth_consents.user_id) from oauth_consents where client_id = oauth_clients.client_id and scope is not NULL) as installations_count 
     from oauth_clients
     left outer join oauth_consents
       on oauth_consents.client_id = oauth_clients.client_id
@@ -206,7 +206,7 @@ export default class OAuth2Repository {
               SELECT 1 as cnt
               FROM oauth_consents
               WHERE user_id = :userId
-                AND scope != ''
+                AND scope IS NOT NULL
               LIMIT 1) as t`,
       { userId },
     )

--- a/backend/src/managers/OAuth2Manager.ts
+++ b/backend/src/managers/OAuth2Manager.ts
@@ -164,7 +164,7 @@ export default class OAuth2Manager {
       userId: client.user_id,
       logoUrl: client.logo_url,
       author,
-      scopes: client.scopes,
+      scopes: client.scopes === null ? undefined : client.scopes,
       installationsCount: client.installations_count,
     } as OAuth2ClientEntity
   }

--- a/frontend/src/Components/OAuth2AppCardModalComponent.tsx
+++ b/frontend/src/Components/OAuth2AppCardModalComponent.tsx
@@ -95,6 +95,7 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
   const [editing, setEditing] = useState(false)
   const embedCode = `<app>${client.clientId}</app>`
   const shouldShowManagementControls = client.author.id === userId && !props.disallowEditing
+  const authorized = client.scopes !== null && client.scopes !== undefined
 
   const confirmAction = (title: string, message: string, action: () => void) => {
     confirmAlert({
@@ -144,7 +145,8 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
       })
   }
 
-  const handleInstallClick = () => {
+  const handleInstallClick: MouseEventHandler = (e) => {
+    e.preventDefault()
     if (client.initialAuthorizationUrl) {
       window.open(client.initialAuthorizationUrl, '_blank')
     }
@@ -166,7 +168,8 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
     )
   }
 
-  const handleUnInstallClick = () => {
+  const handleUnInstallClick: MouseEventHandler = (e) => {
+    e.preventDefault()
     const message = `Вы уверены, что хотите отключить приложение (отозвать его авторизацию)?
              Это действие отзовет весь доступ, ранее данный вами приложению.
             В принципе, это не страшно, можно подключить его потом снова.`
@@ -261,7 +264,7 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
           </ExpandSection>
         )}
 
-        {client.scopes && (
+        {authorized && (
           <ExpandSection title='Текушие разрешения'>
             <OAuth2ScopesComponent appRequests={client.scopes} />
           </ExpandSection>
@@ -274,10 +277,10 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
                 onClick={handleInstallClick}
                 className={classNames(buttonStyles.settingsButton, buttonStyles.positiveButton, buttonStyles.bigger)}
               >
-                Подключить {client.scopes ? 'еще раз' : ''}
+                Подключить {authorized ? 'еще раз' : ''}
               </button>
             )}
-            {client.scopes && (
+            {authorized && (
               <button
                 onClick={handleUnInstallClick}
                 className={classNames(buttonStyles.settingsButton, buttonStyles.danger, buttonStyles.bigger)}

--- a/frontend/src/Components/OAuth2ScopesComponent.tsx
+++ b/frontend/src/Components/OAuth2ScopesComponent.tsx
@@ -15,7 +15,7 @@ function ScopeControl(props: { name: string; description: string; checked: boole
   )
 }
 
-export default function OAuth2ScopesComponent(props: { appRequests: string | null }) {
+export default function OAuth2ScopesComponent(props: { appRequests: string | undefined }) {
   const [scopes, setScopes] = useState<Record<string, string> | undefined>(undefined)
   const { oauth2Api } = useAPI()
 
@@ -31,6 +31,7 @@ export default function OAuth2ScopesComponent(props: { appRequests: string | nul
 
   return (
     <div className={styles.container}>
+      {Object.keys(scopes).length === 0 && <div>Только ваш номер и юзернейм.</div>}
       {Object.keys(scopes).map((scope) => (
         <ScopeControl key={scope} name={scope} checked={true} description={scopes[scope]} />
       ))}


### PR DESCRIPTION
### Problem

Currently when empty scope is requested, it looks weird:
<img width="495" alt="image" src="https://github.com/user-attachments/assets/962cbc3f-21a1-44ba-82b7-c6753ba32ac2" />

Additionally, the app UX counts the empty authorization scope as "no authorization" that is wrong.

### Changes

This PR changes the invariant of the `scope` field in DB. NULL now means "no authorization", and "" (empty text) means minimal authorization: id and username (basically, just perpetuate tokens with oauth flow and read info in them).


<img width="464" alt="Image" src="https://github.com/user-attachments/assets/f73158de-4681-462a-90db-78ceb0689cbe" />

<img width="540" alt="Image" src="https://github.com/user-attachments/assets/e0ff8dee-7a4c-4f72-ae19-37c0546d9aab" />