### PR TITLE
Implement account anonymization feature

### DIFF
--- a/backend/src/api/UserController.ts
+++ b/backend/src/api/UserController.ts
@@ -18,6 +18,8 @@ import { UserPostsRequest, UserPostsResponse } from './types/requests/UserPosts'
 import {
   BarmaliniPasswordRequest,
   BarmaliniPasswordResponse,
+  UserAnonymizeRequest,
+  UserAnonymizeResponse,
   UserKarmaResponse,
   UserProfileRequest,
   UserProfileResponse,
@@ -174,6 +176,7 @@ export default class UserController {
       validate(publicKeySchema),
       (req, res) => this.savePublicKey(req, res),
     )
+    this.router.post('/user/anonymize-account', settingsSaveLimiter, (req, res) => this.anonymizeAccount(req, res))
   }
 
   async profile(request: APIRequest<UserProfileRequest>, response: APIResponse<UserProfileResponse>) {
@@ -563,6 +566,29 @@ export default class UserController {
     } catch (error) {
       this.logger.error('Could not update user public key', { error })
       return res.error('error', `Could not update public key`, 500)
+    }
+  }
+
+  async anonymizeAccount(req: APIRequest<UserAnonymizeRequest>, res: APIResponse<UserAnonymizeResponse>) {
+    if (!req.session.data.userId) {
+      return res.authRequired()
+    }
+
+    const userId = req.session.data.userId
+
+    try {
+      const userInfo = await this.userManager.getById(userId)
+      if (!userInfo) {
+        return res.error('user-not-found', 'User not found', 404)
+      }
+
+      await this.userManager.anonymizeAccount(userId)
+      await this.userManager.resetAllPushSubscriptions(userId)
+      await req.session.destroyAllForCurrentUser()
+      return res.success({})
+    } catch (error) {
+      this.logger.error('Failed to anonymize account', { error, user_id: userId })
+      return res.error('unknown', 'Unknown error', 500)
     }
   }
 }

--- a/backend/src/api/UserController.ts
+++ b/backend/src/api/UserController.ts
@@ -582,8 +582,13 @@ export default class UserController {
         return res.error('user-not-found', 'User not found', 404)
       }
 
+      if (this.userManager.isBarmaliniUser(userId)) {
+        return res.error('forbidden', 'Cannot anonymize Barmalini account', 403)
+      }
+
       await this.userManager.anonymizeAccount(userId)
       await this.userManager.resetAllPushSubscriptions(userId)
