### PR TITLE
Revalidate html cache

### DIFF
--- a/caddy/Caddyfile.local
+++ b/caddy/Caddyfile.local
@@ -20,8 +20,21 @@ http://{$SERVER_DOMAIN} {
     }
   }
 
+  # Hashed static assets (JS/CSS) - cache for 1 year (immutable)
+  @static {
+    path /static/*
+  }
+  handle @static {
+    root * /srv
+    header Cache-Control "public, max-age=31536000, immutable"
+    file_server
+  }
+
+  # Everything else serves index.html via try_files - never cache
+  # This includes SPA routes like /u/username, /s/sitename, etc.
   handle {
     root * /srv
+    header Cache-Control "no-cache, no-store, must-revalidate"
     file_server
     try_files {path} /index.html
   }

--- a/caddy/Caddyfile.ssl.local
+++ b/caddy/Caddyfile.ssl.local
@@ -22,8 +22,21 @@
     }
   }
 
+  # Hashed static assets (JS/CSS) - cache for 1 year (immutable)
+  @static {
+    path /static/*
+  }
+  handle @static {
+    root * /srv
+    header Cache-Control "public, max-age=31536000, immutable"
+    file_server
+  }
+
+  # Everything else serves index.html via try_files - never cache
+  # This includes SPA routes like /u/username, /s/sitename, etc.
   handle {
     root * /srv
+    header Cache-Control "no-cache, no-store, must-revalidate"
     file_server
     try_files {path} /index.html
   }


### PR DESCRIPTION
 This should fix the "white page" issue we have after deployments.

  Currently all our static pages (including SPA html) are cached indefinitely, meaning that after deployment users' browsers serve stale `index.html` from disk cache. The old HTML references JS bundles (e.g., main.ede71b45.js) that no longer exist on the server, resulting in a white page with Unexpected token '<' errors.

  Solution: Add explicit Cache-Control headers in Caddy:
  - /static/* → max-age=31536000, immutable (hashed assets, safe to cache forever)
  - Everything else → no-cache, no-store, must-revalidate (always revalidate HTML/SPA routes)

  This ensures browsers always fetch fresh index.html while still caching hashed JS/CSS bundles efficiently.