### PR TITLE
Fix uploader auto-open for video files

### DIFF
--- a/frontend/src/Components/CreateCommentComponent.tsx
+++ b/frontend/src/Components/CreateCommentComponent.tsx
@@ -400,8 +400,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
     if (
       e.dataTransfer.items.length > 0 &&
       e.dataTransfer.items[0].kind === 'file' &&
-      (e.dataTransfer.items[0].type.startsWith('image/') ||
-        e.dataTransfer.items[0].type.startsWith('video/'))
+      (e.dataTransfer.items[0].type.startsWith('image/') || e.dataTransfer.items[0].type.startsWith('video/'))
     ) {
       setMediaUploaderOpen(true)
     }

--- a/frontend/src/Components/CreateCommentComponent.tsx
+++ b/frontend/src/Components/CreateCommentComponent.tsx
@@ -396,11 +396,12 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
 
   const onDragEnter = (e: React.DragEvent<HTMLTextAreaElement>) => {
     // open media uploader on drag enter
-    // check that image files are dragged
+    // check that media files are dragged
     if (
       e.dataTransfer.items.length > 0 &&
       e.dataTransfer.items[0].kind === 'file' &&
-      e.dataTransfer.items[0].type.startsWith('image/')
+      (e.dataTransfer.items[0].type.startsWith('image/') ||
+        e.dataTransfer.items[0].type.startsWith('video/'))
     ) {
       setMediaUploaderOpen(true)
     }


### PR DESCRIPTION
## Summary
- open media uploader when dragging videos into comment box

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: missing script)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c757f66c8832e8a6da946c7bb8e8e