### PR TITLE
Fix Topbar shifting when modal/noscroll is shown

### DIFF
--- a/frontend/src/Components/Topbar.module.scss
+++ b/frontend/src/Components/Topbar.module.scss
@@ -3,6 +3,7 @@
   position: fixed;
   right: 0;
   left: 0;
+  width: calc(100% - var(--scrollbar-compensation, 0px));
 
   display: flex;
   align-items: center;
@@ -19,6 +20,10 @@
     display: flex;
     gap: 16px;
     pointer-events: auto;
+  }
+
+  .right {
+    padding-right: 28px;
   }
 
   //:global{ }

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -2,6 +2,10 @@
 
 // TODO add css reset
 
+:root {
+  --scrollbar-width: 16px;
+}
+
 html {
   overflow-y: scroll;
 }
@@ -237,6 +241,7 @@ iframe.low-rating {
 html.no-scroll {
   overflow: hidden;
   margin-right: 16px;
+  --scrollbar-compensation: 16px;
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
when `useNoScroll` is invoked (usually when modals are shown), the Topbar currently shifts to the right, which is annoying. This fixes it.


before / after demo:

https://github.com/user-attachments/assets/c7f309a4-3552-402d-8ab1-46f1255431e8

