### PR TITLE
Clear user cache when removing votes from the user with low karma

### DIFF
--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -367,6 +367,7 @@ export default class UserManager {
     const karmaVotes = await this.voteRepository.getVotesByUser(userId)
     for (const vote of karmaVotes) {
       await this.voteRepository.userSetVote(vote.userId, 0, vote.voterId)
+      this.userCache.clearCache(vote.voterId)
     }
     await this.redis.set(`remove_votes_when_karma_is_low_${userId}`, 'true')
     await this.redis.expire(


### PR DESCRIPTION
reported by the user, the cached karma value and the actual (retrieved by clicking on the rating switch) is different
