### PR TITLE
Clarify retry delay

### DIFF
--- a/frontend/src/API/APIHelper.ts
+++ b/frontend/src/API/APIHelper.ts
@@ -85,6 +85,7 @@ export default class APIHelper {
       } else {
         console.error('ERROR', error)
         this.initRetryCount++
+        // retry delay in milliseconds
         let retryIn = 60 * 1000
         if (this.initRetryCount === 1) {
           // first retry in 3 seconds
@@ -97,7 +98,7 @@ export default class APIHelper {
         }
         setTimeout(() => {
           this.init().then().catch()
-        }, retryIn * 1000)
+        }, retryIn)
       }
     }
   }


### PR DESCRIPTION
## Summary
- comment retry delay unit in APIHelper
- use milliseconds directly for initialization retry

## Testing
- `cd frontend && npm run lint` *(fails: ESLint couldn't find configuration)*
- `cd frontend && npm test --silent` *(fails: react-app-rewired not found)*
- `cd backend && npm run lint` *(fails: ESLint couldn't find configuration)*
- `cd backend && npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b059a97c832eb0fc5fd7fa0a3201