### PR TITLE
ez: Restrict width of the full oauth authorization form

### DIFF
--- a/frontend/src/Components/OAuth2AppCardModalComponent.module.scss
+++ b/frontend/src/Components/OAuth2AppCardModalComponent.module.scss
@@ -11,6 +11,8 @@
   background: var(--bg);
   padding: 24px;
 
+  max-width: 500px;
+
   display: flex;
   flex-direction: column;
   align-items: stretch;


### PR DESCRIPTION
Before:
<img width="1424" alt="Image" src="https://github.com/user-attachments/assets/c01739c7-9410-4ae5-ac4b-c3352724cc4a" />

After:
<img width="1427" alt="Image" src="https://github.com/user-attachments/assets/b0a1ec03-9156-4755-86e6-97b99bbb7870" />