### PR TITLE
Hotfix theme loading logic to support previous format

### DIFF
--- a/frontend/src/AppState/AppState.tsx
+++ b/frontend/src/AppState/AppState.tsx
@@ -7,7 +7,7 @@ import {observable, makeObservable, autorun, action, computed, makeAutoObservabl
 import APICache from '../API/APICache';
 import {createBrowserHistory} from 'history';
 import {RouterStore} from '@superwf/mobx-react-router';
-import {UserRestrictionsResponse} from '../API/UserAPI';
+import {UserRestrictionsResponse} from '@api/UserAPI';
 import MediaUploader, {MediaUploaderProps} from '../Components/MediaUploader';
 import ConfirmDialog, {ConfirmDialogProps} from '../Components/ConfirmDialog';
 import { themes } from '../theme'
@@ -111,13 +111,22 @@ export class AppState {
             return 'light';
         };
 
-        // load from localStorage
-        this.theme = localStorage.getItem('theme') || getPreferredColorScheme();
-
-        // fallback if the value in localStorage is not in the themes
-        if (themes[this.theme] === undefined) {
-            this.theme = Object.keys(themes)[0];
+        let loadedTheme = localStorage.getItem('theme');
+        // support the previous storage format
+        if (loadedTheme && loadedTheme.startsWith('{')) {
+            try {
+                loadedTheme = JSON.parse(loadedTheme).theme
+            } catch (e) {
+            }
         }
+        if (!loadedTheme || !themes[loadedTheme]) {
+            loadedTheme = getPreferredColorScheme();
+            if (!themes[loadedTheme]) {
+                // fallback to the last defined theme
+                loadedTheme = Object.keys(themes)[Object.keys(themes).length - 1];
+            }
+        }
+        this.theme = loadedTheme;
     }
 
     @computed


### PR DESCRIPTION
fixes BC breakage introduced in #436

previous
```
function storeTheme(theme: string, styles?: ThemeStyles) {
  localStorage.setItem(
    'theme',
    JSON.stringify({
      theme,
      styles,
    }),
  )
}
```


new:
```
    @action
    setTheme(value: string) {
        // just in case, ensures the value is in the themes
        if (!themes[value]) {
            console.error(`Theme ${value} not found`);
            return;
        }
        this.theme = value;
        localStorage.setItem('theme', value);
    }
```


### Fix

Tries to load theme from the old format, if not, falls back to other variants. Never falls back to debug theme (uses last key instead of the first).


### Testing

Locally, by setting different local storage values.