### PR TITLE
An attempt to fix self closing tags inside <pre>

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -25,7 +25,7 @@
         "express-winston": "^4.2.0",
         "helmet": "^5.0.2",
         "html-escaper": "^3.0.3",
-        "htmlparser2": "^8.0.0",
+        "htmlparser2": "^10.0.0",
         "install": "^0.13.0",
         "joi": "^17.6.0",
         "jsonwebtoken": "^9.0.2",
@@ -2885,13 +2885,14 @@
       }
     },
     "node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
+        "domhandler": "^5.0.3"
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -4015,9 +4016,9 @@
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
     },
     "node_modules/htmlparser2": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -4025,11 +4026,24 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "entities": "^4.3.0"
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http_ece": {
@@ -12345,13 +12359,13 @@
       }
     },
     "domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "requires": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
+        "domhandler": "^5.0.3"
       }
     },
     "dotenv": {
@@ -13205,14 +13219,21 @@
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
     },
     "htmlparser2": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
       "requires": {
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "entities": "^4.3.0"
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+          "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw=="
+        }
       }
     },
     "http_ece": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -60,7 +60,7 @@
     "express-winston": "^4.2.0",
     "helmet": "^5.0.2",
     "html-escaper": "^3.0.3",
-    "htmlparser2": "^8.0.0",
+    "htmlparser2": "^10.0.0",
     "install": "^0.13.0",
     "joi": "^17.6.0",
     "jsonwebtoken": "^9.0.2",

