### PR TITLE
Split lintstaged into eslint and prettier

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -79,6 +79,10 @@
     "winston": "^3.7.2"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,scss,css}": "npx eslint --fix"
+    "*.{js,jsx,ts,tsx}": [
+      "npx eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,scss,css}": "prettier --write"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,6 +86,10 @@
     ]
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,scss,css}": "npx eslint --fix"
+    "*.{js,jsx,ts,tsx}": [
+      "npx eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,scss,css}": "prettier --write"
   }
 }


### PR DESCRIPTION
Noticed that `eslint --fix` fails for `scss` files.

Thus splitting the lint-staged config into:
* "*.{js,jsx,ts,tsx}" (runs eslint that includes prettier)
* "*.{json,scss,css}" only runs prettier

### Test

tested locally by modifying all relevant files