### PR TITLE
Replace react-confirm-alert with our own component

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,7 +36,6 @@
         "react": "^18.0.0",
         "react-app-rewired": "^2.2.1",
         "react-circular-progressbar": "^2.1.0",
-        "react-confirm-alert": "^3.0.6",
         "react-dom": "^18.0.0",
         "react-hook-form": "^7.29.0",
         "react-hotkeys-hook": "^4.3.8",
@@ -14744,15 +14743,6 @@
       "integrity": "sha512-xp4THTrod4aLpGy68FX/k1Q3nzrfHUjUe5v6FsdwXBl3YVMwgeXYQKDrku7n/D6qsJA9CuunarAboC2xCiKs1g==",
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-confirm-alert": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-3.0.6.tgz",
-      "integrity": "sha512-rplP6Ed9ZSNd0KFV5BUzk4EPQ77BxsrayllBXGFuA8xPXc7sbBjgU5KUrNpl7aWFmP7mXRlVXfuy1IT5DbffYw==",
-      "peerDependencies": {
-        "react": ">=18.0.0",
-        "react-dom": ">=10.0.0"
       }
     },
     "node_modules/react-dev-utils": {
@@ -29640,12 +29630,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.1.0.tgz",
       "integrity": "sha512-xp4THTrod4aLpGy68FX/k1Q3nzrfHUjUe5v6FsdwXBl3YVMwgeXYQKDrku7n/D6qsJA9CuunarAboC2xCiKs1g==",
-      "requires": {}
-    },
-    "react-confirm-alert": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-3.0.6.tgz",
-      "integrity": "sha512-rplP6Ed9ZSNd0KFV5BUzk4EPQ77BxsrayllBXGFuA8xPXc7sbBjgU5KUrNpl7aWFmP7mXRlVXfuy1IT5DbffYw==",
       "requires": {}
     },
     "react-dev-utils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,6 @@
     "react": "^18.0.0",
     "react-app-rewired": "^2.2.1",
     "react-circular-progressbar": "^2.1.0",
-    "react-confirm-alert": "^3.0.6",
     "react-dom": "^18.0.0",
     "react-hook-form": "^7.29.0",
     "react-hotkeys-hook": "^4.3.8",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -82,6 +82,7 @@ const ModalContainer = observer(() => {
     <>
       {appState.modal}
       {appState.mediaUploaderModal}
+      {appState.confirmDialogModal}
     </>
   )
 })

--- a/frontend/src/AppState/AppState.tsx
+++ b/frontend/src/AppState/AppState.tsx
@@ -9,6 +9,7 @@ import {createBrowserHistory} from 'history';
 import {RouterStore} from '@superwf/mobx-react-router';
 import {UserRestrictionsResponse} from '../API/UserAPI';
 import MediaUploader, {MediaUploaderProps} from '../Components/MediaUploader';
