### PR TITLE
Remove excessive user info from oauth endpoint results

### DIFF
--- a/backend/src/api/types/entities/OAuth2ClientEntity.ts
+++ b/backend/src/api/types/entities/OAuth2ClientEntity.ts
@@ -1,4 +1,4 @@
-import { UserInfo } from '../../../managers/types/UserInfo'
+import { UserBaseEntity } from './UserEntity'
 
 export type OAuth2ClientEntity = {
   name: string
@@ -11,7 +11,7 @@ export type OAuth2ClientEntity = {
   redirectUris: string
   grants: string
   userId: number
-  author: UserInfo
+  author: UserBaseEntity
   scopes?: string
   installationsCount?: number
 }

--- a/backend/src/managers/OAuth2Manager.ts
+++ b/backend/src/managers/OAuth2Manager.ts
@@ -163,7 +163,7 @@ export default class OAuth2Manager {
       grants: client.grants,
       userId: client.user_id,
       logoUrl: client.logo_url,
-      author,
+      author: { id: author.id, username: author.username, gender: author.gender },
       scopes: client.scopes === null ? undefined : client.scopes,
       installationsCount: client.installations_count,
     } as OAuth2ClientEntity

--- a/frontend/src/Types/OAuth2.ts
+++ b/frontend/src/Types/OAuth2.ts
@@ -1,4 +1,4 @@
-import { UserInfo } from './UserInfo'
+import { UserBaseInfo } from './UserInfo'
 
 export type OAuth2ClientEntity = {
   id: number
@@ -11,7 +11,7 @@ export type OAuth2ClientEntity = {
   initialAuthorizationUrl: string
   redirectUris: string
   grants: string[]
-  author: UserInfo
+  author: UserBaseInfo
   scopes?: string
   installationsCount?: number
 }


### PR DESCRIPTION
Reduces the user info that is passed with oauth clients to the bare minimum.

There is no reason to pass things like full bio.