### PR TITLE
Implement exponential edit delay for posts and comments

### DIFF
--- a/backend/src/CodeError.ts
+++ b/backend/src/CodeError.ts
@@ -1,8 +1,12 @@
 export default class CodeError extends Error {
   public code: string
+  public statusCode?: number
+  public meta?: Record<string, unknown>
 
-  constructor(code: string, message: string) {
+  constructor(code: string, message: string, statusCode?: number, meta?: Record<string, unknown>) {
     super(message)
     this.code = code
+    this.statusCode = statusCode
+    this.meta = meta
   }
 }

--- a/backend/src/api/PostController.ts
+++ b/backend/src/api/PostController.ts
@@ -314,6 +314,10 @@ export default class PostController {
         return response.error('access-denied', 'Access-denied')
       }
 
+      if (err instanceof CodeError && err.code === 'rate-limit') {
+        return response.error('rate-limit', err.message, err.statusCode || 429, err.meta)
+      }
+
       return response.error('error', 'Unknown error', 500)
     }
   }
@@ -570,6 +574,10 @@ export default class PostController {
 
       if (err instanceof CodeError && err.code === 'access-denied') {
         return response.error('access-denied', 'Access-denied')
+      }
+
+      if (err instanceof CodeError && err.code === 'rate-limit') {
+        return response.error('rate-limit', err.message, err.statusCode || 429, err.meta)
       }
 
       return response.error('error', 'Unknown error', 500)

--- a/backend/src/db/repositories/PostRepository.ts
+++ b/backend/src/db/repositories/PostRepository.ts
@@ -451,4 +451,26 @@ export default class PostRepository {
       })
       .then((row) => row?.author_id)
   }
+
+  async getEditStats(
+    userId: number,
+    refType: 'post' | 'comment',
+    refId: number,
+  ): Promise<{ lastEditTime: Date | null; numberOfEdits: number }> {
+    const result = await this.db.fetchOne<{ last_edit_time: Date | null; edit_count: number }>(
+      `select 
+        max(created_at) as last_edit_time,
+        count(*) - 1 as edit_count
+       from content_source 
+       where author_id = :userId 
+       and ref_type = :refType 
+       and ref_id = :refId`,
+      { userId, refType, refId },
+    )
+
+    return {
+      lastEditTime: result?.last_edit_time || null,
+      numberOfEdits: result?.edit_count || 0,
+    }
+  }
 }

--- a/backend/src/managers/PostManager.ts
+++ b/backend/src/managers/PostManager.ts
@@ -147,6 +147,12 @@ export default class PostManager {
       throw new CodeError('access-denied', 'Access denied')
     }
 