+import ConfirmDialog, {ConfirmDialogProps} from '../Components/ConfirmDialog';
 
 export enum AppLoadingState {
     loading,
@@ -74,6 +75,9 @@ export class AppState {
 
     @observable
     mediaUploaderModal: ReactElement<MediaUploaderProps> | undefined = undefined;
+
+    @observable
+    confirmDialogModal: ReactElement<ConfirmDialogProps> | undefined = undefined;
 
     browserHistory = createBrowserHistory();
     router = new RouterStore(this.browserHistory);
@@ -171,6 +175,11 @@ export class AppState {
     }
 
     @action
+    setConfirmDialog(value: ReactElement<ConfirmDialogProps> | undefined) {
+        this.confirmDialogModal = value;
+    }
+
+    @action
     mediaUploader(
         props: MediaUploaderProps
     ) {
@@ -194,6 +203,30 @@ export class AppState {
     @action
     closeMediaUploader() {
         this.mediaUploaderModal = undefined;
+    }
+
+    confirmAlert = (options: Omit<ConfirmDialogProps, 'onCancel'> & { onCancel?: () => void }): Promise<boolean> => {
+        return new Promise<boolean>((resolve) => {
+            this.setConfirmDialog(
+                <ConfirmDialog
+                    {...options}
+                    onConfirm={() => {
+                        this.setConfirmDialog(undefined);
+                        if (options.onConfirm) {
+                            options.onConfirm();
+                        }
+                        resolve(true);
+                    }}
+                    onCancel={() => {
+                        this.setConfirmDialog(undefined);
+                        if (options.onCancel) {
+                            options.onCancel();
+                        }
+                        resolve(false);
+                    }}
+                />
+            );
+        });
     }
 }
 

--- a/frontend/src/Components/ConfirmDialog.module.scss
+++ b/frontend/src/Components/ConfirmDialog.module.scss
@@ -77,7 +77,7 @@
 .primaryButton {
   border: none;
   background: var(--primary);
-  color: var(--onAccent, #fff);
+  color: var(--onAccent);
 
   &:hover {
     background: var(--primaryHover);
@@ -86,18 +86,18 @@
 
 .secondaryButton {
   border: none;
-  background: var(--fgSoftest, rgba(255, 255, 255, 0.1));
+  background: var(--fgSoftest);
   color: var(--fg);
 
   &:hover {
-    background: var(--fgSofter, rgba(255, 255, 255, 0.2));
+    background: var(--fgSofter);
   }
 }
 
 .dangerButton {
   border: none;
   background: var(--danger);
-  color: var(--onAccent, #fff);
+  color: var(--onAccent);
 
   &:hover {
     background: var(--dangerHover);
@@ -110,6 +110,6 @@
   color: var(--fg);
 
   &:hover {
-    background: var(--dim1, rgba(255, 255, 255, 0.05));
+    background: var(--dim1);
   }
 }

--- a/frontend/src/Components/ConfirmDialog.module.scss
+++ b/frontend/src/Components/ConfirmDialog.module.scss
@@ -39,30 +39,47 @@
     border-radius: 4px;
     font-weight: bold;
     cursor: pointer;
-    border: none;
-    background: var(--primary);
-    color: var(--onAccent, #fff);
     transition: background-color 0.2s ease;
+  }
+}
 
-    &:hover {
-      background: var(--primaryHover);
-    }
+/* Button types */
+.primaryButton {
+  border: none;
+  background: var(--primary);
+  color: var(--onAccent, #fff);
 
-    &.cancel {
-      background: var(--fgSoftest, rgba(255, 255, 255, 0.1));
-      color: var(--fg);
+  &:hover {
+    background: var(--primaryHover);
+  }
+}
 
-      &:hover {
-        background: var(--fgSofter, rgba(255, 255, 255, 0.2));
-      }
-    }
+.secondaryButton {
+  border: none;
+  background: var(--fgSoftest, rgba(255, 255, 255, 0.1));
+  color: var(--fg);
 
-    &.danger {
-      background: var(--danger);
+  &:hover {
+    background: var(--fgSofter, rgba(255, 255, 255, 0.2));
+  }
+}
 
-      &:hover {
-        background: var(--dangerHover);
-      }
-    }
+.dangerButton {
+  border: none;
+  background: var(--danger);
+  color: var(--onAccent, #fff);
+
+  &:hover {
+    background: var(--dangerHover);
+  }
+}
+
+.ghostButton {
+  border: 1px solid var(--inactive-fg);
+  background: transparent;
+  color: var(--fg);
+
+  &:hover {
+    background: var(--dim1, rgba(255, 255, 255, 0.05));
   }
 }

--- a/frontend/src/Components/ConfirmDialog.module.scss
+++ b/frontend/src/Components/ConfirmDialog.module.scss
@@ -1,0 +1,68 @@
+.container {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--bg);
+  box-shadow: 0 4px 8px var(--shadow);
+  border: 1px solid var(--inactive-fg);
+  border-radius: 4px;
+  padding: 20px;
+  max-width: 500px;
+  width: 90%;
+  z-index: 10000;
+  text-align: center;
+}
+
+.title {
+  margin-top: 0;
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 15px;
+  color: var(--primary);
+}
+
+.message {
+  margin-bottom: 20px;
+  line-height: 1.5;
+  color: var(--fg);
+}
+
+.buttons {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+
+  button {
+    padding: 8px 16px;
+    border-radius: 4px;
+    font-weight: bold;
+    cursor: pointer;
+    border: none;
+    background: var(--primary);
+    color: var(--onAccent, #fff);
+    transition: background-color 0.2s ease;
+
+    &:hover {
+      background: var(--primaryHover);
+    }
+
+    &.cancel {
+      background: var(--fgSoftest, rgba(255, 255, 255, 0.1));
+      color: var(--fg);
+
+      &:hover {
+        background: var(--fgSofter, rgba(255, 255, 255, 0.2));
+      }
+    }
+
+    &.danger {
+      background: var(--danger);
+
+      &:hover {
+        background: var(--dangerHover);
+      }
+    }
+  }
+}

--- a/frontend/src/Components/ConfirmDialog.module.scss
+++ b/frontend/src/Components/ConfirmDialog.module.scss
@@ -1,3 +1,25 @@
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -48%);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+}
+
+@keyframes scaleIn {
+  from {
+    transform: scale(0.95);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
 .container {
   position: fixed;
   top: 50%;
@@ -12,6 +34,14 @@
   width: 90%;
   z-index: 10000;
   text-align: center;
+
+  /* Animation */
+  animation: fadeIn 0.25s ease-out;
+
+  /* Apply scale animation to content inside */
+  & > * {
+    animation: scaleIn 0.25s ease-out;
+  }
 }
 
 .title {

--- a/frontend/src/Components/ConfirmDialog.tsx
+++ b/frontend/src/Components/ConfirmDialog.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import Overlay from './Overlay'
+
+import styles from './ConfirmDialog.module.scss'
+
+export interface ConfirmDialogProps {
+  title?: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  onConfirm?: () => void
+  onCancel: () => void
+  confirmButtonClassName?: string
+  cancelButtonClassName?: string
+}
+
+export default function ConfirmDialog(props: ConfirmDialogProps) {
+  const {
+    title = 'Астанавитесь!',
+    message,
+    confirmLabel = 'Да!',
+    cancelLabel = 'Отмена',
+    onConfirm,
+    onCancel,
+    confirmButtonClassName = '',
+    cancelButtonClassName = 'cancel',
+  } = props
+
+  return (
+    <>
+      <Overlay onClick={onCancel} zIndex={9999} />
+      <div className={styles.container}>
+        {title && <h2 className={styles.title}>{title}</h2>}
+        <div className={styles.message}>{message}</div>
+        <div className={styles.buttons}>
+          <button className={confirmButtonClassName} onClick={onConfirm}>
+            {confirmLabel}
+          </button>
+          <button className={cancelButtonClassName} onClick={onCancel}>
+            {cancelLabel}
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/Components/ConfirmDialog.tsx
+++ b/frontend/src/Components/ConfirmDialog.tsx
@@ -4,6 +4,15 @@ import Overlay from './Overlay'
 
 import styles from './ConfirmDialog.module.scss'
 
+export const BUTTON_TYPES = {
+  primary: styles.primaryButton,
+  secondary: styles.secondaryButton,
+  danger: styles.dangerButton,
+  ghost: styles.ghostButton,
+} as const
+
+export type ButtonType = keyof typeof BUTTON_TYPES
+
 export interface ConfirmDialogProps {
   title?: string
   message: string
@@ -11,8 +20,8 @@ export interface ConfirmDialogProps {
   cancelLabel?: string
   onConfirm?: () => void
   onCancel: () => void
-  confirmButtonClassName?: string
-  cancelButtonClassName?: string
+  confirmButtonType?: ButtonType
+  cancelButtonType?: ButtonType
 }
 
 export default function ConfirmDialog(props: ConfirmDialogProps) {
@@ -23,8 +32,8 @@ export default function ConfirmDialog(props: ConfirmDialogProps) {
     cancelLabel = 'Отмена',
     onConfirm,
     onCancel,
-    confirmButtonClassName = '',
-    cancelButtonClassName = 'cancel',
+    confirmButtonType = 'danger',
+    cancelButtonType = 'secondary',
   } = props
 
   return (
@@ -34,10 +43,10 @@ export default function ConfirmDialog(props: ConfirmDialogProps) {
         {title && <h2 className={styles.title}>{title}</h2>}
         <div className={styles.message}>{message}</div>
         <div className={styles.buttons}>
-          <button className={confirmButtonClassName} onClick={onConfirm}>
+          <button className={BUTTON_TYPES[confirmButtonType]} onClick={onConfirm}>
             {confirmLabel}
           </button>
-          <button className={cancelButtonClassName} onClick={onCancel}>
+          <button className={BUTTON_TYPES[cancelButtonType]} onClick={onCancel}>
             {cancelLabel}
           </button>
         </div>

--- a/frontend/src/Components/OAuth2AppCardModalComponent.tsx
+++ b/frontend/src/Components/OAuth2AppCardModalComponent.tsx
@@ -105,15 +105,6 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
   const embedCode = `<app>${client.clientId}</app>`
   const shouldShowManagementControls = client.author.id === userId && !props.disallowEditing
   const authorized = client.scopes !== null && client.scopes !== undefined
-
-  const confirmAction = async (title: string, message: string, action: () => void) => {
-    await confirmAlert({
-      title,
-      message,
-      onConfirm: action,
-    })
-  }
-
   const handleClientEdit: MouseEventHandler = (e) => {
     e.preventDefault()
     setEditing(true)
@@ -121,12 +112,11 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
 
   const handleClientSecretUpdate: MouseEventHandler = (e) => {
     e.preventDefault()
-    confirmAction(
-      'Астанавитесь!',
-      `Вы точно хотите сгенерировать новый секрет (client_secret) приложения? Это действие необратимо. 
+    confirmAlert({
+      message: `Вы точно хотите сгенерировать новый секрет (client_secret) приложения? Это действие необратимо. 
                 Новые авторизации, исользующие старый секрет, не будут работать.
                 Но токены, выданные ранее, работать продолжат.`,
-      () => {
+      onConfirm: () => {
         api.oauth2Api
           .regenerateClientSecret(client.clientId)
           .then((data) => {
@@ -136,7 +126,7 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
             toast.error('Failed to regenerate client secret')
           })
       },
-    )
+    })
   }
 
   const handleNewLogo = (url: string) => {
@@ -169,37 +159,40 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
 
   const handleClientDelete: MouseEventHandler = (e) => {
     e.preventDefault()
-    const message = 'Вы уверены, что хотите удалить приложение? Это необратимое действие.'
-    confirmAction('Астанавитесь!', message, () =>
-      api.oauth2Api
-        .deleteClient(client.clientId)
-        .then(() => {
-          props.onClientDelete?.(client.clientId)
-          props.onClose()
-        })
-        .catch(() => {
-          toast.error('Не удалось удалить приложение')
-        }),
-    )
+    confirmAlert({
+      message: 'Вы уверены, что хотите удалить приложение? Это необратимое действие.',
+      onConfirm: () => {
+        api.oauth2Api
+          .deleteClient(client.clientId)
+          .then(() => {
+            props.onClientDelete?.(client.clientId)
+            props.onClose()
+          })
+          .catch(() => {
+            toast.error('Не удалось удалить приложение')
+          })
+      },
+    })
   }
 
   const handleUnInstallClick: MouseEventHandler = async (e) => {
     e.preventDefault()
-    console.log('Uninstalling app')
-    const message = `Вы уверены, что хотите отключить приложение (отозвать его авторизацию)?
+    confirmAlert({
+      message: `Вы уверены, что хотите отключить приложение (отозвать его авторизацию)?
              Это действие отзовет весь доступ, ранее данный вами приложению.
-            В принципе, это не страшно, можно подключить его потом снова.`
-    await confirmAction('Астанавитесь!', message, () =>
-      api.oauth2Api
-        .unauthorizeClient(client.clientId)
-        .then((updatedClient) => {
-          api.oauth2Api.clearClientCache()
-          props.onClientUpdate?.(updatedClient)
-        })
-        .catch(() => {
-          toast.error('Не удалось отключить приложение')
-        }),
-    )
+            В принципе, это не страшно, можно подключить его потом снова.`,
+      onConfirm: () => {
+        api.oauth2Api
+          .unauthorizeClient(client.clientId)
+          .then((updatedClient) => {
+            api.oauth2Api.clearClientCache()
+            props.onClientUpdate?.(updatedClient)
+          })
+          .catch(() => {
+            toast.error('Не удалось отключить приложение')
+          })
+      },
+    })
   }
 
   if (editing) {

--- a/frontend/src/Components/OAuth2AppCardModalComponent.tsx
+++ b/frontend/src/Components/OAuth2AppCardModalComponent.tsx
@@ -1,7 +1,6 @@
 import React, { MouseEventHandler, useEffect, useState } from 'react'
 
 import classNames from 'classnames'
-import { confirmAlert } from 'react-confirm-alert'
 import { FaEdit, FaKey, FaLink, FaTrash } from 'react-icons/fa'
 import { toast } from 'react-toastify'
 
@@ -99,7 +98,7 @@ interface OAuth2AppCardModalProps {
 
 export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
   const api = useAPI()
-  const { userInfo } = useAppState()
+  const { userInfo, confirmAlert } = useAppState()
   const userId = userInfo?.id
   const { client, onClientSecretUpdate } = props
   const [editing, setEditing] = useState(false)
@@ -107,15 +106,11 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
   const shouldShowManagementControls = client.author.id === userId && !props.disallowEditing
   const authorized = client.scopes !== null && client.scopes !== undefined
 
-  const confirmAction = (title: string, message: string, action: () => void) => {
-    confirmAlert({
+  const confirmAction = async (title: string, message: string, action: () => void) => {
+    await confirmAlert({
       title,
       message,
-      buttons: [
-        { label: 'Yes', onClick: action },
-        { label: 'Cancel', className: 'cancel' },
-      ],
-      overlayClassName: 'orbitar-confirm-overlay',
+      onConfirm: action,
     })
   }
 
@@ -188,12 +183,13 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
     )
   }
 
-  const handleUnInstallClick: MouseEventHandler = (e) => {
+  const handleUnInstallClick: MouseEventHandler = async (e) => {
     e.preventDefault()
+    console.log('Uninstalling app')
     const message = `Вы уверены, что хотите отключить приложение (отозвать его авторизацию)?
              Это действие отзовет весь доступ, ранее данный вами приложению.
             В принципе, это не страшно, можно подключить его потом снова.`
-    confirmAction('Астанавитесь!', message, () =>
+    await confirmAction('Астанавитесь!', message, () =>
       api.oauth2Api
         .unauthorizeClient(client.clientId)
         .then((updatedClient) => {

--- a/frontend/src/Components/Overlay.module.scss
+++ b/frontend/src/Components/Overlay.module.scss
@@ -1,11 +1,24 @@
+@keyframes overlayFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 .overlay {
   width: 100vw;
   height: 100vh;
   background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
   display: block;
   position: fixed;
   z-index: 999;
   content: '';
   left: 0;
   top: 0;
+
+  /* Animation */
+  animation: overlayFadeIn 0.2s ease-out;
 }

--- a/frontend/src/Components/UserProfileInvites.tsx
+++ b/frontend/src/Components/UserProfileInvites.tsx
@@ -1,30 +1,25 @@
 import React, { useEffect, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 
+import classNames from 'classnames'
 import { observer } from 'mobx-react-lite'
 import moment from 'moment'
 import plural from 'plural-ru'
-import { confirmAlert } from 'react-confirm-alert'
 import { toast } from 'react-toastify'
 
 import { InviteEntity, InvitesAvailability } from '../API/InviteAPI'
+import { useRestrictions } from '../API/use/useRestrictions'
 import { useAPI, useAppState } from '../AppState/AppState'
 import { CommentInfo } from '../Types/PostInfo'
 import ContentComponent from './ContentComponent'
 import CreateCommentComponent from './CreateCommentComponent'
+import DateComponent from './DateComponent' // Import css
 import Username from './Username'
 
 import createPostStyles from '../Pages/CreatePostPage.module.css'
 import commentStyles from './CommentComponent.module.scss'
 import styles from './UserProfileInvites.module.scss'
 import karmaStyles from './UserProfileKarma.module.scss'
-
-import 'react-confirm-alert/src/react-confirm-alert.css'
-
-import classNames from 'classnames'
-
-import { useRestrictions } from '../API/use/useRestrictions'
-import DateComponent from './DateComponent' // Import css
 
 type UserProfileInvitesProps = {
   username: string
@@ -354,21 +349,14 @@ type ConfirmButtonProps = {
 }
 
 const ConfirmButton = (props: ConfirmButtonProps) => {
-  const handleConfirm = () => {
-    confirmAlert({
+  const appState = useAppState()
+  const handleConfirm = async () => {
+    await appState.confirmAlert({
       title: 'Астанавитесь!',
-      message: props.message,
-      buttons: [
-        {
-          label: 'Да!',
-          onClick: () => props.onAction(),
-        },
-        {
-          label: 'Отмена',
-          className: 'cancel',
-        },
-      ],
-      overlayClassName: 'orbitar-confirm-overlay',
+      message: props.message || '',
+      confirmLabel: 'Да!',
+      cancelLabel: 'Отмена',
+      onConfirm: () => props.onAction(),
     })
   }
 

--- a/frontend/src/Components/UserProfileInvites.tsx
+++ b/frontend/src/Components/UserProfileInvites.tsx
@@ -352,10 +352,7 @@ const ConfirmButton = (props: ConfirmButtonProps) => {
   const appState = useAppState()
   const handleConfirm = async () => {
     await appState.confirmAlert({
-      title: 'Астанавитесь!',
       message: props.message || '',
-      confirmLabel: 'Да!',
-      cancelLabel: 'Отмена',
       onConfirm: () => props.onAction(),
     })
   }

--- a/frontend/src/Components/UserProfileSettings.tsx
+++ b/frontend/src/Components/UserProfileSettings.tsx
@@ -3,7 +3,6 @@ import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 import classNames from 'classnames'
 import { observer } from 'mobx-react-lite'
-import { confirmAlert } from 'react-confirm-alert'
 import { toast } from 'react-toastify'
 
 import { useUserProfile } from '../API/use/useUserProfile'
@@ -58,6 +57,7 @@ export function getLegacyZoom(): boolean {
 export function getPreferredLang(): string {
   return localStorage.getItem('preferredLang') || 'ru'
 }
+
 export function getShowInlineTranslateButton(): boolean {
   return localStorage.getItem('showInlineTranslateButton') === 'true'
 }
@@ -70,6 +70,7 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
   const api = useAPI()
   const navigate = useNavigate()
   const location = useLocation()
+  const { confirmAlert } = useAppState()
 
   let gender = props.gender
 
@@ -78,23 +79,22 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
   const [preferredLang, setPreferredLang] = useState<string>(getPreferredLang())
   const [showInlineTranslateButton, setShowInlineTranslateButton] = useState<boolean>(getShowInlineTranslateButton())
 
-  const confirmWrapper = (message: string, callback: () => void) => (e: React.MouseEvent) => {
+  const confirmWrapper = (message: string, callback: () => void) => async (e: React.MouseEvent) => {
     e.preventDefault()
-    confirmAlert({
+
+    // Use our new AppState confirmAlert API
+    const confirmed = await confirmAlert({
       title: 'Астанавитесь! Подумайте!',
       message,
-      buttons: [
-        {
-          label: 'Да!',
-          onClick: callback,
-        },
-        {
-          label: 'Отмена',
-          className: 'cancel',
-        },
-      ],
-      overlayClassName: 'orbitar-confirm-overlay',
+      confirmLabel: 'Да!',
+      cancelLabel: 'Отмена',
+      onConfirm: callback,
     })
+
+    // Alternative: if you want to use the callback directly when confirmed
+    if (confirmed) {
+      // callback(); // Uncomment if you remove the onConfirm above
+    }
   }
 
   const handleLogout = confirmWrapper(
@@ -313,39 +313,30 @@ const BarmaliniAccess = observer(() => {
  */
 export const MailboxSettings = observer(() => {
   const api = useAPI()
-  const { userInfo } = useAppState()
+  const { userInfo, confirmAlert } = useAppState()
   const [state, refreshProfile] = useUserProfile(userInfo?.username || '')
   const publicKey = state.status === 'ready' && state.profile.publicKey
   const [creatingMailbox, setCreatingMailbox] = React.useState(false)
   const [revealPublicKey, setRevealPublicKey] = React.useState(false)
 
-  const handleDelete = (e: React.MouseEvent) => {
+  const handleDelete = async (e: React.MouseEvent) => {
     e.preventDefault()
-    confirmAlert({
+    await confirmAlert({
       title: 'Астанавитесь! Подумайте!',
       message:
         'Вы действительно хотите удалить почтовый ящик? Вы больше не сможете получать новые шифровки, ' +
         'но вы сможете читать старые шифровки, адресованные вам.',
-      buttons: [
-        {
-          label: 'Да!',
-          onClick: () => {
-            api.userAPI
-              .savePublicKey('')
-              .then(() => {
-                refreshProfile()
-              })
-              .catch((error) => {
-                toast.error(error?.message || 'Не удалось удалить почтовый ящик.')
-              })
-          },
-        },
-        {
-          label: 'Отмена',
-          className: 'cancel',
-        },
-      ],
-      overlayClassName: 'orbitar-confirm-overlay',
+      confirmLabel: 'Да!',
+      onConfirm: () => {
+        api.userAPI
+          .savePublicKey('')
+          .then(() => {
+            refreshProfile()
+          })
+          .catch((error) => {
+            toast.error(error?.message || 'Не удалось удалить почтовый ящик.')
+          })
+      },
     })
   }
 

--- a/frontend/src/Components/UserProfileSettings.tsx
+++ b/frontend/src/Components/UserProfileSettings.tsx
@@ -82,19 +82,10 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
   const confirmWrapper = (message: string, callback: () => void) => async (e: React.MouseEvent) => {
     e.preventDefault()
 
-    // Use our new AppState confirmAlert API
-    const confirmed = await confirmAlert({
-      title: 'Астанавитесь! Подумайте!',
+    await confirmAlert({
       message,
-      confirmLabel: 'Да!',
-      cancelLabel: 'Отмена',
       onConfirm: callback,
     })
-
-    // Alternative: if you want to use the callback directly when confirmed
-    if (confirmed) {
-      // callback(); // Uncomment if you remove the onConfirm above
-    }
   }
 
   const handleLogout = confirmWrapper(
@@ -322,11 +313,9 @@ export const MailboxSettings = observer(() => {
   const handleDelete = async (e: React.MouseEvent) => {
     e.preventDefault()
     await confirmAlert({
-      title: 'Астанавитесь! Подумайте!',
       message:
         'Вы действительно хотите удалить почтовый ящик? Вы больше не сможете получать новые шифровки, ' +
         'но вы сможете читать старые шифровки, адресованные вам.',
-      confirmLabel: 'Да!',
       onConfirm: () => {
         api.userAPI
           .savePublicKey('')

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -267,38 +267,3 @@ body::-webkit-scrollbar-thumb {
     box-shadow: inset 0 0 14px 14px var(--fgSoftest);
   }
 }
-
-.react-confirm-alert-overlay.orbitar-confirm-overlay {
-  z-index: 2000;
-  background: linear-gradient(0deg, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5));
-  backdrop-filter: blur(5px);
-  background-size: cover;
-
-  .react-confirm-alert-body {
-    background-color: var(--elevated);
-    color: var(--fg);
-
-    button {
-      background: var(--danger);
-      border: none;
-      border-radius: 4px;
-      padding: 8px 16px;
-      font-weight: bold;
-      cursor: pointer;
-      &:hover {
-        background: var(--dangerHover);
-      }
-      &:disabled {
-        background: var(--primaryGhost);
-        color: var(--onAccentGhost);
-        cursor: default;
-      }
-      &.cancel {
-        background: var(--fgSoftest);
-        &:hover {
-          background: var(--fgSofter);
-        }
-      }
-    }
-  }
-}


### PR DESCRIPTION
Reimplements `react-confirm-alert` with a simple component, better integrated into our app structure. The result is cleaner and smaller.

**Main purpose**: fixes the scroll bug (described in discord).

Demo:

https://github.com/user-attachments/assets/1181535a-13c0-421e-80c5-00ac0363bcc0

---

Demo of the bug (previous behavior, notice the scroll to the top after click on the button):


https://github.com/user-attachments/assets/a906f503-ec1a-46a5-8403-e58a314bfca5


---


### Testing
---

Manually tested all usages of the `confirmAlert`: oauth apps, invites, logout
