### PR TITLE
Add video auto-mute option and remember volume

### DIFF
--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -20,7 +20,13 @@ import { OAuthEmbeddedAppComponent } from './OAuth2AppCardModalComponent'
 import { SecretMailDecoderForm, SecretMailEncoderForm } from './SecretMailbox'
 import TelegramEmbed from './TelegramEmbed'
 import TwitterEmbed from './TwitterEmbed'
-import { getLegacyZoom, getVideoAutopause } from './UserProfileSettings'
+import {
+  getAutoMuteVideos,
+  getLegacyZoom,
+  getVideoAutopause,
+  getVideoVolume,
+  setVideoVolume,
+} from './UserProfileSettings'
 
 import styles from './ContentComponent.module.scss'
 import overlayStyles from './Overlay.module.scss'
@@ -408,6 +414,22 @@ function updateVideo(video: HTMLVideoElement) {
   video.addEventListener('play', () => stopInnerVideos(document.body, video))
   if (getVideoAutopause()) {
     observeOnHidden(video, () => stopVideo(video))
+  }
+
+  if (getAutoMuteVideos()) {
+    video.muted = true
+  } else {
+    const volume = getVideoVolume()
+    if (!isNaN(volume)) {
+      video.volume = volume
+    }
+  }
+
+  if (!video.dataset.volumeProcessed) {
+    video.addEventListener('volumechange', () => {
+      setVideoVolume(video.volume)
+    })
+    video.dataset.volumeProcessed = '1'
   }
 
   if (video.dataset.aspectRatioProcessed) {

--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -515,10 +515,8 @@ function processVideoEmbed(img: HTMLImageElement) {
       video.style.width = img.width.toString() + 'px'
       video.style.height = img.height.toString() + 'px'
       img.parentElement?.replaceWith(video)
-      video.addEventListener('play', () => stopInnerVideos(document.body, video))
-      if (getVideoAutopause()) {
-        observeOnHidden(video, () => stopVideo(video))
-      }
+      // Apply standard video behavior (mute/volume/autopause/stop-on-play/aspect ratio)
+      updateVideo(video)
     })
   }
   return !!videoUrl

--- a/frontend/src/Components/UserProfileSettings.tsx
+++ b/frontend/src/Components/UserProfileSettings.tsx
@@ -55,6 +55,18 @@ export function getVideoAutopause(): boolean {
   return JSON.parse(localStorage.getItem('autoStopVideos') || 'false')
 }
 
+export function getAutoMuteVideos(): boolean {
+  return localStorage.getItem('autoMuteVideos') === 'true'
+}
+
+export function getVideoVolume(): number {
+  return parseFloat(localStorage.getItem('videoVolume') || '1')
+}
+
+export function setVideoVolume(volume: number): void {
+  localStorage.setItem('videoVolume', volume.toString())
+}
+
 export function getLegacyZoom(): boolean {
   return localStorage.getItem('legacyZoom') === 'true'
 }
@@ -81,6 +93,7 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
   let gender = props.gender
 
   const [autoStop, setAutoStop] = useState<boolean>(getVideoAutopause())
+  const [autoMute, setAutoMute] = useState<boolean>(getAutoMuteVideos())
   const [legacyZoom, setLegacyZoom] = useState<boolean>(getLegacyZoom())
   const [preferredLang, setPreferredLang] = useState<string>(getPreferredLang())
   const [showInlineTranslateButton, setShowInlineTranslateButton] = useState<boolean>(getShowInlineTranslateButton())
@@ -135,6 +148,10 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
     setAutoStop(!autoStop)
   }
 
+  const toggleAutoMute = () => {
+    setAutoMute(!autoMute)
+  }
+
   const toggleLegacyZoom = () => {
     setLegacyZoom(!legacyZoom)
   }
@@ -176,6 +193,10 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
   }, [autoStop])
 
   useEffect(() => {
+    localStorage.setItem('autoMuteVideos', JSON.stringify(autoMute))
+  }, [autoMute])
+
+  useEffect(() => {
     localStorage.setItem('legacyZoom', JSON.stringify(legacyZoom))
   }, [legacyZoom])
 
@@ -197,6 +218,7 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
           </Button>
         )}
         <Button onClick={toggleAutoStop}>Видео автопауза: {autoStop ? 'Вкл' : 'Выкл'}</Button>
+        <Button onClick={toggleAutoMute}>Видео без звука: {autoMute ? 'Вкл' : 'Выкл'}</Button>
         <Button onClick={toggleLegacyZoom}>Легаси зум: {legacyZoom ? 'Вкл' : 'Выкл'}</Button>
         {<ThemeToggleComponent dynamic={true} buttonLabel='Сменить тему' />}
       </div>


### PR DESCRIPTION
## Summary
- add user setting to start videos muted and remember volume in local storage
- apply mute/volume preferences when rendering video elements

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a206504eac832e8bce5123aeb70f17