### PR TITLE
Posts by "karmadead" authors are not bumped in the main feed, only in watch feed

### DIFF
--- a/backend/src/api/PostController.ts
+++ b/backend/src/api/PostController.ts
@@ -392,16 +392,27 @@ export default class PostController {
         )
       }
 
+      const postAuthorId = await this.postManager.getUserIdByPostId(postId)
+      const postAuthorRestrictions = await this.userManager.getUserRestrictions(postAuthorId)
+
       const overrideUserId = (await this.postManager.getUserIdOverride(postId)) || userId
 
-      const doFanOutAndNotifications = userRestrictions.restrictedToPostId === false
+      // feed bump when post author is not fully karmadead
+      const bumpFeed = postAuthorRestrictions.restrictedToPostId === false
+
+      // send notifications when commenter is not fully karmadead
+      const sendNotifications = userRestrictions.restrictedToPostId === false
+
       const commentInfo = await this.postManager.createComment(
         overrideUserId,
         postId,
         parentCommentId,
         content,
         format,
-        doFanOutAndNotifications,
+        {
+          bumpFeed,
+          sendNotifications,
+        },
       )
       const {
         allComments: [comment],

--- a/backend/src/managers/PostManager.ts
+++ b/backend/src/managers/PostManager.ts
@@ -289,10 +289,14 @@ export default class PostManager {
     parentCommentId: number | undefined,
     content: string,
     format: ContentFormat,
-    fanOutAndNotifications = true,
+    notificationOptions: {
+      bumpFeed: boolean
+      sendNotifications: boolean
+    },
   ): Promise<CommentInfoWithPostData> {
     const parseResult = this.parser.parse(content)
     const language = await this.translationManager.detectLanguage('', parseResult.text)
+    const { bumpFeed, sendNotifications } = notificationOptions
 
     const commentRaw = await this.commentRepository.createComment(
       userId,
@@ -301,11 +305,11 @@ export default class PostManager {
       content,
       language,
       parseResult.text,
-      fanOutAndNotifications,
+      bumpFeed,
     )
     this.userManager.clearUserRestrictionsCache(userId)
 
-    if (fanOutAndNotifications) {
+    if (sendNotifications) {
       let parentAuthor: UserInfo | undefined
       if (parentCommentId) {
         const parentComment = await this.commentRepository.getComment(parentCommentId)
@@ -335,7 +339,7 @@ export default class PostManager {
         commentRaw.post_id,
         undefined,
         commentRaw.created_at,
-        /*onlyDbUpdate=*/ !fanOutAndNotifications,
+        /*onlyDbUpdate=*/ !bumpFeed, // note, currently this will update Watch feed (bookmarks) in any case!
       )
       .then()
       .catch()


### PR DESCRIPTION
Posts by "karmadead" authors are not bumped in the main feed, only in the watch feeds of individual users.

Notifications and mentions, on the other hand, depend on **who** writes the comment, regardless of the post

### Testing

Tested locally by commenting and mentioning from the regular users and "karmadead users".


### Note
<details>
<summary>even with fanOutAndNotifications=false, the post will still be bumped in the Watch feed</summary>

Based on my research, I can confirm that even with fanOutAndNotifications=false, the post will still be bumped in the Watch feed. Here's why:

  1. How the code flows:
    - PostManager.createComment calls FeedManager.postFanOut with onlyDbUpdate=true when fanOutAndNotifications=false
    - In FeedManager.postFanOut, when onlyDbUpdate=true, it still creates and executes dbUpdateJob if updatedAt is provided
    - The dbUpdateJob calls BookmarkRepository.setUpdated(post_id, updatedAt)
    - BookmarkRepository.setUpdated updates the post_updated_at field in the user_bookmarks table
  2. The Watch feed query:
  ```
  SELECT p.*, v.vote, b.read_comments, b.bookmark, b.last_read_comment_id, b.watch, (p.comments - b.read_comments) AS cnt
  FROM user_bookmarks b
  JOIN posts p ON (p.post_id = b.post_id)
  LEFT JOIN post_votes v ON (v.post_id = p.post_id AND v.voter_id = 11)
  WHERE b.user_id = 11 AND watch = 1
  HAVING cnt > 0
  ORDER BY b.post_updated_at DESC
  ```
  2. This query sorts by b.post_updated_at DESC, which is the field that gets updated by BookmarkRepository.setUpdated.
  3. What onlyDbUpdate=true does:
    - It prevents updating the feed API (lines 409-414, 422-429)
    - It does NOT prevent updating the user_bookmarks table (lines 416-420, 431-433)

  Therefore, even with fanOutAndNotifications=false (which sets onlyDbUpdate=true), posts will still be bumped in the Watch feed because:
  - user_bookmarks.post_updated_at still gets updated
  - The Watch feed query sorts by this updated timestamp

  This could be unintended behavior if the goal is to completely prevent post bumping for barmalini user comments on certain posts.
</details>