### PR TITLE
Fix favicon not updating after closing notification popup

### DIFF
--- a/frontend/src/AppState/AppState.tsx
+++ b/frontend/src/AppState/AppState.tsx
@@ -280,18 +280,29 @@ export const AppStateProvider = (props: {children: ReactNode}) => {
     }, []);
 
     useEffect(() => {
-        return autorun(() => {
+        // Helper to set favicon with cache-busting timestamp
+        const updateFavicon = () => {
             const link = document.querySelector('link[rel~="icon"]') as HTMLLinkElement;
             if (!link) {
                 return;
             }
-            if (appState.unreadNotificationsCount > 0) {
-                link.href = '//' + process.env.REACT_APP_ROOT_DOMAIN + '/favicon-badge.png';
-            }
-            else {
-                link.href = '//' + process.env.REACT_APP_ROOT_DOMAIN + '/favicon.ico';
-            }
-        });
+            const baseUrl = appState.unreadNotificationsCount > 0
+                ? '//' + process.env.REACT_APP_ROOT_DOMAIN + '/favicon-badge.png'
+                : '//' + process.env.REACT_APP_ROOT_DOMAIN + '/favicon.ico';
+            // Cache-busting fragment prevents Chrome from restoring stale favicon on history navigation
+            link.href = baseUrl + '#' + Date.now();
+        };
+
+        const disposeAutorun = autorun(updateFavicon);
+
+        // Re-apply favicon after history.back() - Chrome caches favicon per history entry
+        const handlePopState = () => setTimeout(updateFavicon, 0);
+        window.addEventListener('popstate', handlePopState);
+
+        return () => {
+            disposeAutorun();
+            window.removeEventListener('popstate', handlePopState);
+        };
     }, [appState]);
 
     return <AppStateContext.Provider value={{ appState }}>


### PR DESCRIPTION
### Problem

  When marking notifications as read and closing the popup, the favicon would revert to showing the "unread" badge even though there were no unread notifications. This happened because Chrome caches favicons per browser history entry, and the notification popup uses history.pushState/history.back() for back button support.

### Solution

  - Add cache-busting fragment (#timestamp) to favicon URLs to prevent Chrome from using stale cached versions
  - Listen for popstate events and re-apply the correct favicon after history navigation