+      this.postManager.clearUserContentCaches(userId)
       await req.session.destroyAllForCurrentUser()
       return res.success({})
     } catch (error) {

--- a/backend/src/api/types/requests/UserProfile.ts
+++ b/backend/src/api/types/requests/UserProfile.ts
@@ -98,3 +98,7 @@ export type BarmaliniPasswordResponse = {
   login: string
   password: string
 }
+
+export type UserAnonymizeRequest = Record<string, never>
+
+export type UserAnonymizeResponse = Record<string, never>

--- a/backend/src/db/repositories/UserRepository.ts
+++ b/backend/src/db/repositories/UserRepository.ts
@@ -352,6 +352,26 @@ export default class UserRepository {
     return this.db.query(`update users set password = '' where user_id = :user_id`, { user_id: userId })
   }
 
+  async anonymizeAccount(userId: number, anonymousUserId: number) {
+    await this.db.inTransaction(async (db) => {
+      await db.query('update content_source set author_id = :anon where author_id = :user', {
+        anon: anonymousUserId,
+        user: userId,
+      })
+      await db.query('update posts set author_id = :anon where author_id = :user', {
+        anon: anonymousUserId,
+        user: userId,
+      })
+      await db.query('update comments set author_id = :anon where author_id = :user', {
+        anon: anonymousUserId,
+        user: userId,
+      })
+      await db.query("update users set email = '', password = '' where user_id = :user", {
+        user: userId,
+      })
+    })
+  }
+
   async savePublicKey(publicKey: string, userId: number) {
     return this.db.query(
       `UPDATE users

--- a/backend/src/managers/PostManager.ts
+++ b/backend/src/managers/PostManager.ts
@@ -482,6 +482,11 @@ export default class PostManager {
   getLastUserComment(userId: number) {
     return this.commentRepository.getLastUserComment(userId)
   }
+
+  clearUserContentCaches(userId: number) {
+    delete this.numberOfPostsCache[userId]
+    delete this.numberOfCommentsCache[userId]
+  }
 }
 
 class ContentNumberCache {

--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -733,6 +733,15 @@ export default class UserManager {
     await this.userRepository.dropPassword(userId)
   }
 
+  async anonymizeAccount(userId: number) {
+    if (!this.barmaliniUserConfigured()) {
+      throw new Error('Barmalini user not configured')
+    }
+    await this.userRepository.anonymizeAccount(userId, config.barmalini.userId!)
+    this.clearCache(userId)
+    this.clearUserRestrictionsCache(userId)
+  }
+
   savePublicKey(publicKey: string, userId: number) {
     const res = this.userRepository.savePublicKey(publicKey, userId)
     this.userCache.clearPublicKeysCache(userId)

--- a/frontend/src/API/UserAPI.ts
+++ b/frontend/src/API/UserAPI.ts
@@ -190,4 +190,8 @@ export default class UserAPI {
   async getUsernameSuggestions(start: string): Promise<UsernameSuggestResult> {
     return this.api.request<{ start: string }, UsernameSuggestResult>('/user/suggest-username', { start })
   }
+
+  async anonymizeAccount(): Promise<Record<string, never>> {
+    return this.api.request<Record<string, never>, Record<string, never>>('/user/anonymize-account', {})
+  }
 }

--- a/frontend/src/API/UserAPIHelper.ts
+++ b/frontend/src/API/UserAPIHelper.ts
@@ -1,4 +1,4 @@
-import { AppState } from '../AppState/AppState'
+import { AppLoadingState, AppState } from '../AppState/AppState'
 import { UserInfo, UserProfileInfo } from '../Types/UserInfo'
 import UserAPI from './UserAPI'
 import { VoteListItemEntity } from './VoteAPI'
@@ -55,5 +55,12 @@ export default class UserAPIHelper {
           this.restrictionRefreshInProgress = false
         })
     }
+  }
+
+  async anonymizeAccount() {
+    await this.api.anonymizeAccount()
+    this.appState.setUserInfo(undefined)
+    this.appState.setAppLoadingState(AppLoadingState.unauthorized)
+    this.appState.clearCachesOnLogout()
   }
 }

--- a/frontend/src/Components/AnonymizeAccountDialog.module.scss
+++ b/frontend/src/Components/AnonymizeAccountDialog.module.scss
@@ -1,0 +1,69 @@
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -48%);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+}
+
+@keyframes scaleIn {
+  from {
+    transform: scale(0.95);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.container {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--bg);
+  box-shadow: 0 4px 8px var(--shadow);
+  border: 1px solid var(--inactive-fg);
+  border-radius: 4px;
+  padding: 20px;
+  max-width: 500px;
+  width: 90%;
+  z-index: 10000;
+
+  animation: fadeIn 0.25s ease-out;
+  & > * {
+    animation: scaleIn 0.25s ease-out;
+  }
+}
+
+.title {
+  margin-top: 0;
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 15px;
+  color: var(--primary);
+  text-align: center;
+}
+
+.message {
+  margin-bottom: 20px;
+  line-height: 1.5;
+  color: var(--fg);
+  text-align: center;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.buttons {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+}

--- a/frontend/src/Components/AnonymizeAccountDialog.tsx
+++ b/frontend/src/Components/AnonymizeAccountDialog.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react'
 
+import { Button } from '@ui/Button'
+import { Field } from '@ui/Field'
 import { toast } from 'react-toastify'
 
 import Overlay from './Overlay'
-import { Button } from './UI/Button'
-import { Field } from './UI/Field'
 
 import styles from './AnonymizeAccountDialog.module.scss'
 
@@ -32,7 +32,16 @@ export default function AnonymizeAccountDialog({ username, onConfirm, onCancel }
       <Overlay onClick={onCancel} zIndex={9999} />
       <div className={styles.container} style={{ zIndex: 10000 }}>
         <h2 className={styles.title}>Анонимизировать аккаунт?</h2>
-        <p className={styles.message}>Это действие необратимо. Введите имя пользователя наоборот для подтверждения.</p>
+        <p className={styles.message}>Вы потеряете доступ к аккаунту.</p>
+        <p className={styles.message}>
+          Все опубликованные посты и комментарии останутся доступны другим пользователям.
+        </p>
+        <p className={styles.message}>Авторство постов и комментариев будет изменено на анонимного пользователя</p>
+        <p className={styles.message}>
+          Другие полноправные пользователи смогут редактировать этот контент через общий доступ.
+        </p>
+        <p className={styles.message}>Это действие необратимо.</p>
+        <p className={styles.message}>Введите имя пользователя наоборот для подтверждения.</p>
         <form onSubmit={handleSubmit} className={styles.form}>
           <Field autoFocus value={value} onChange={(e) => setValue(e.target.value)} />
           <div className={styles.buttons}>

--- a/frontend/src/Components/AnonymizeAccountDialog.tsx
+++ b/frontend/src/Components/AnonymizeAccountDialog.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react'
+
+import { toast } from 'react-toastify'
+
+import Overlay from './Overlay'
+import { Button } from './UI/Button'
+import { Field } from './UI/Field'
+
+import styles from './AnonymizeAccountDialog.module.scss'
+
+type Props = {
+  username: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function AnonymizeAccountDialog({ username, onConfirm, onCancel }: Props) {
+  const [value, setValue] = useState('')
+  const reversed = username.split('').reverse().join('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (value === reversed) {
+      onConfirm()
+    } else {
+      toast.error('Неверное подтверждение')
+    }
+  }
+
+  return (
+    <>
+      <Overlay onClick={onCancel} zIndex={9999} />
+      <div className={styles.container} style={{ zIndex: 10000 }}>
+        <h2 className={styles.title}>Анонимизировать аккаунт?</h2>
+        <p className={styles.message}>Это действие необратимо. Введите имя пользователя наоборот для подтверждения.</p>
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <Field autoFocus value={value} onChange={(e) => setValue(e.target.value)} />
+          <div className={styles.buttons}>
+            <Button variant='danger' type='submit'>
+              Анонимизировать
+            </Button>
+            <Button onClick={onCancel}>Отмена</Button>
+          </div>
+        </form>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/Components/UserProfileSettings.tsx
+++ b/frontend/src/Components/UserProfileSettings.tsx
@@ -10,10 +10,12 @@ import { observer } from 'mobx-react-lite'
 import { toast } from 'react-toastify'
 
 import { BarmaliniAccessResult, UserGender } from '../Types/UserInfo'
+import AnonymizeAccountDialog from './AnonymizeAccountDialog'
 import { SecretMailKeyGeneratorForm } from './SecretMailbox'
 import ThemeToggleComponent from './ThemeToggleComponent'
 
 import styles from './UserProfileSettings.module.scss'
+import { ReactComponent as AnonIcon } from '@assets/anon.svg'
 import { ReactComponent as CopyIcon } from '@assets/copy.svg'
 import { ReactComponent as GhostIcon } from '@assets/ghost.svg'
 import { ReactComponent as LogoutIcon } from '@assets/logout.svg'
@@ -73,7 +75,8 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
   const api = useAPI()
   const navigate = useNavigate()
   const location = useLocation()
-  const { confirmAlert } = useAppState()
+  const appState = useAppState()
+  const { confirmAlert, userInfo } = appState
 
   let gender = props.gender
 
@@ -110,6 +113,23 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
       })
     },
   )
+
+  const handleAnonymize = (e: React.MouseEvent) => {
+    e.preventDefault()
+    if (!userInfo) return
+    appState.setModal(
+      <AnonymizeAccountDialog
+        username={userInfo.username}
+        onConfirm={() => {
+          api.user.anonymizeAccount().then(() => {
+            navigate(location.pathname)
+          })
+          appState.setModal(undefined)
+        }}
+        onCancel={() => appState.setModal(undefined)}
+      />,
+    )
+  }
 
   const toggleAutoStop = () => {
     setAutoStop(!autoStop)
@@ -209,6 +229,11 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
         {!props.isBarmalini && (
           <Button variant='danger' onClick={handleResetSessions}>
             <GhostIcon /> Сброс пароля и сессий
+          </Button>
+        )}
+        {!props.isBarmalini && (
+          <Button variant='danger' onClick={handleAnonymize}>
+            <AnonIcon /> Анонимизировать аккаунт
           </Button>
         )}
         <Button onClick={handleLogout}>


### PR DESCRIPTION
  Allows users to permanently transfer their content ownership to the anonymous "Barmalini" user account while maintaining content visibility.

###  Changes

  Backend:
  - Added /user/anonymize-account API endpoint with security guards
  - Implemented transaction-safe content ownership transfer (posts, comments, content_source)
  - Added Barmalini account protection to prevent self-anonymization
  - Clears user credentials (email, password) and terminates all sessions
  - Invalidates user caches including post/comment count caches
  - Resets all push notification subscriptions

  Frontend:
  - Added anonymization button in user profile settings (hidden for Barmalini)
  - Implemented confirmation dialog requiring reverse username entry
  - Displays clear warnings about irreversibility and content ownership transfer
  - Auto-logout and redirect after successful anonymization

###  Security Measures

  - Rate-limited endpoint using settingsSaveLimiter
  - Barmalini account cannot be anonymized (frontend + backend protection)
  - Requires authenticated session
  - Destroys all user sessions post-anonymization


## Testing
- `npm run lint`
- `npm run test` in backend
- `npm run test -- -w=1` in frontend


------
https://chatgpt.com/codex/tasks/task_e_688c629531b4832ea716650d6a17165a