### PR TITLE
chore: update default OpenAI model

### DIFF
--- a/backend/src/managers/TranslationManager.ts
+++ b/backend/src/managers/TranslationManager.ts
@@ -133,7 +133,7 @@ export default class TranslationManager {
 
     return openai.chat.completions.create({
       messages: messages,
-      model: 'gpt-4.1-mini',
+      model: 'gpt-5-mini',
       stream: true,
       temperature: temperature,
     })


### PR DESCRIPTION
## Summary
- use `gpt-5-mini` as the default OpenAI model

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689500761014832eb902a039fd2ce856