--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -503,7 +503,13 @@ export default class TheParser {
 
   parsePre(node: Element): ParseResult {
     // Use the original HTML text rather than the parsed DOM to preserve self-closing tags
-    const originalHtml = htmlEscape(node.children.map((child) => this.renderOriginalHtml(child)).join(''))
+    let originalHtml = this.renderOriginalHtml(node)
+
+    // strip <pre> </pre> from the original HTML
+    originalHtml = originalHtml.replace(/^<pre[^>]*>/gi, '').replace(/<\/\s*pre>$/gi, '')
+
+    // escape
+    originalHtml = escapeHTML(originalHtml)
 
     return {
       mentions: [],

--- a/backend/src/parser/TheParser.ts
+++ b/backend/src/parser/TheParser.ts
@@ -1,4 +1,3 @@
-import render from 'dom-serializer'
 import { ChildNode, Document, Element } from 'domhandler'
 import escapeHTML from 'escape-html'
 import { escape as htmlEscape } from 'html-escaper'
@@ -47,6 +46,8 @@ export default class TheParser {
 
   // Stack of tags that are currently being parsed, for internal use only
   private parseChildNodesStack: string[]
+  // Original version of the text that is being parsed, used to get the original HTML for <pre> tags
+  private originalDocumentString: string
 
   constructor(parserConfig: ParserConfig) {
     this.parserConfig = parserConfig
@@ -104,8 +105,11 @@ export default class TheParser {
 
     const doc = this.parseDocument(text, {
       decodeEntities: false,
+      withStartIndices: true,
+      withEndIndices: true,
     })
 
+    this.originalDocumentString = text
     this.parseChildNodesStack.length = 0 // clear stack, should not be necessary, but just in case
     const parseResult = this.parseChildNodes(doc.childNodes)
     parseResult.mentions = [...new Set(parseResult.mentions)]
@@ -124,6 +128,10 @@ export default class TheParser {
       return false
     }
     return this.parseChildNodesStack.includes(disallowed)
+  }
+
+  private renderOriginalHtml(node: ChildNode): string {
+    return this.originalDocumentString.substring(node.startIndex, node.endIndex + 1)
   }
 
   private parseChildNodes(doc: ChildNode[]): ParseResult {
@@ -494,11 +502,14 @@ export default class TheParser {
   }
 
   parsePre(node: Element): ParseResult {
-    const result = this.parseChildNodes(node.children)
-    const escapedContent = htmlEscape(render(node.children, { encodeEntities: false }))
+    // Use the original HTML text rather than the parsed DOM to preserve self-closing tags
+    const originalHtml = htmlEscape(node.children.map((child) => this.renderOriginalHtml(child)).join(''))
+
     return {
-      ...result,
-      text: `<pre>${escapedContent}</pre>`,
+      mentions: [],
+      urls: [],
+      images: [],
+      text: `<pre>${originalHtml}</pre>`,
     }
   }
 

--- a/backend/test/parser/TheParser.test.ts
+++ b/backend/test/parser/TheParser.test.ts
@@ -415,14 +415,10 @@ Multiple empty lines above</pre>`,
     const input = '<pre><div>text</div><span />code with <em>format</em>\n<img src="test.jpg"/></pre>'
     // Get the actual result to inspect
     const result = p.parse(input).text
-    // Verify all tags are properly escaped using individual checks
-    // This avoids potential issues with exact string matching when
-    // there might be subtle differences in the implementation's output
-    expect(result).toContain('&lt;div&gt;text&lt;/div&gt;')
-    expect(result).toContain('&lt;span /&gt;')
-    expect(result).toContain('code with')
-    expect(result).toContain('&lt;em&gt;format&lt;/em&gt;')
-    expect(result).toContain('&lt;img src=&quot;test.jpg&quot;/&gt;')
+    // Verify all tags are properly escaped as a single string
+    expect(result).toEqual(
+      '<pre>&lt;div&gt;text&lt;/div&gt;&lt;span /&gt;code with &lt;em&gt;format&lt;/em&gt;\n&lt;img src=&quot;test.jpg&quot;/&gt;</pre>',
+    )
   })
 
   test('nested or malformed tags', () => {
@@ -443,10 +439,44 @@ Multiple empty lines above</pre>`,
 
   test('attribute format preservation', () => {
     // Test that attribute formats are preserved
-    const result = p.parse('<pre><div data-test="value" another=\'quotes\'></div></pre>').text
-    // Check that both attributes are preserved
-    expect(result).toContain('data-test=&quot;value&quot;')
-    expect(result).toContain('another=&#39;quotes&#39;')
+    const result = p.parse('<pre><div data-test="value" another=\'quotes\'></div></pre>end').text
+    // Check that attributes are properly escaped and preserved
+    expect(result).toEqual('<pre>&lt;div data-test=&quot;value&quot; another=&#39;quotes&#39;&gt;&lt;/div&gt;</pre>end')
+  })
+
+  // test spaces inside the tag
+  test('spaces inside the tag', () => {
+    const result = p.parse('<pre> <div > </div > </pre>end').text
+    expect(result).toEqual('<pre> &lt;div &gt; &lt;/div &gt; </pre>end')
+  })
+
+  test('spaces inside the tag2', () => {
+    const result = p.parse('start<pre> <div test="1"   test="2"> </div> </pre>end').text
+    expect(result).toEqual('start<pre> &lt;div test=&quot;1&quot;   test=&quot;2&quot;&gt; &lt;/div&gt; </pre>end')
+  })
+
+  test('test unmatched tag inside pre', () => {
+    const result = p.parse('start<pre><div>test</pre>end').text
+    expect(result).toEqual('start<pre>&lt;div&gt;test</pre>end')
+  })
+
+  test('pre tag with unclosed tag', () => {
+    const result = p.parse('<pre><blockquote>content</pre>end')
+    expect(result.text).toEqual('<pre>&lt;blockquote&gt;content</pre>end')
+  })
+
+  test('pre tag with > in attribute', () => {
+    const result = p.parse('<pre attr=">">content</pre>end')
+    // FIXME: the correct expected value should be '<pre>content</pre>end'
+    // but the hacky stripping logic in the parser doesn't strip attributes of pre tag
+    // the fix for this would be too complicated,
+    // need to wait for the htmlparser2 to fix this bug: https://github.com/fb55/htmlparser2/issues/2060
+    expect(result.text).toEqual('<pre>&quot;&gt;content</pre>end')
+  })
+
+  test('pre tag with line breaks', () => {
+    const result = p.parse('<pre\nattr="value">content</pre>')
+    expect(result.text).toEqual('<pre>content</pre>')
   })
 })
 

--- a/backend/test/parser/TheParser.test.ts
+++ b/backend/test/parser/TheParser.test.ts
@@ -371,6 +371,85 @@ test('base64 validation', () => {
   expect(TheParser.isValidBase64('"SGVsbG8=')).toEqual(false)
 })
 
+describe('pre tag behavior', () => {
+  test('self-closing tags', () => {
+    // Test that self-closing tags inside pre are properly escaped and preserved
+    expect(p.parse('<pre><video/></pre>').text).toEqual('<pre>&lt;video/&gt;</pre>')
+    expect(p.parse('<pre><img/></pre>').text).toEqual('<pre>&lt;img/&gt;</pre>')
+    expect(p.parse('<pre><br/></pre>').text).toEqual('<pre>&lt;br/&gt;</pre>')
+    expect(p.parse('<pre><video></pre>').text).toEqual('<pre>&lt;video&gt;</pre>')
+    expect(p.parse('<pre><img></pre>').text).toEqual('<pre>&lt;img&gt;</pre>')
+    expect(p.parse('<pre><br></pre>').text).toEqual('<pre>&lt;br&gt;</pre>')
+  })
+
+  test('whitespace preservation', () => {
+    // Test that whitespace is preserved exactly as in the original
+    const input = '<pre>  spaces    </pre>'
+    expect(p.parse(input).text).toEqual('<pre>  spaces    </pre>')
+
+    // Test with actual line breaks and various whitespace combinations
+    const multilineInput = `<pre>Line one
+    Indented line
+Line with    multiple    spaces
+
+Multiple empty lines above</pre>`
+
+    expect(p.parse(multilineInput).text).toEqual(
+      `<pre>Line one
+    Indented line
+Line with    multiple    spaces
+
+Multiple empty lines above</pre>`,
+    )
+  })
+
+  test('HTML entities', () => {
+    // Test that entities are preserved as-is
+    expect(p.parse('<pre>&lt;div&gt;&amp;nbsp;&lt;/div&gt;</pre>').text).toEqual(
+      '<pre>&amp;lt;div&amp;gt;&amp;amp;nbsp;&amp;lt;/div&amp;gt;</pre>',
+    )
+  })
+
+  test('mixed content with various tag formats', () => {
+    // Test with a variety of tag formats and content
+    const input = '<pre><div>text</div><span />code with <em>format</em>\n<img src="test.jpg"/></pre>'
+    // Get the actual result to inspect
+    const result = p.parse(input).text
+    // Verify all tags are properly escaped using individual checks
+    // This avoids potential issues with exact string matching when
+    // there might be subtle differences in the implementation's output
+    expect(result).toContain('&lt;div&gt;text&lt;/div&gt;')
+    expect(result).toContain('&lt;span /&gt;')
+    expect(result).toContain('code with')
+    expect(result).toContain('&lt;em&gt;format&lt;/em&gt;')
+    expect(result).toContain('&lt;img src=&quot;test.jpg&quot;/&gt;')
+  })
+
+  test('nested or malformed tags', () => {
+    // Test with nested or improperly closed tags
+    expect(p.parse('<pre><div><span></div></pre>').text).toEqual('<pre>&lt;div&gt;&lt;span&gt;&lt;/div&gt;</pre>')
+  })
+
+  test('comments and CDATA', () => {
+    // Test with HTML comments and CDATA sections
+    expect(p.parse('<pre><!-- comment --></pre>').text).toEqual('<pre>&lt;!-- comment --&gt;</pre>')
+    expect(p.parse('<pre><![CDATA[data]]></pre>').text).toEqual('<pre>&lt;![CDATA[data]]&gt;</pre>')
+  })
+
+  test('tag case preservation', () => {
+    // Test that tag casing is preserved
+    expect(p.parse('<pre><DIV>Text</DIV></pre>').text).toEqual('<pre>&lt;DIV&gt;Text&lt;/DIV&gt;</pre>')
+  })
+
+  test('attribute format preservation', () => {
+    // Test that attribute formats are preserved
+    const result = p.parse('<pre><div data-test="value" another=\'quotes\'></div></pre>').text
+    // Check that both attributes are preserved
+    expect(result).toContain('data-test=&quot;value&quot;')
+    expect(result).toContain('another=&#39;quotes&#39;')
+  })
+})
+
 describe('processInternalUrl', () => {
   test('valid internal url', () => {
     const url = 'https://orbitar.local/s/site/p123'


### PR DESCRIPTION
Currently:
`<pre><video/></pre>`
expands to
`<pre><video></video></pre>`

The problem is, there is an actual bug in htmlparser2: https://github.com/fb55/htmlparser2/issues/2060

If it's not addressed, we might need to switch to another parser library.