### PR TITLE
Fix session destruction user cleanup

### DIFF
--- a/backend/src/session/Session.ts
+++ b/backend/src/session/Session.ts
@@ -132,11 +132,12 @@ export default class Session {
 
   async destroy() {
     if (!this.id) return
+    const userId = this.data.userId
     this.data.clear()
     this.data = new SessionData('')
     delete sessionStorage[this.id]
-    if (this.data.userId) {
-      deleteFromUserSessions(this.data.userId, this.id)
+    if (userId) {
+      deleteFromUserSessions(userId, this.id)
     }
     this.logger.verbose(`Session ${this.id} removed from DB`, { session: this.id })
 


### PR DESCRIPTION
## Summary
- fix `Session.destroy` removing sessions from per-user index

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684db8266870832ea486fe58514c5fc5