+    // Check edit delay restrictions
+    const waitTimeToEditSec = await this.calcTimeToEdit(forUserId, 'post', postId)
+    if (waitTimeToEditSec > 0) {
+      throw new CodeError('rate-limit', 'Edit rate limit exceeded', 429, { waitSeconds: Math.ceil(waitTimeToEditSec) })
+    }
+
     if (rawPost.source === content && rawPost.title === title) {
       // nothing changed
       const [post] = await this.feedManager.convertRawPosts(forUserId, [rawPost], format)
@@ -370,6 +376,12 @@ export default class PostManager {
       throw new CodeError('access-denied', 'Access denied')
     }
 
+    // Check edit delay restrictions
+    const waitTimeToEditSec = await this.calcTimeToEdit(forUserId, 'comment', commentId)
+    if (waitTimeToEditSec > 0) {
+      throw new CodeError('rate-limit', 'Edit rate limit exceeded', 429, { waitSeconds: Math.ceil(waitTimeToEditSec) })
+    }
+
     if (rawComment.source === content) {
       // nothing changed
       const [comment] = await this.convertRawCommentsWithPostData(forUserId, [rawComment], format)
@@ -387,6 +399,28 @@ export default class PostManager {
     rawComment = await this.commentRepository.getCommentWithUserData(forUserId, commentId)
     const [comment] = await this.convertRawCommentsWithPostData(forUserId, [rawComment], format)
     return comment
+  }
+
+  private async calcTimeToEdit(userId: number, contentType: 'post' | 'comment', contentId: number): Promise<number> {
+    const restrictions = await this.userManager.getUserRestrictions(userId)
+
+    if (!restrictions.editSlowModeEnabled) {
+      return 0
+    }
+
+    const { lastEditTime, numberOfEdits } = await this.postRepository.getEditStats(userId, contentType, contentId)
+
+    // Base delay: 5 minutes, doubling with each edit
+    const baseDelay = 5 * 60 // 5 minutes in seconds
+    // Prevent overflow: 2^53 is the max safe integer, so limit exponent
+    const editDelay = baseDelay * Math.pow(2, Math.min(numberOfEdits, 50))
+
+    if (!lastEditTime) {
+      return 0 // No previous edits, no delay
+    }
+
+    const timeSinceLastEdit = (Date.now() - lastEditTime.getTime()) / 1000
+    return Math.max(0, editDelay - timeSinceLastEdit)
   }
 
   async setRead(postId: number, userId: number, readComments: number, lastCommentId?: number): Promise<boolean> {

--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -452,6 +452,7 @@ export default class UserManager {
       canCreateSubsites: effectiveKarma > 0,
       canEditOwnContent: effectiveKarma > MIN_KARMA,
       canCreatePolls: effectiveKarma > MIN_KARMA,
+      editSlowModeEnabled: effectiveKarma < NEG_KARMA_THRESH,
     }
   }
 

--- a/backend/src/managers/types/UserInfo.ts
+++ b/backend/src/managers/types/UserInfo.ts
@@ -55,4 +55,5 @@ export type UserRestrictions = {
   canCreateSubsites: boolean /* whether this user can create subsites */
   canEditOwnContent: boolean /* whether this user can edit own content */
   canCreatePolls: boolean /* whether this user can create polls */
+  editSlowModeEnabled: boolean /* whether exponential edit delays apply (karma < -10) */
 }

--- a/frontend/src/API/APIBase.ts
+++ b/frontend/src/API/APIBase.ts
@@ -4,7 +4,7 @@ type APIResponseError = {
   result: 'error'
   code: string
   message: string
-  meta?: any
+  meta?: Record<string, unknown>
 }
 type APIResponseSuccess<Response> = {
   result: 'success'

--- a/frontend/src/API/APIBase.ts
+++ b/frontend/src/API/APIBase.ts
@@ -4,6 +4,7 @@ type APIResponseError = {
   result: 'error'
   code: string
   message: string
+  meta?: any
 }
 type APIResponseSuccess<Response> = {
   result: 'success'
@@ -52,10 +53,6 @@ export default class APIBase {
       responseCallback(response)
     }
 
-    if (response.status === 429) {
-      throw new APIError('rate-limit', 'Rate limit exceeded', response.status)
-    }
-
     const sessionId = response.headers.get('x-session-id')
     if (sessionId) {
       this.sessionId = sessionId
@@ -63,6 +60,15 @@ export default class APIBase {
     }
 
     const responseJson = (await response.json()) as APIResponse<Res>
+
+    if (response.status === 429 && responseJson.result === 'error') {
+      let message = 'Rate limit exceeded'
+      if (responseJson.meta?.waitSeconds) {
+        const minutes = Math.ceil(responseJson.meta.waitSeconds / 60)
+        message = `Rate limit exceeded. Wait ${minutes} minute${minutes === 1 ? '' : 's'} before trying again`
+      }
+      throw new APIError('rate-limit', message, response.status)
+    }
 
     if (responseJson.result === 'error') {
       throw new APIError(responseJson.code, responseJson.message, response.status)

--- a/frontend/src/API/APIBase.ts
+++ b/frontend/src/API/APIBase.ts
@@ -4,7 +4,8 @@ type APIResponseError = {
   result: 'error'
   code: string
   message: string
-  meta?: Record<string, unknown>
+  //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  meta?: Record<string, any>
 }
 type APIResponseSuccess<Response> = {
   result: 'success'

--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -76,9 +76,9 @@ export default function CommentComponent(props: CommentProps) {
       const res = await props.onEdit?.(text, props.comment)
       setEditingText(false)
       return res
-    } catch (err) {
+    } catch (err: any) {
       console.log('Could not edit comment', err)
-      toast.error('Не удалось отредактировать комментарий')
+      toast.error(err.message || 'Не удалось отредактировать комментарий')
       throw err
     }
   }

--- a/frontend/src/Components/PostComponent.tsx
+++ b/frontend/src/Components/PostComponent.tsx
@@ -120,9 +120,9 @@ export default function PostComponent(props: PostComponentProps) {
       setEditingText(false)
       // return res;
       return undefined
-    } catch (err) {
+    } catch (err: any) {
       console.log('Could not edit post', err)
-      toast.error('Не удалось отредактировать пост')
+      toast.error(err.message || 'Не удалось отредактировать пост')
       throw err
     }
   }


### PR DESCRIPTION
<img width="884" alt="image" src="https://github.com/user-attachments/assets/3969a5e5-554d-4184-a8a1-344f96016212" />

Implements an exponential delay restriction for post/comment editing when users are downvoted below the first negative effective karma threshold (-10). The delay starts at 5 minutes and doubles with each edit of the same content.
