### PR TITLE
Fix cache clearing logic when removing votes from downvoted users

### DIFF
--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -367,7 +367,7 @@ export default class UserManager {
     const karmaVotes = await this.voteRepository.getVotesByUser(userId)
     for (const vote of karmaVotes) {
       await this.voteRepository.userSetVote(vote.userId, 0, vote.voterId)
-      this.userCache.clearCache(vote.voterId)
+      this.userCache.clearCache(vote.userId)
     }
     await this.redis.set(`remove_votes_when_karma_is_low_${userId}`, 'true')
     await this.redis.expire(


### PR DESCRIPTION
a followup for #414

wrong cache was cleared: need to clear the **user**, e.g. the target of the vote