### PR TITLE
Rework how notifications counts are displayed

### DIFF
--- a/backend/src/api/types/requests/PostRead.ts
+++ b/backend/src/api/types/requests/PostRead.ts
@@ -7,7 +7,7 @@ export type PostReadRequest = {
 export type PostReadResponse = {
   notifications?: {
     unread: number
-    visible: number
+    visible: boolean
   }
   watch?: {
     posts: number

--- a/backend/src/api/types/requests/Status.ts
+++ b/backend/src/api/types/requests/Status.ts
@@ -10,6 +10,6 @@ export type StatusResponse = {
   }
   notifications: {
     unread: number
-    visible: number
+    visible: boolean
   }
 }

--- a/backend/src/db/repositories/NotificationsRepository.ts
+++ b/backend/src/db/repositories/NotificationsRepository.ts
@@ -20,14 +20,14 @@ export default class NotificationsRepository {
     return parseInt(result?.cnt || '0')
   }
 
-  async getVisibleNotificationsCount(forUserId: number): Promise<number> {
+  async hasVisibleNotifications(forUserId: number): Promise<boolean> {
     const result = await this.db.fetchOne<{ cnt: string }>(
-      'select count(*) cnt from notifications where user_id=:user_id and hidden=0',
+      `select 1 as cnt from notifications where user_id=:user_id and hidden=0 limit 1`,
       {
         user_id: forUserId,
       },
     )
-    return parseInt(result?.cnt || '0')
+    return !!result?.cnt
   }
 
   async getNotifications(forUserId: number, limit = 20): Promise<NotificationRaw[]> {

--- a/backend/src/db/repositories/UserRepository.ts
+++ b/backend/src/db/repositories/UserRepository.ts
@@ -205,15 +205,14 @@ export default class UserRepository {
   async getUserUnreadComments(forUserId: number, ownOnly = false): Promise<number> {
     const res = await this.db.fetchOne<{ cnt: string }>(
       `
-          select sum(case when p.comments > ub.read_comments then 1 else 0 end) cnt
-            from
-              user_bookmarks ub
-              join posts p on (p.post_id = ub.post_id)
-            where
-              ub.user_id = :user_id
-              and watch = 1
+          select count(*) cnt
+          from user_bookmarks ub
+                   join posts p on (p.post_id = ub.post_id)
+          where ub.user_id = :user_id
+            and watch = 1
+            and p.comments > ub.read_comments
               ${ownOnly ? 'and p.author_id = :user_id' : ''}
-        `,
+      `,
       {
         user_id: forUserId,
       },

--- a/backend/src/db/repositories/UserRepository.ts
+++ b/backend/src/db/repositories/UserRepository.ts
@@ -199,10 +199,13 @@ export default class UserRepository {
     )
   }
 
+  /**
+   * Returns the number of unread watched posts for the user.
+   */
   async getUserUnreadComments(forUserId: number, ownOnly = false): Promise<number> {
     const res = await this.db.fetchOne<{ cnt: string }>(
       `
-          select sum(p.comments - ub.read_comments) cnt
+          select sum(case when p.comments > ub.read_comments then 1 else 0 end) cnt
             from
               user_bookmarks ub
               join posts p on (p.post_id = ub.post_id)

--- a/backend/src/managers/NotificationManager.ts
+++ b/backend/src/managers/NotificationManager.ts
@@ -62,9 +62,9 @@ export default class NotificationManager {
     return this.siteManagerLazy()
   }
 
-  async getNotificationsCounts(forUserId: number): Promise<{ unread: number; visible: number }> {
+  async getNotificationsCounts(forUserId: number): Promise<{ unread: number; visible: boolean }> {
     const unread = this.notificationsRepository.getUnreadNotificationsCount(forUserId)
-    const visible = this.notificationsRepository.getVisibleNotificationsCount(forUserId)
+    const visible = this.notificationsRepository.hasVisibleNotifications(forUserId)
     return { unread: await unread, visible: await visible }
   }
 

--- a/backend/src/managers/types/UserInfo.ts
+++ b/backend/src/managers/types/UserInfo.ts
@@ -23,7 +23,7 @@ export type UserInfo = UserBaseInfo & {
 export type UserStats = {
   notifications: {
     unread: number
-    visible: number
+    visible: boolean
   }
   watch: {
     posts: number

--- a/frontend/src/API/APIHelper.ts
+++ b/frontend/src/API/APIHelper.ts
@@ -101,7 +101,7 @@ export default class APIHelper {
     this.appState.setUserInfo(status.user)
     this.appState.setWatchCommentsCount(status.watch.comments)
     this.appState.setUnreadNotificationsCount(status.notifications.unread)
-    this.appState.setVisibleNotificationsCount(status.notifications.visible)
+    this.appState.setVisibleNotifications(status.notifications.visible)
     this.appState.setAppLoadingState(AppLoadingState.authorized)
     this.appState.setLatestHash(fingerprint || '')
   }

--- a/frontend/src/API/AuthAPI.ts
+++ b/frontend/src/API/AuthAPI.ts
@@ -10,7 +10,7 @@ export type StatusResponse = {
   }
   notifications: {
     unread: number
-    visible: number
+    visible: boolean
   }
 }
 

--- a/frontend/src/API/PostAPI.ts
+++ b/frontend/src/API/PostAPI.ts
@@ -153,7 +153,7 @@ type PostReadRequest = {
 type PostReadResponse = {
   notifications?: {
     unread: number
-    visible: number
+    visible: boolean
   }
   watch?: {
     comments: number

--- a/frontend/src/API/PostAPIHelper.ts
+++ b/frontend/src/API/PostAPIHelper.ts
@@ -204,7 +204,7 @@ export default class PostAPIHelper {
     const result = await this.postAPI.read(postId, comments, lastCommentId)
     if (result.watch !== undefined && result.notifications !== undefined) {
       this.appState.setUnreadNotificationsCount(result.notifications.unread)
-      this.appState.setVisibleNotificationsCount(result.notifications.visible)
+      this.appState.setVisibleNotifications(result.notifications.visible)
       this.appState.setWatchCommentsCount(result.watch.comments)
     }
     return result

--- a/frontend/src/AppState/AppState.tsx
+++ b/frontend/src/AppState/AppState.tsx
@@ -55,7 +55,7 @@ export class AppState {
     unreadNotificationsCount = 0;
 
     @observable
-    visibleNotificationsCount = 0;
+    visibleNotifications = false;
 
     @observable
     watchCommentsCount = 0;
@@ -138,8 +138,8 @@ export class AppState {
         this.unreadNotificationsCount = value;
     }
     @action
-    setVisibleNotificationsCount(value: number) {
-        this.visibleNotificationsCount = value;
+    setVisibleNotifications(value: boolean) {
+        this.visibleNotifications = value;
     }
 
     @action

--- a/frontend/src/Components/NotificationsPopup.tsx
+++ b/frontend/src/Components/NotificationsPopup.tsx
@@ -108,8 +108,9 @@ export default function NotificationsPopup(props: NotificationsPopupProps) {
     if (!ntInfo.read) {
       app.setUnreadNotificationsCount(app.unreadNotificationsCount - 1)
     }
-    app.setVisibleNotificationsCount(app.visibleNotificationsCount - 1)
-    setNotifications(notifications?.filter((n) => n.id !== ntInfo.id))
+    const remainingNotifications = notifications?.filter((n) => n.id !== ntInfo.id)
+    app.setVisibleNotifications(!!remainingNotifications?.length)
+    setNotifications(remainingNotifications)
   }
 
   const handleClearAll = () => {
@@ -119,7 +120,7 @@ export default function NotificationsPopup(props: NotificationsPopupProps) {
     setNotifications(filteredNotifications)
 
     const remainingCount = filteredNotifications?.length || 0
-    app.setVisibleNotificationsCount(remainingCount)
+    app.setVisibleNotifications(!!remainingCount)
     app.setUnreadNotificationsCount(remainingCount)
 
     api.notifications

--- a/frontend/src/Components/Topbar.tsx
+++ b/frontend/src/Components/Topbar.tsx
@@ -124,30 +124,32 @@ const CreateButton = observer(() => {
 
 const WatchButton = observer(() => {
   const { watchCommentsCount } = useAppState()
+
+  let label = ''
+  if (watchCommentsCount > 0) {
+    label = watchCommentsCount > 99 ? '99+' : `${watchCommentsCount}`
+  }
+
   return (
     <ReloadingLink to={'/watch'} className={watchCommentsCount > 0 ? styles.active : ''}>
       <HotIcon />
-      <span className={styles.label}>{watchCommentsCount > 0 ? watchCommentsCount : ''}</span>
+      <span className={styles.label}>{label}</span>
     </ReloadingLink>
   )
 })
 
 const NotificationsButton = observer((props: React.ComponentPropsWithRef<'button'>) => {
-  const { unreadNotificationsCount, visibleNotificationsCount } = useAppState()
+  const { unreadNotificationsCount, visibleNotifications } = useAppState()
 
   let label = ''
-  if (visibleNotificationsCount > 0) {
-    if (unreadNotificationsCount > 0 && unreadNotificationsCount !== visibleNotificationsCount) {
-      label = `${unreadNotificationsCount}/${visibleNotificationsCount}`
-    } else {
-      label = `${visibleNotificationsCount}`
-    }
+  if (visibleNotifications && unreadNotificationsCount > 0) {
+    label = unreadNotificationsCount > 9 ? '9+' : `${unreadNotificationsCount}`
   }
 
   return (
     <button
       {...props}
-      disabled={visibleNotificationsCount === 0}
+      disabled={!visibleNotifications && !unreadNotificationsCount}
       className={classNames({ [styles.active]: unreadNotificationsCount })}
     >
       <NotificationIcon />


### PR DESCRIPTION
<img width="237" alt="Image" src="https://github.com/user-attachments/assets/672fd758-6069-45cb-96c8-dcb354a5241f" />

Changes:
* show only unread notifications count
* show only unread watched **posts** count
* cap notifications at 9, watched posts at 99

This better aligns with people usage patterns (half of the users don't bother cleaning the counters) and removed useless information from the topbar, making space for another icon (leaderboards).