### PR TITLE
hotfix: schedule poll autoupdate only if expiration is within a day from now

### DIFF
--- a/frontend/src/Components/Poll/PollComponent.tsx
+++ b/frontend/src/Components/Poll/PollComponent.tsx
@@ -9,6 +9,7 @@ import Button from '@ui/Button'
 import Checkbox from '@ui/Checkbox'
 import Radio from '@ui/Radio'
 import { pluralize } from '@utils/utils'
+import moment from 'moment'
 import { toast } from 'react-toastify'
 
 import styles from './PollComponent.module.scss'
@@ -60,7 +61,12 @@ export const PollComponent: React.FC<PollProps> = ({ pollId }) => {
 
   // if expiration date is in the future, schedule a refresh
   useEffect(() => {
-    if (poll && poll?.expires && poll.expires > new Date()) {
+    if (
+      poll &&
+      poll?.expires &&
+      poll.expires > new Date() &&
+      poll.expires < moment().add(1, 'day').startOf('day').toDate()
+    ) {
       const refreshTimer = setTimeout(
         () => {
           fetchPoll(true)


### PR DESCRIPTION
Bug:

Browsers (and Node) store the timeout internally as a 32‑bit signed int. Values above 2^31 − 1 wrap and effectively become < 1


this fixes the repeated poll update spamming by setting autoupdate only for the polls that expire in one day or earlier 