### PR TITLE
Add PKCE support and client types for OAuth2

### DIFF
--- a/backend/migrations/20260111000001-add-client-type.js
+++ b/backend/migrations/20260111000001-add-client-type.js
@@ -1,0 +1,33 @@
+'use strict'
+
+var dbm
+var type
+var seed
+
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+}
+
+exports.up = async function (db) {
+  await db.runSql(`
+    ALTER TABLE oauth_clients
+    ADD COLUMN client_type ENUM('public', 'confidential') NOT NULL DEFAULT 'confidential'
+    AFTER grants;
+  `)
+
+  return null
+}
+
+exports.down = async function (db) {
+  await db.runSql(`
+    ALTER TABLE oauth_clients
+    DROP COLUMN client_type;
+  `)
+  return null
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/backend/src/api/ApiMiddleware.ts
+++ b/backend/src/api/ApiMiddleware.ts
@@ -141,16 +141,38 @@ export const urisListValidator = Joi.string().custom((value, helpers) => {
   // remove optional trailing slash with star to support urls like https://example.com/*
   const urls = value.split(',').map((url) => url.trim().replace(/\/*$/, ''))
   for (const url of urls) {
-    if (
-      !isURL(url, {
-        require_tld: process.env.NODE_ENV !== 'development',
-        require_protocol: true,
-        allow_fragments:
-          false /*RFC 6749 Section 3.1.2: The redirection endpoint URI MUST NOT include a fragment component.*/,
-        protocols: ['https', ...(process.env.NODE_ENV === 'development' ? ['https', 'http'] : [])],
-      })
-    ) {
-      return helpers.error('any.invalid')
+    try {
+      const urlObj = new URL(url)
+
+      // RFC 6749 Section 3.1.2: no fragments
+      if (urlObj.hash && urlObj.hash !== '#') {
+        return helpers.error('any.invalid', {
+          message: 'Redirect URIs must not include fragment components (RFC 6749)',
+        })
+      }
+
+      // Strict validation for http/https
+      if (urlObj.protocol === 'http:' || urlObj.protocol === 'https:') {
+        if (
+          !isURL(url, {
+            require_tld: process.env.NODE_ENV !== 'development',
+            require_protocol: true,
+            allow_fragments: false,
+            protocols: ['https', ...(process.env.NODE_ENV === 'development' ? ['http'] : [])],
+          })
+        ) {
+          return helpers.error('any.invalid')
+        }
+      } else {
+        // Custom protocols: minimal validation
+        if (!urlObj.protocol || urlObj.protocol === ':') {
+          return helpers.error('any.invalid', {
+            message: 'Custom protocol URIs must have a valid protocol scheme',
+          })
+        }
+      }
+    } catch (err) {
+      return helpers.error('any.invalid', { message: 'Invalid URI format' })
     }
   }
   return value

--- a/backend/src/api/OAuth2Controller.ts
+++ b/backend/src/api/OAuth2Controller.ts
@@ -200,6 +200,11 @@ export default class OAuth2Controller {
           }
         } catch (err) {
           this.logger.error('Error checking client type for PKCE enforcement', { error: err })
+          // Fail closed: if we can't determine client type, reject the request
+          return res.status(500).json({
+            error: 'server_error',
+            error_description: 'Unable to verify client configuration.',
+          })
         }
       }
 

--- a/backend/src/api/OAuth2Controller.ts
+++ b/backend/src/api/OAuth2Controller.ts
@@ -63,6 +63,10 @@ const clientRegisterSchema = Joi.object<OAuth2RegisterRequest>({
     'any.required': 'Redirect URIs are required.',
     'any.invalid': 'Please enter valid comma-separated URIs.',
   }),
+  clientType: Joi.string().valid('public', 'confidential').required().messages({
+    'any.required': 'Client type is required.',
+    'any.only': 'Client type must be either "public" or "confidential".',
+  }),
 })
 
 const clientEditSchema = Joi.object<OAuth2EditRequest>({
@@ -178,8 +182,29 @@ export default class OAuth2Controller {
     this.router.post('/oauth2/verify-scopes', commonLimiter, validate(verifyScopesSchema), (req, res) =>
       this.verifyScopes(req, res),
     )
-    this.router.post('/oauth2/authorize', commonLimiter, (req, res) =>
-      this.oauthExpressServer.authorize({
+    this.router.post('/oauth2/authorize', commonLimiter, async (req, res, next) => {
+      // PKCE enforcement for public clients (OAuth 2.0 best practice - RFC 7636)
+      const clientId = req.body.client_id || req.query.client_id
+      if (clientId) {
+        try {
+          const clientType = await this.oauth2Manager.getClientType(clientId)
+          if (clientType === 'public') {
+            const codeChallenge = req.body.code_challenge || req.query.code_challenge
+            if (!codeChallenge) {
+              this.logger.warn('Public client attempted authorization without PKCE', { clientId })
+              return res.status(400).json({
+                error: 'invalid_request',
+                error_description: 'Public clients MUST use PKCE. Missing code_challenge parameter.',
+              })
+            }
+          }
+        } catch (err) {
+          this.logger.error('Error checking client type for PKCE enforcement', { error: err })
+        }
+      }
+
+      // Continue with OAuth authorization
+      await this.oauthExpressServer.authorize({
         authenticateHandler: {
           handle: async (req) => {
             await req.session.restore(req.body['X-Session-Id'])
@@ -201,8 +226,8 @@ export default class OAuth2Controller {
             }
           },
         },
-      })(req, res, () => {}),
-    )
+      })(req, res, () => {})
+    })
     this.router.post('/oauth2/unauthorize', commonLimiter, validate(clientManageSchema), (req, res) =>
       this.unAuthorizeClient(req, res),
     )
@@ -220,7 +245,7 @@ export default class OAuth2Controller {
     }
 
     try {
-      const { name, description, logoUrl, initialAuthorizationUrl, redirectUris } = request.body
+      const { name, description, logoUrl, initialAuthorizationUrl, redirectUris, clientType } = request.body
       const userId = request.session.data.userId
       const author = await this.userManager.getById(userId)
 
@@ -231,6 +256,7 @@ export default class OAuth2Controller {
         initialAuthorizationUrl,
         redirectUris,
         userId,
+        clientType,
       )
       const responseData: OAuth2RegisterResponse = {
         client: {
@@ -242,6 +268,7 @@ export default class OAuth2Controller {
           initialAuthorizationUrl: client.initial_authorization_url,
           redirectUris: client.redirect_uris,
           grants: client.grants,
+          clientType: client.client_type,
           userId: client.user_id,
           author,
         },

--- a/backend/src/api/types/entities/OAuth2ClientEntity.ts
+++ b/backend/src/api/types/entities/OAuth2ClientEntity.ts
@@ -10,6 +10,7 @@ export type OAuth2ClientEntity = {
   logoUrl?: string
   redirectUris: string
   grants: string
+  clientType: 'public' | 'confidential'
   userId: number
   author: UserBaseEntity
   scopes?: string

--- a/backend/src/api/types/requests/OAuth2.ts
+++ b/backend/src/api/types/requests/OAuth2.ts
@@ -6,6 +6,7 @@ export type OAuth2RegisterRequest = {
   logoUrl?: string
   initialAuthorizationUrl?: string
   redirectUris: string
+  clientType: 'public' | 'confidential'
 }
 
 export type OAuth2RegisterResponse = {

--- a/backend/src/db/repositories/OAuth2Repository.ts
+++ b/backend/src/db/repositories/OAuth2Repository.ts
@@ -74,13 +74,14 @@ export default class OAuth2Repository {
     clientSecretHash: string,
     redirectUris: string,
     userId: number,
+    clientType: 'public' | 'confidential',
   ): Promise<OAuth2ClientRaw> {
     await this.db.query(
       `
-      INSERT INTO oauth_clients 
-        (name, description, logo_url, client_id, client_secret_hash, initial_authorization_url, redirect_uris, user_id, grants)
-      VALUES 
-        (:name, :description, :logo_url, :client_id, :client_secret_hash, :initial_authorization_url, :redirect_uris, :user_id, :grants)
+      INSERT INTO oauth_clients
+        (name, description, logo_url, client_id, client_secret_hash, initial_authorization_url, redirect_uris, user_id, grants, client_type)
+      VALUES
+        (:name, :description, :logo_url, :client_id, :client_secret_hash, :initial_authorization_url, :redirect_uris, :user_id, :grants, :client_type)
       `,
       {
         name,
@@ -92,6 +93,7 @@ export default class OAuth2Repository {
         redirect_uris: redirectUris,
         user_id: userId,
         grants: 'authorization_code,refresh_token',
+        client_type: clientType,
       },
     )
 
@@ -105,6 +107,7 @@ export default class OAuth2Repository {
       redirect_uris: redirectUris,
       user_id: userId,
       grants: 'authorization_code,refresh_token',
+      client_type: clientType,
     } as OAuth2ClientRaw
   }
 

--- a/backend/src/db/types/OAuth2.ts
+++ b/backend/src/db/types/OAuth2.ts
@@ -9,6 +9,7 @@ export interface OAuth2ClientRaw {
   initial_authorization_url: string
   redirect_uris: string
   grants: string
+  client_type: 'public' | 'confidential'
   user_id: number
   scopes?: string
   last_revoked_ts?: Date

--- a/backend/src/managers/OAuth2Manager.ts
+++ b/backend/src/managers/OAuth2Manager.ts
@@ -25,6 +25,7 @@ export default class OAuth2Manager {
     initialAuthorizationUrl: string,
     redirectUris: string,
     userId: number,
+    clientType: 'public' | 'confidential',
   ): Promise<OAuth2ClientRaw> {
     try {
       const currentNumberOfClientsByUser = await this.oauthRepository.getNumberOfClientsCreatedByUser(userId)
@@ -33,8 +34,20 @@ export default class OAuth2Manager {
       }
 
       const clientId = AuthorizationCodeModelImpl.generateClientId()
-      const clientSecret = AuthorizationCodeModelImpl.generateClientSecret()
-      const clientSecretHash = AuthorizationCodeModelImpl.hashString(clientSecret)
+
+      // Only generate client_secret for confidential clients
+      let clientSecret: string
+      let clientSecretHash: string
+
+      if (clientType === 'confidential') {
+        clientSecret = AuthorizationCodeModelImpl.generateClientSecret()
+        clientSecretHash = AuthorizationCodeModelImpl.hashString(clientSecret)
+      } else {
+        // For public clients, store empty hash (never used)
+        clientSecret = ''
+        clientSecretHash = ''
+      }
+
       const result: OAuth2ClientRaw = await this.oauthRepository.createClient(
         name,
         description,
@@ -44,8 +57,14 @@ export default class OAuth2Manager {
         clientSecretHash,
         redirectUris,
         userId,
+        clientType,
       )
-      result.client_secret_original = clientSecret
+
+      // Only return client_secret for confidential clients
+      if (clientType === 'confidential') {
+        result.client_secret_original = clientSecret
+      }
+
       return result
     } catch (error) {
       this.logger.error('Error registering OAuth client', { error })
@@ -77,6 +96,16 @@ export default class OAuth2Manager {
     } catch (error) {
       this.logger.error('Error getting OAuth client by client ID', { error })
       throw error
+    }
+  }
+
+  async getClientType(clientId: string): Promise<'public' | 'confidential' | undefined> {
+    try {
+      const client = await this.oauthRepository.getClientByClientId(clientId)
+      return client?.client_type
+    } catch (error) {
+      this.logger.error('Error getting OAuth client type', { error })
+      return undefined
     }
   }
 
@@ -161,6 +190,7 @@ export default class OAuth2Manager {
       initialAuthorizationUrl: client.initial_authorization_url,
       redirectUris: client.redirect_uris,
       grants: client.grants,
+      clientType: client.client_type,
       userId: client.user_id,
       logoUrl: client.logo_url,
       author: { id: author.id, username: author.username, gender: author.gender },

--- a/backend/src/oauth/AuthorizationCodeModelImpl.ts
+++ b/backend/src/oauth/AuthorizationCodeModelImpl.ts
@@ -52,12 +52,27 @@ export default class AuthorizationCodeModelImpl implements AuthorizationCodeMode
 
   async getClient(clientId: string, clientSecret?: string): Promise<Falsey | Client> {
     const clientFromDB = await this.repo.getClientByClientId(clientId)
-    if (
-      !clientFromDB ||
-      (clientSecret && clientFromDB.client_secret_hash !== AuthorizationCodeModelImpl.hashString(clientSecret))
-    ) {
+    if (!clientFromDB) {
       return null
     }
+
+    // Handle authentication based on client type
+    if (clientFromDB.client_type === 'confidential') {
+      // Validate client_secret if provided (during token exchange)
+      // If not provided, allow through (authorization phase or PKCE-based token exchange)
+      if (clientSecret && clientFromDB.client_secret_hash !== AuthorizationCodeModelImpl.hashString(clientSecret)) {
+        this.logger.warn('Confidential client authentication failed: invalid client_secret', { clientId })
+        return null
+      }
+    } else if (clientFromDB.client_type === 'public') {
+      // Public clients MUST NOT use client_secret
+      if (clientSecret) {
+        this.logger.warn('Public client attempted authentication with client_secret (not allowed)', { clientId })
+        return null
+      }
+      // Note: PKCE validation happens automatically in the library at token endpoint
+    }
+
     return {
       id: clientId,
       redirectUris: clientFromDB.redirect_uris.split(',').map((uri) => uri.trim()),
@@ -161,13 +176,19 @@ export default class AuthorizationCodeModelImpl implements AuthorizationCodeMode
         return null
       }
 
-      const authCode = {
+      const authCode: AuthorizationCode = {
         authorizationCode: code.authorizationCode,
         expiresAt,
         redirectUri,
         scope,
         client,
         user,
+      }
+
+      // Only include PKCE properties if they exist (JSON.stringify omits undefined values)
+      if (code.codeChallenge) {
+        authCode.codeChallenge = code.codeChallenge
+        authCode.codeChallengeMethod = code.codeChallengeMethod
       }
 
       await this.redis.set(`oauth2code:${code.authorizationCode}`, JSON.stringify(authCode))
@@ -187,12 +208,22 @@ export default class AuthorizationCodeModelImpl implements AuthorizationCodeMode
       }
 
       const authCode: AuthorizationCode = JSON.parse(authCodeStr)
+
       // Convert expiresAt back to a Date object.
       authCode.expiresAt = new Date(authCode.expiresAt)
       if (authCode.expiresAt < new Date()) {
         await this.revokeAuthorizationCode(authCode)
         return null
       }
+
+      // Ensure client.grants is an array (required by oauth2-server for PKCE validation)
+      if (authCode.client && !Array.isArray(authCode.client.grants)) {
+        const clientFromDB = await this.repo.getClientByClientId(authCode.client.id)
+        if (clientFromDB) {
+          authCode.client.grants = clientFromDB.grants.split(',').map((grant) => grant.trim())
+        }
+      }
+
       return authCode
     } catch (error) {
       return null

--- a/backend/test/api/urisListValidator.test.ts
+++ b/backend/test/api/urisListValidator.test.ts
@@ -1,0 +1,198 @@
+import { urisListValidator } from '../../src/api/ApiMiddleware'
+
+describe('urisListValidator', () => {
+  // Helper to validate a URI string
+  const validate = (value: string) => {
+    const result = urisListValidator.validate(value)
+    return {
+      isValid: !result.error,
+      value: result.value,
+      error: result.error?.message,
+    }
+  }
+
+  describe('HTTPS URLs', () => {
+    it('accepts valid HTTPS URLs', () => {
+      const result = validate('https://example.com/callback')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('accepts HTTPS URLs with paths', () => {
+      const result = validate('https://example.com/oauth/callback')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('accepts HTTPS URLs with query parameters', () => {
+      const result = validate('https://example.com/callback?param=value')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('accepts HTTPS URLs with ports', () => {
+      const result = validate('https://example.com:8443/callback')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('rejects URLs with fragments (#hash)', () => {
+      const result = validate('https://example.com/callback#section')
+      expect(result.isValid).toBe(false)
+    })
+
+    it('rejects URLs with empty fragment (#)', () => {
+      // RFC 6749: no fragments allowed, even empty ones
+      // Note: urlObj.hash is '#' for empty fragments, which is still rejected
+      const result = validate('https://example.com/callback#')
+      expect(result.isValid).toBe(false)
+    })
+  })
+
+  describe('HTTP URLs (environment-dependent)', () => {
+    const originalNodeEnv = process.env.NODE_ENV
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalNodeEnv
+    })
+
+    it('accepts HTTP URLs in development mode', () => {
+      process.env.NODE_ENV = 'development'
+      const result = validate('http://localhost:3000/callback')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('accepts HTTP localhost in development mode', () => {
+      process.env.NODE_ENV = 'development'
+      const result = validate('http://localhost/callback')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('rejects HTTP URLs in production mode', () => {
+      process.env.NODE_ENV = 'production'
+      const result = validate('http://example.com/callback')
+      expect(result.isValid).toBe(false)
+    })
+  })
+
+  describe('Custom protocol URIs (for mobile/desktop apps)', () => {
+    it('accepts myapp:// scheme', () => {
+      const result = validate('myapp://callback')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('accepts myapp:// scheme with path', () => {
+      const result = validate('myapp://oauth/callback')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('accepts reverse-domain style schemes (com.example.app://)', () => {
+      const result = validate('com.example.app://oauth')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('accepts custom schemes with dashes', () => {
+      const result = validate('my-custom-app://callback')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('accepts custom schemes with numbers', () => {
+      const result = validate('app123://callback')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('rejects custom protocol URIs with fragments', () => {
+      const result = validate('myapp://callback#section')
+      expect(result.isValid).toBe(false)
+    })
+  })
+
+  describe('Multiple URIs (comma-separated)', () => {
+    it('accepts multiple valid HTTPS URIs', () => {
+      const result = validate('https://example.com/callback,https://example.org/callback')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('accepts mixed HTTPS and custom protocol URIs', () => {
+      const result = validate('https://example.com/callback,myapp://callback')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('trims whitespace around URIs', () => {
+      const result = validate('https://example.com/callback , https://example.org/callback')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('rejects if any URI is invalid', () => {
+      const result = validate('https://example.com/callback,not-a-valid-uri')
+      expect(result.isValid).toBe(false)
+    })
+
+    it('rejects if any URI has a fragment', () => {
+      const result = validate('https://example.com/callback,https://example.org/callback#hash')
+      expect(result.isValid).toBe(false)
+    })
+  })
+
+  describe('Invalid URIs', () => {
+    it('rejects empty string', () => {
+      const result = validate('')
+      expect(result.isValid).toBe(false)
+    })
+
+    it('rejects plain text', () => {
+      const result = validate('not-a-url')
+      expect(result.isValid).toBe(false)
+    })
+
+    it('rejects URIs without protocol', () => {
+      const result = validate('example.com/callback')
+      expect(result.isValid).toBe(false)
+    })
+
+    // Note: The validator accepts any valid custom protocol for mobile/desktop apps.
+    // While javascript:, data:, and file: protocols are technically valid,
+    // they should not be used as OAuth redirect URIs in practice.
+    // These tests document the current behavior.
+    it('accepts javascript: protocol (valid URI, but should not be used)', () => {
+      const result = validate('javascript:void(0)')
+      // Current implementation accepts any custom protocol
+      expect(result.isValid).toBe(true)
+    })
+
+    it('accepts data: protocol (valid URI, but should not be used)', () => {
+      // Note: data URIs with commas are problematic since the validator splits by comma
+      // Using a data URI without comma in the data portion
+      const result = validate('data:text/plain;base64,dGVzdA==')
+      // This will be split and fail - documenting the limitation
+      // The comma-split means data: URIs with payload are effectively not supported
+      expect(result.isValid).toBe(false)
+    })
+
+    it('accepts file: protocol (valid URI, but should not be used)', () => {
+      const result = validate('file:///etc/passwd')
+      // Current implementation accepts any custom protocol
+      expect(result.isValid).toBe(true)
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('handles trailing slashes', () => {
+      const result = validate('https://example.com/callback/')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('strips trailing slash with asterisk (wildcard pattern)', () => {
+      const result = validate('https://example.com/*')
+      expect(result.isValid).toBe(true)
+      // The validator strips trailing /* so the value should be modified
+    })
+
+    it('handles URLs with special characters in path', () => {
+      const result = validate('https://example.com/callback%20test')
+      expect(result.isValid).toBe(true)
+    })
+
+    it('handles internationalized domain names', () => {
+      // Punycode-encoded IDN
+      const result = validate('https://xn--nxasmq5b.com/callback')
+      expect(result.isValid).toBe(true)
+    })
+  })
+})

--- a/backend/test/managers/OAuth2Manager.test.ts
+++ b/backend/test/managers/OAuth2Manager.test.ts
@@ -1,0 +1,370 @@
+import OAuth2Manager from '../../src/managers/OAuth2Manager'
+import {
+  createMockConfidentialClient,
+  createMockLogger,
+  createMockOAuth2Repository,
+  createMockPublicClient,
+} from '../utils/oauth2TestHelpers'
+
+// Mock the config
+jest.mock('../../src/config', () => ({
+  config: {
+    oauth: {
+      maxNumberOfClientsPerDeveloper: 10,
+    },
+  },
+}))
+
+// Mock UserManager
+const createMockUserManager = () => ({
+  getById: jest.fn().mockResolvedValue({
+    id: 1,
+    username: 'testuser',
+    gender: 'unknown',
+  }),
+})
+
+describe('OAuth2Manager', () => {
+  let manager: OAuth2Manager
+  let mockRepo: ReturnType<typeof createMockOAuth2Repository>
+  let mockUserManager: ReturnType<typeof createMockUserManager>
+  let mockLogger: ReturnType<typeof createMockLogger>
+
+  beforeEach(() => {
+    mockRepo = createMockOAuth2Repository()
+    mockUserManager = createMockUserManager()
+    mockLogger = createMockLogger()
+
+    manager = new OAuth2Manager(mockRepo as any, mockUserManager as any, mockLogger as any)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('registerClient', () => {
+    describe('public clients', () => {
+      it('creates public client without client_secret', async () => {
+        mockRepo.createClient.mockImplementation(async (...args) => ({
+          name: args[0],
+          description: args[1],
+          logo_url: args[2],
+          initial_authorization_url: args[3],
+          client_id: args[4],
+          client_secret_hash: args[5],
+          redirect_uris: args[6],
+          user_id: args[7],
+          client_type: args[8],
+          grants: 'authorization_code,refresh_token',
+        }))
+
+        const result = await manager.registerClient(
+          'Test Public App',
+          'A test application',
+          '',
+          '',
+          'myapp://callback',
+          1,
+          'public',
+        )
+
+        expect(result.client_secret_original).toBeUndefined()
+        expect(result.client_type).toBe('public')
+      })
+
+      it('stores empty client_secret_hash for public clients', async () => {
+        mockRepo.createClient.mockImplementation(async (...args) => ({
+          client_id: args[4],
+          client_secret_hash: args[5],
+          client_type: args[8],
+          grants: 'authorization_code,refresh_token',
+        }))
+
+        await manager.registerClient('Test App', 'Description', '', '', 'myapp://callback', 1, 'public')
+
+        expect(mockRepo.createClient).toHaveBeenCalledWith(
+          'Test App',
+          'Description',
+          '',
+          '',
+          expect.any(String), // clientId (UUID)
+          '', // Empty secret hash for public clients
+          'myapp://callback',
+          1,
+          'public',
+        )
+      })
+    })
+
+    describe('confidential clients', () => {
+      it('creates confidential client with client_secret', async () => {
+        mockRepo.createClient.mockImplementation(async (...args) => ({
+          name: args[0],
+          description: args[1],
+          logo_url: args[2],
+          initial_authorization_url: args[3],
+          client_id: args[4],
+          client_secret_hash: args[5],
+          redirect_uris: args[6],
+          user_id: args[7],
+          client_type: args[8],
+          grants: 'authorization_code,refresh_token',
+        }))
+
+        const result = await manager.registerClient(
+          'Test Confidential App',
+          'A test application',
+          '',
+          '',
+          'https://example.com/callback',
+          1,
+          'confidential',
+        )
+
+        expect(result.client_secret_original).toBeDefined()
+        expect(result.client_secret_original!.length).toBe(64) // 32 bytes hex = 64 chars
+        expect(result.client_type).toBe('confidential')
+      })
+
+      it('stores non-empty client_secret_hash for confidential clients', async () => {
+        mockRepo.createClient.mockImplementation(async (...args) => ({
+          client_id: args[4],
+          client_secret_hash: args[5],
+          client_type: args[8],
+          grants: 'authorization_code,refresh_token',
+        }))
+
+        await manager.registerClient(
+          'Test App',
+          'Description',
+          '',
+          '',
+          'https://example.com/callback',
+          1,
+          'confidential',
+        )
+
+        expect(mockRepo.createClient).toHaveBeenCalledWith(
+          'Test App',
+          'Description',
+          '',
+          '',
+          expect.any(String), // clientId (UUID)
+          expect.stringMatching(/^[0-9a-f]{64}$/i), // Non-empty SHA-256 hash
+          'https://example.com/callback',
+          1,
+          'confidential',
+        )
+      })
+    })
+
+    it('enforces max clients per user limit', async () => {
+      mockRepo.getNumberOfClientsCreatedByUser.mockResolvedValue(10) // At limit
+
+      await expect(
+        manager.registerClient('Test App', 'Description', '', '', 'https://example.com/callback', 1, 'confidential'),
+      ).rejects.toBe('Too many clients already created')
+    })
+
+    it('allows creation when under the limit', async () => {
+      mockRepo.getNumberOfClientsCreatedByUser.mockResolvedValue(9) // Under limit
+      mockRepo.createClient.mockResolvedValue({
+        client_id: 'new-client-id',
+        client_type: 'confidential',
+        grants: 'authorization_code,refresh_token',
+      })
+
+      const result = await manager.registerClient(
+        'Test App',
+        'Description',
+        '',
+        '',
+        'https://example.com/callback',
+        1,
+        'confidential',
+      )
+
+      expect(result).toBeDefined()
+      expect(mockRepo.createClient).toHaveBeenCalled()
+    })
+
+    it('generates unique client IDs', async () => {
+      const clientIds = new Set<string>()
+
+      mockRepo.createClient.mockImplementation(async (...args) => {
+        clientIds.add(args[4]) // clientId is 5th argument
+        return {
+          client_id: args[4],
+          client_type: args[8],
+          grants: 'authorization_code,refresh_token',
+        }
+      })
+
+      // Create multiple clients
+      for (let i = 0; i < 10; i++) {
+        await manager.registerClient(
+          'App ' + i,
+          'Description',
+          '',
+          '',
+          'https://example.com/callback',
+          1,
+          'confidential',
+        )
+      }
+
+      expect(clientIds.size).toBe(10)
+    })
+  })
+
+  describe('getClientType', () => {
+    it('returns "public" for public clients', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(createMockPublicClient())
+
+      const result = await manager.getClientType('test-public-client-id')
+
+      expect(result).toBe('public')
+    })
+
+    it('returns "confidential" for confidential clients', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(createMockConfidentialClient())
+
+      const result = await manager.getClientType('test-confidential-client-id')
+
+      expect(result).toBe('confidential')
+    })
+
+    it('returns undefined for non-existent clients', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(undefined)
+
+      const result = await manager.getClientType('non-existent')
+
+      expect(result).toBeUndefined()
+    })
+
+    it('returns undefined and logs error on exception', async () => {
+      mockRepo.getClientByClientId.mockRejectedValue(new Error('DB error'))
+
+      const result = await manager.getClientType('test-client')
+
+      expect(result).toBeUndefined()
+      expect(mockLogger.error).toHaveBeenCalledWith('Error getting OAuth client type', { error: expect.any(Error) })
+    })
+  })
+
+  describe('regenerateClientSecret', () => {
+    it('generates new secret and updates in database', async () => {
+      mockRepo.updateClientSecret.mockResolvedValue(true)
+
+      const result = await manager.regenerateClientSecret('test-client-id', 1)
+
+      expect(result).toBeDefined()
+      expect(result!.length).toBe(64) // 32 bytes hex
+      expect(mockRepo.updateClientSecret).toHaveBeenCalledWith(
+        expect.stringMatching(/^[0-9a-f]{64}$/i), // New hash
+        'test-client-id',
+        1,
+      )
+    })
+
+    it('returns null if update fails', async () => {
+      mockRepo.updateClientSecret.mockResolvedValue(false)
+
+      const result = await manager.regenerateClientSecret('test-client-id', 1)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('deleteClient', () => {
+    it('deletes client when owner initiates', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(createMockConfidentialClient({ user_id: 1 }))
+      mockRepo.deleteClient.mockResolvedValue(true)
+
+      const result = await manager.deleteClient('test-client-id', 1)
+
+      expect(result).toBe(true)
+      expect(mockRepo.deleteClient).toHaveBeenCalledWith('test-client-id', 1)
+    })
+
+    it('returns false for non-existent client', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(undefined)
+
+      const result = await manager.deleteClient('non-existent', 1)
+
+      expect(result).toBe(false)
+      expect(mockLogger.error).toHaveBeenCalledWith('Error deleting OAuth client, no such client', {
+        clientId: 'non-existent',
+      })
+    })
+
+    it('returns false when non-owner tries to delete', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(createMockConfidentialClient({ user_id: 1 }))
+
+      const result = await manager.deleteClient('test-client-id', 999) // Different user
+
+      expect(result).toBe(false)
+      expect(mockLogger.error).toHaveBeenCalledWith('Error deleting OAuth client, not client owner initiated', {
+        clientId: 'test-client-id',
+        byUserId: 999,
+        authorId: 1,
+      })
+      expect(mockRepo.deleteClient).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getClientByClientId', () => {
+    it('returns enriched client entity', async () => {
+      mockRepo.getClientByClientIdWithConsent.mockResolvedValue(createMockConfidentialClient())
+
+      const result = await manager.getClientByClientId('test-client-id', 1)
+
+      expect(result).toBeDefined()
+      expect(result!.clientId).toBe('test-confidential-client-id')
+      expect(result!.clientType).toBe('confidential')
+      expect(result!.author).toEqual({
+        id: 1,
+        username: 'testuser',
+        gender: 'unknown',
+      })
+    })
+
+    it('returns undefined for non-existent client', async () => {
+      mockRepo.getClientByClientIdWithConsent.mockResolvedValue(undefined)
+
+      const result = await manager.getClientByClientId('non-existent', 1)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('returns undefined if author not found', async () => {
+      mockRepo.getClientByClientIdWithConsent.mockResolvedValue(createMockConfidentialClient())
+      mockUserManager.getById.mockResolvedValue(undefined)
+
+      const result = await manager.getClientByClientId('test-client-id', 1)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('includes clientType in response for public clients', async () => {
+      mockRepo.getClientByClientIdWithConsent.mockResolvedValue(createMockPublicClient())
+
+      const result = await manager.getClientByClientId('test-public-client-id', 1)
+
+      expect(result!.clientType).toBe('public')
+    })
+  })
+
+  describe('unAuthorizeClient', () => {
+    it('resets consent scope and updates revoke date', async () => {
+      mockRepo.resetConsentScope.mockResolvedValue(true)
+      mockRepo.updateConsentLastRevokeDate.mockResolvedValue(true)
+
+      const result = await manager.unAuthorizeClient('test-client-id', 1)
+
+      expect(result).toBe(true)
+      expect(mockRepo.resetConsentScope).toHaveBeenCalledWith('test-client-id', 1)
+      expect(mockRepo.updateConsentLastRevokeDate).toHaveBeenCalledWith('test-client-id', 1)
+    })
+  })
+})

--- a/backend/test/oauth/AuthorizationCodeModelImpl.test.ts
+++ b/backend/test/oauth/AuthorizationCodeModelImpl.test.ts
@@ -1,0 +1,418 @@
+import { AuthorizationCode } from '@node-oauth/oauth2-server'
+
+import AuthorizationCodeModelImpl from '../../src/oauth/AuthorizationCodeModelImpl'
+import {
+  createMockConfidentialClient,
+  createMockLogger,
+  createMockOAuth2Repository,
+  createMockPublicClient,
+  createMockRedisClient,
+  generateCodeChallenge,
+  generateCodeVerifier,
+  hashString,
+} from '../utils/oauth2TestHelpers'
+
+// Mock the ExpressOauth2ScopesFilter
+const createMockScopesFilter = () => ({
+  minimizeAndFilterScopes: jest.fn((scopes: string[]) => scopes),
+  filterScopes: jest.fn((scopes: string[]) => scopes),
+  getAllScopes: jest.fn(() => ['user', 'user:profile']),
+  getAllScopesSet: jest.fn(() => new Set(['user', 'user:profile'])),
+})
+
+describe('AuthorizationCodeModelImpl', () => {
+  let model: AuthorizationCodeModelImpl
+  let mockRepo: ReturnType<typeof createMockOAuth2Repository>
+  let mockRedis: ReturnType<typeof createMockRedisClient>
+  let mockLogger: ReturnType<typeof createMockLogger>
+  let mockScopesFilter: ReturnType<typeof createMockScopesFilter>
+
+  const testConfig = {
+    authorizationCodeTtlSeconds: 600,
+    accessTokenTtlSeconds: 1800,
+    refreshTokenTtlSeconds: 86400,
+    maxNumberOfClientsPerDeveloper: 10,
+  }
+
+  beforeEach(() => {
+    mockRepo = createMockOAuth2Repository()
+    mockRedis = createMockRedisClient()
+    mockLogger = createMockLogger()
+    mockScopesFilter = createMockScopesFilter()
+
+    model = new AuthorizationCodeModelImpl(
+      mockRepo as any,
+      mockRedis as any,
+      mockScopesFilter as any,
+      testConfig,
+      mockLogger as any,
+    )
+  })
+
+  afterEach(() => {
+    mockRedis._clear()
+    jest.clearAllMocks()
+  })
+
+  describe('getClient', () => {
+    describe('public clients', () => {
+      it('returns client when no secret provided', async () => {
+        mockRepo.getClientByClientId.mockResolvedValue(createMockPublicClient())
+
+        const result = await model.getClient('test-public-client-id')
+
+        expect(result).not.toBeNull()
+        expect(result).not.toBe(false)
+        if (result) {
+          expect(result.id).toBe('test-public-client-id')
+          expect(result.grants).toEqual(['authorization_code', 'refresh_token'])
+        }
+      })
+
+      it('returns client when empty string secret provided', async () => {
+        mockRepo.getClientByClientId.mockResolvedValue(createMockPublicClient())
+
+        const result = await model.getClient('test-public-client-id', '')
+
+        // Empty string is falsy, so this should work
+        expect(result).not.toBeNull()
+      })
+
+      it('returns null when secret IS provided (public clients cannot use secrets)', async () => {
+        mockRepo.getClientByClientId.mockResolvedValue(createMockPublicClient())
+
+        const result = await model.getClient('test-public-client-id', 'any-secret')
+
+        expect(result).toBeNull()
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'Public client attempted authentication with client_secret (not allowed)',
+          { clientId: 'test-public-client-id' },
+        )
+      })
+
+      it('parses redirect URIs correctly', async () => {
+        mockRepo.getClientByClientId.mockResolvedValue(
+          createMockPublicClient({
+            redirect_uris: 'myapp://callback, https://example.com/callback',
+          }),
+        )
+
+        const result = await model.getClient('test-public-client-id')
+
+        expect(result).toBeTruthy()
+        if (result) {
+          expect(result.redirectUris).toEqual(['myapp://callback', 'https://example.com/callback'])
+        }
+      })
+    })
+
+    describe('confidential clients', () => {
+      it('returns client when correct secret provided', async () => {
+        mockRepo.getClientByClientId.mockResolvedValue(createMockConfidentialClient())
+
+        const result = await model.getClient('test-confidential-client-id', 'test-secret')
+
+        expect(result).toBeTruthy()
+        if (result) {
+          expect(result.id).toBe('test-confidential-client-id')
+        }
+      })
+
+      it('returns null when wrong secret provided', async () => {
+        mockRepo.getClientByClientId.mockResolvedValue(createMockConfidentialClient())
+
+        const result = await model.getClient('test-confidential-client-id', 'wrong-secret')
+
+        expect(result).toBeNull()
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          'Confidential client authentication failed: invalid client_secret',
+          { clientId: 'test-confidential-client-id' },
+        )
+      })
+
+      it('returns client when no secret provided (authorization phase)', async () => {
+        // During the authorization phase, client_secret is not required
+        mockRepo.getClientByClientId.mockResolvedValue(createMockConfidentialClient())
+
+        const result = await model.getClient('test-confidential-client-id')
+
+        expect(result).toBeTruthy()
+        if (result) {
+          expect(result.id).toBe('test-confidential-client-id')
+        }
+      })
+
+      it('returns client when no secret provided (PKCE flow)', async () => {
+        // Confidential clients using PKCE may not provide client_secret
+        mockRepo.getClientByClientId.mockResolvedValue(createMockConfidentialClient())
+
+        const result = await model.getClient('test-confidential-client-id', undefined)
+
+        expect(result).not.toBeNull()
+      })
+    })
+
+    it('returns null for non-existent client', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(undefined)
+
+      const result = await model.getClient('non-existent-client-id')
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null for null client', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(null)
+
+      const result = await model.getClient('non-existent-client-id')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('saveAuthorizationCode', () => {
+    const baseCode: AuthorizationCode = {
+      authorizationCode: 'test-auth-code-123',
+      expiresAt: new Date(Date.now() + 600000),
+      redirectUri: 'https://example.com/callback',
+      scope: ['user'],
+      client: { id: 'test-client-id', grants: ['authorization_code'] },
+      user: { id: 1 },
+    }
+
+    it('stores authorization code in Redis', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(createMockConfidentialClient())
+
+      await model.saveAuthorizationCode(baseCode, baseCode.client, baseCode.user)
+
+      expect(mockRedis.set).toHaveBeenCalled()
+      expect(mockRedis.expire).toHaveBeenCalledWith(
+        'oauth2code:test-auth-code-123',
+        testConfig.authorizationCodeTtlSeconds,
+      )
+    })
+
+    it('stores PKCE data when provided', async () => {
+      const verifier = generateCodeVerifier()
+      const challenge = generateCodeChallenge(verifier)
+      mockRepo.getClientByClientId.mockResolvedValue(createMockPublicClient())
+
+      const codeWithPKCE: AuthorizationCode = {
+        ...baseCode,
+        client: { id: 'test-public-client-id', grants: ['authorization_code'] },
+        redirectUri: 'myapp://callback',
+        codeChallenge: challenge,
+        codeChallengeMethod: 'S256',
+      }
+
+      await model.saveAuthorizationCode(codeWithPKCE, codeWithPKCE.client, codeWithPKCE.user)
+
+      expect(mockRedis.set).toHaveBeenCalled()
+      const storedValue = JSON.parse(mockRedis.set.mock.calls[0][1])
+      expect(storedValue.codeChallenge).toBe(challenge)
+      expect(storedValue.codeChallengeMethod).toBe('S256')
+    })
+
+    it('omits PKCE data when not provided', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(createMockConfidentialClient())
+
+      await model.saveAuthorizationCode(baseCode, baseCode.client, baseCode.user)
+
+      const storedValue = JSON.parse(mockRedis.set.mock.calls[0][1])
+      expect(storedValue.codeChallenge).toBeUndefined()
+      expect(storedValue.codeChallengeMethod).toBeUndefined()
+    })
+
+    it('returns null if client does not exist', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(undefined)
+
+      const result = await model.saveAuthorizationCode(baseCode, baseCode.client, baseCode.user)
+
+      expect(result).toBeNull()
+      expect(mockRedis.set).not.toHaveBeenCalled()
+    })
+
+    // Note: saveOrUpdateConsent is called in generateAuthorizationCode, not saveAuthorizationCode
+    // This test verifies the code storage behavior only
+  })
+
+  describe('getAuthorizationCode', () => {
+    it('retrieves code from Redis', async () => {
+      const storedCode = {
+        authorizationCode: 'test-code',
+        expiresAt: new Date(Date.now() + 60000).toISOString(),
+        redirectUri: 'https://example.com/callback',
+        scope: ['user'],
+        client: { id: 'test-client-id', grants: ['authorization_code', 'refresh_token'] },
+        user: { id: 1 },
+      }
+      mockRedis._store.set('oauth2code:test-code', JSON.stringify(storedCode))
+
+      const result = await model.getAuthorizationCode('test-code')
+
+      expect(result).not.toBeNull()
+      expect(result!.authorizationCode).toBe('test-code')
+    })
+
+    it('retrieves code with PKCE data intact', async () => {
+      const challenge = generateCodeChallenge(generateCodeVerifier())
+      const storedCode = {
+        authorizationCode: 'test-pkce-code',
+        expiresAt: new Date(Date.now() + 60000).toISOString(),
+        redirectUri: 'myapp://callback',
+        scope: ['user'],
+        codeChallenge: challenge,
+        codeChallengeMethod: 'S256',
+        client: { id: 'test-public-client-id', grants: ['authorization_code', 'refresh_token'] },
+        user: { id: 1 },
+      }
+      mockRedis._store.set('oauth2code:test-pkce-code', JSON.stringify(storedCode))
+
+      const result = await model.getAuthorizationCode('test-pkce-code')
+
+      expect(result!.codeChallenge).toBe(challenge)
+      expect(result!.codeChallengeMethod).toBe('S256')
+    })
+
+    it('converts expiresAt string back to Date object', async () => {
+      const expiresAt = new Date(Date.now() + 60000)
+      const storedCode = {
+        authorizationCode: 'test-code',
+        expiresAt: expiresAt.toISOString(),
+        redirectUri: 'https://example.com/callback',
+        scope: ['user'],
+        client: { id: 'test-client-id', grants: ['authorization_code'] },
+        user: { id: 1 },
+      }
+      mockRedis._store.set('oauth2code:test-code', JSON.stringify(storedCode))
+
+      const result = await model.getAuthorizationCode('test-code')
+
+      expect(result!.expiresAt).toBeInstanceOf(Date)
+    })
+
+    it('converts grants string to array when needed', async () => {
+      const storedCode = {
+        authorizationCode: 'test-code',
+        expiresAt: new Date(Date.now() + 60000).toISOString(),
+        redirectUri: 'https://example.com/callback',
+        scope: ['user'],
+        client: { id: 'test-client-id', grants: 'authorization_code,refresh_token' }, // String, not array
+        user: { id: 1 },
+      }
+      mockRedis._store.set('oauth2code:test-code', JSON.stringify(storedCode))
+      mockRepo.getClientByClientId.mockResolvedValue(createMockConfidentialClient())
+
+      const result = await model.getAuthorizationCode('test-code')
+
+      expect(Array.isArray(result!.client.grants)).toBe(true)
+      expect(result!.client.grants).toContain('authorization_code')
+      expect(result!.client.grants).toContain('refresh_token')
+    })
+
+    it('returns null for non-existent code', async () => {
+      const result = await model.getAuthorizationCode('non-existent-code')
+
+      expect(result).toBeNull()
+    })
+
+    it('returns null and revokes expired codes', async () => {
+      const storedCode = {
+        authorizationCode: 'expired-code',
+        expiresAt: new Date(Date.now() - 60000).toISOString(), // Expired
+        redirectUri: 'https://example.com/callback',
+        scope: ['user'],
+        client: { id: 'test-client-id', grants: ['authorization_code'] },
+        user: { id: 1 },
+      }
+      mockRedis._store.set('oauth2code:expired-code', JSON.stringify(storedCode))
+
+      const result = await model.getAuthorizationCode('expired-code')
+
+      expect(result).toBeNull()
+      expect(mockRedis.del).toHaveBeenCalledWith('oauth2code:expired-code')
+    })
+
+    it('returns null for invalid JSON', async () => {
+      mockRedis._store.set('oauth2code:bad-code', 'not valid json')
+
+      const result = await model.getAuthorizationCode('bad-code')
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('revokeAuthorizationCode', () => {
+    it('deletes code from Redis', async () => {
+      const code: AuthorizationCode = {
+        authorizationCode: 'code-to-revoke',
+        expiresAt: new Date(),
+        redirectUri: 'https://example.com/callback',
+        scope: ['user'],
+        client: { id: 'test-client-id', grants: ['authorization_code'] },
+        user: { id: 1 },
+      }
+
+      const result = await model.revokeAuthorizationCode(code)
+
+      expect(result).toBe(true)
+      expect(mockRedis.del).toHaveBeenCalledWith('oauth2code:code-to-revoke')
+    })
+  })
+
+  describe('static methods', () => {
+    describe('generateClientId', () => {
+      it('generates a UUID', () => {
+        const clientId = AuthorizationCodeModelImpl.generateClientId()
+        // UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+        expect(clientId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+      })
+
+      it('generates unique values', () => {
+        const ids = new Set<string>()
+        for (let i = 0; i < 100; i++) {
+          ids.add(AuthorizationCodeModelImpl.generateClientId())
+        }
+        expect(ids.size).toBe(100)
+      })
+    })
+
+    describe('generateClientSecret', () => {
+      it('generates a 64-character hex string', () => {
+        const secret = AuthorizationCodeModelImpl.generateClientSecret()
+        expect(secret).toMatch(/^[0-9a-f]{64}$/i)
+      })
+
+      it('generates unique values', () => {
+        const secrets = new Set<string>()
+        for (let i = 0; i < 100; i++) {
+          secrets.add(AuthorizationCodeModelImpl.generateClientSecret())
+        }
+        expect(secrets.size).toBe(100)
+      })
+    })
+
+    describe('hashString', () => {
+      it('produces consistent SHA-256 hash', () => {
+        const hash1 = AuthorizationCodeModelImpl.hashString('test-value')
+        const hash2 = AuthorizationCodeModelImpl.hashString('test-value')
+        expect(hash1).toBe(hash2)
+      })
+
+      it('produces different hashes for different inputs', () => {
+        const hash1 = AuthorizationCodeModelImpl.hashString('value1')
+        const hash2 = AuthorizationCodeModelImpl.hashString('value2')
+        expect(hash1).not.toBe(hash2)
+      })
+
+      it('produces 64-character hex string', () => {
+        const hash = AuthorizationCodeModelImpl.hashString('test')
+        expect(hash).toMatch(/^[0-9a-f]{64}$/i)
+      })
+
+      it('matches our test helper hashString', () => {
+        const value = 'test-secret'
+        expect(AuthorizationCodeModelImpl.hashString(value)).toBe(hashString(value))
+      })
+    })
+  })
+})

--- a/backend/test/oauth/pkce.test.ts
+++ b/backend/test/oauth/pkce.test.ts
@@ -1,0 +1,110 @@
+import { generateCodeChallenge, generateCodeVerifier, verifyCodeChallenge } from '../utils/oauth2TestHelpers'
+
+describe('PKCE Utils', () => {
+  describe('generateCodeVerifier', () => {
+    it('generates a string of default length 43', () => {
+      const verifier = generateCodeVerifier()
+      expect(verifier.length).toBe(43)
+    })
+
+    it('generates a string of specified length', () => {
+      const verifier = generateCodeVerifier(64)
+      expect(verifier.length).toBe(64)
+    })
+
+    it('generates a string of maximum length 128', () => {
+      const verifier = generateCodeVerifier(128)
+      expect(verifier.length).toBe(128)
+    })
+
+    it('throws for length less than 43', () => {
+      expect(() => generateCodeVerifier(42)).toThrow('Code verifier length must be between 43 and 128')
+    })
+
+    it('throws for length greater than 128', () => {
+      expect(() => generateCodeVerifier(129)).toThrow('Code verifier length must be between 43 and 128')
+    })
+
+    it('uses only URL-safe characters [A-Za-z0-9-_]', () => {
+      const verifier = generateCodeVerifier()
+      // URL-safe base64 characters only (no +, /, or =)
+      expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/)
+    })
+
+    it('generates unique values on each call', () => {
+      const verifiers = new Set<string>()
+      for (let i = 0; i < 100; i++) {
+        verifiers.add(generateCodeVerifier())
+      }
+      // All 100 should be unique
+      expect(verifiers.size).toBe(100)
+    })
+  })
+
+  describe('generateCodeChallenge', () => {
+    it('generates base64url-encoded string', () => {
+      const verifier = generateCodeVerifier()
+      const challenge = generateCodeChallenge(verifier)
+      // Should be URL-safe base64 (no +, /, or =)
+      expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/)
+    })
+
+    it('produces consistent output for same input', () => {
+      const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+      const challenge1 = generateCodeChallenge(verifier)
+      const challenge2 = generateCodeChallenge(verifier)
+      expect(challenge1).toBe(challenge2)
+    })
+
+    it('produces different output for different input', () => {
+      const verifier1 = generateCodeVerifier()
+      const verifier2 = generateCodeVerifier()
+      const challenge1 = generateCodeChallenge(verifier1)
+      const challenge2 = generateCodeChallenge(verifier2)
+      expect(challenge1).not.toBe(challenge2)
+    })
+
+    // RFC 7636 Appendix B test vector
+    it('matches RFC 7636 Appendix B test vector', () => {
+      const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+      const expectedChallenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'
+      const challenge = generateCodeChallenge(verifier)
+      expect(challenge).toBe(expectedChallenge)
+    })
+
+    it('generates challenge of expected length (~43 chars for SHA-256)', () => {
+      const verifier = generateCodeVerifier()
+      const challenge = generateCodeChallenge(verifier)
+      // SHA-256 = 32 bytes = 43 base64 chars (without padding)
+      expect(challenge.length).toBe(43)
+    })
+  })
+
+  describe('verifyCodeChallenge', () => {
+    it('returns true for matching verifier/challenge pair', () => {
+      const verifier = generateCodeVerifier()
+      const challenge = generateCodeChallenge(verifier)
+      expect(verifyCodeChallenge(verifier, challenge)).toBe(true)
+    })
+
+    it('returns false for mismatched verifier/challenge pair', () => {
+      const verifier1 = generateCodeVerifier()
+      const verifier2 = generateCodeVerifier()
+      const challenge = generateCodeChallenge(verifier1)
+      expect(verifyCodeChallenge(verifier2, challenge)).toBe(false)
+    })
+
+    it('returns false for tampered challenge', () => {
+      const verifier = generateCodeVerifier()
+      const challenge = generateCodeChallenge(verifier)
+      const tamperedChallenge = challenge.slice(0, -1) + 'X'
+      expect(verifyCodeChallenge(verifier, tamperedChallenge)).toBe(false)
+    })
+
+    it('verifies RFC 7636 test vector', () => {
+      const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+      const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'
+      expect(verifyCodeChallenge(verifier, challenge)).toBe(true)
+    })
+  })
+})

--- a/backend/test/utils/oauth2TestHelpers.ts
+++ b/backend/test/utils/oauth2TestHelpers.ts
@@ -1,0 +1,150 @@
+import crypto from 'crypto'
+
+import { OAuth2ClientRaw } from '../../src/db/types/OAuth2'
+
+/**
+ * Generates a PKCE code verifier (43-128 characters, URL-safe)
+ * Per RFC 7636 Section 4.1
+ */
+export function generateCodeVerifier(length = 43): string {
+  if (length < 43 || length > 128) {
+    throw new Error('Code verifier length must be between 43 and 128')
+  }
+  const buffer = crypto.randomBytes(Math.ceil((length * 3) / 4))
+  return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '').slice(0, length)
+}
+
+/**
+ * Generates a PKCE code challenge from a verifier using SHA-256
+ * Per RFC 7636 Section 4.2
+ */
+export function generateCodeChallenge(verifier: string): string {
+  const hash = crypto.createHash('sha256').update(verifier).digest()
+  return hash.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+}
+
+/**
+ * Verifies that a code_verifier matches a code_challenge
+ */
+export function verifyCodeChallenge(verifier: string, challenge: string): boolean {
+  const computedChallenge = generateCodeChallenge(verifier)
+  return computedChallenge === challenge
+}
+
+/**
+ * Creates a mock public OAuth2 client (no client_secret)
+ */
+export function createMockPublicClient(overrides?: Partial<OAuth2ClientRaw>): OAuth2ClientRaw {
+  return {
+    id: 1,
+    name: 'Test Public App',
+    description: 'A test public application',
+    client_id: 'test-public-client-id',
+    client_secret_hash: '',
+    client_type: 'public',
+    redirect_uris: 'myapp://callback',
+    grants: 'authorization_code,refresh_token',
+    user_id: 1,
+    logo_url: '',
+    initial_authorization_url: '',
+    ...overrides,
+  }
+}
+
+/**
+ * Creates a mock confidential OAuth2 client (with client_secret)
+ */
+export function createMockConfidentialClient(overrides?: Partial<OAuth2ClientRaw>): OAuth2ClientRaw {
+  const secretHash = crypto.createHash('sha256').update('test-secret').digest('hex')
+  return {
+    id: 2,
+    name: 'Test Confidential App',
+    description: 'A test confidential application',
+    client_id: 'test-confidential-client-id',
+    client_secret_hash: secretHash,
+    client_type: 'confidential',
+    redirect_uris: 'https://example.com/callback',
+    grants: 'authorization_code,refresh_token',
+    user_id: 1,
+    logo_url: '',
+    initial_authorization_url: '',
+    ...overrides,
+  }
+}
+
+/**
+ * Creates a mock Redis client for testing
+ */
+export function createMockRedisClient() {
+  const store = new Map<string, string>()
+  const expiries = new Map<string, number>()
+
+  return {
+    get: jest.fn((key: string) => Promise.resolve(store.get(key) || null)),
+    set: jest.fn((key: string, value: string) => {
+      store.set(key, value)
+      return Promise.resolve('OK')
+    }),
+    del: jest.fn((key: string) => {
+      const existed = store.has(key)
+      store.delete(key)
+      expiries.delete(key)
+      return Promise.resolve(existed ? 1 : 0)
+    }),
+    expire: jest.fn((key: string, seconds: number) => {
+      if (store.has(key)) {
+        expiries.set(key, Date.now() + seconds * 1000)
+        return Promise.resolve(1)
+      }
+      return Promise.resolve(0)
+    }),
+    // Test helpers
+    _store: store,
+    _expiries: expiries,
+    _clear: () => {
+      store.clear()
+      expiries.clear()
+    },
+  }
+}
+
+/**
+ * Creates a mock logger for testing
+ */
+export function createMockLogger() {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }
+}
+
+/**
+ * Creates a mock OAuth2Repository for testing
+ */
+export function createMockOAuth2Repository() {
+  return {
+    getClientByClientId: jest.fn(),
+    getClientByClientIdWithConsent: jest.fn(),
+    getClients: jest.fn(),
+    getNumberOfClientsCreatedByUser: jest.fn().mockResolvedValue(0),
+    createClient: jest.fn(),
+    updateClientSecret: jest.fn(),
+    deleteClient: jest.fn(),
+    saveOrUpdateConsent: jest.fn().mockResolvedValue(true),
+    resetConsentScope: jest.fn(),
+    updateConsentLastRevokeDate: jest.fn(),
+    updateClientLogoUrl: jest.fn(),
+    hasOwnApps: jest.fn(),
+    editClient: jest.fn(),
+    getClientsByClientIds: jest.fn(),
+  }
+}
+
+/**
+ * Hash a string using SHA-256 (matches AuthorizationCodeModelImpl.hashString)
+ */
+export function hashString(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex')
+}

--- a/docs/api/oauth2/README.md
+++ b/docs/api/oauth2/README.md
@@ -21,13 +21,14 @@ To create a client application, follow these steps:
 4. Fill in the required information:
     - **Name**: Your application name (2-32 characters)
     - **Description**: What your app does (up to 255 characters)
+    - **Client Type**: Choose between "public" or "confidential" (see Client Types section below)
     - **Redirect URIs**: Where users will be sent after authorization (comma-separated list)
     - **App connection URL** (optional): The URL where users will go when clicking the "Connect"
       button on your application card. This URL is usually the landing page of your application.
 
 5. After creating your application, you will receive:
     - **Client ID**: Public identifier for your application
-    - **Client Secret**: Private key that must be kept secure
+    - **Client Secret**: Private key that must be kept secure (confidential clients only)
 
 **Important**:
 
@@ -59,6 +60,86 @@ The embedded card will show:
 - Logo (if you uploaded one)
 - "Connect" button (if you provided an App connection URL)
 
+## Client Types
+
+Orbitar supports two types of OAuth2 clients:
+
+### Confidential Clients
+
+Confidential clients are applications that can securely store a client secret. These are typically:
+
+- Server-side web applications
+- Backend services
+- Applications where the source code is not exposed to users
+
+Confidential clients receive a **Client Secret** upon registration that must be kept secure and used during token exchange.
+
+### Public Clients
+
+Public clients are applications that cannot securely store a client secret. These include:
+
+- Single-page applications (SPAs)
+- Mobile applications
+- Desktop applications
+- Any application where the code is distributed to users
+
+Public clients:
+
+- Do **not** receive a Client Secret
+- **Must** use PKCE (Proof Key for Code Exchange) for authorization
+- Cannot use Basic Authentication for token requests
+
+## PKCE (Proof Key for Code Exchange)
+
+PKCE is a security extension to OAuth2 that protects the authorization code flow, especially for public clients. It prevents authorization code interception attacks.
+
+**PKCE is required for public clients and optional (but recommended) for confidential clients.**
+
+### How PKCE Works
+
+1. Your application generates a random `code_verifier` (43-128 characters, URL-safe)
+2. Your application creates a `code_challenge` by hashing the verifier with SHA-256 and base64url-encoding it
+3. The `code_challenge` is sent with the authorization request
+4. The `code_verifier` is sent with the token exchange request
+5. The server verifies that the challenge matches the verifier
+
+### Generating PKCE Parameters
+
+**Step 1: Generate a Code Verifier**
+
+The code verifier is a cryptographically random string using the characters A-Z, a-z, 0-9, and the punctuation characters `-._~`, between 43 and 128 characters long.
+
+Example (JavaScript):
+
+```javascript
+function generateCodeVerifier() {
+  const array = new Uint8Array(32)
+  crypto.getRandomValues(array)
+  return btoa(String.fromCharCode(...array))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+```
+
+**Step 2: Create a Code Challenge**
+
+The code challenge is created by taking the SHA-256 hash of the code verifier and base64url-encoding it.
+
+Example (JavaScript):
+
+```javascript
+async function generateCodeChallenge(verifier) {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(verifier)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+}
+```
+
 ## Understanding OAuth2 Flow
 
 OAuth2 in Orbitar uses
@@ -75,8 +156,16 @@ which is [defined in RFC 6749, section 4.1](https://datatracker.ietf.org/doc/htm
 
 Redirect the user to Orbitar's authorization endpoint:
 
+**For confidential clients (without PKCE):**
+
 ```
 https://orbitar.space/oauth2/authorize?client_id=YOUR_CLIENT_ID&scope=REQUESTED_SCOPES&redirect_uri=YOUR_REDIRECT_URI&state=RANDOM_STATE_STRING
+```
+
+**For public clients or confidential clients using PKCE:**
+
+```
+https://orbitar.space/oauth2/authorize?client_id=YOUR_CLIENT_ID&scope=REQUESTED_SCOPES&redirect_uri=YOUR_REDIRECT_URI&state=RANDOM_STATE_STRING&code_challenge=CODE_CHALLENGE&code_challenge_method=S256
 ```
 
 Parameters:
@@ -85,6 +174,8 @@ Parameters:
 - `scope`: Space-separated list of permissions your app needs
 - `redirect_uri`: Must match one of the URIs you registered
 - `state`: Random string for security validation (see security note below)
+- `code_challenge`: The PKCE code challenge (required for public clients)
+- `code_challenge_method`: Must be `S256` (required when using PKCE)
 
 **Note**: If you provided an App connection URL, you have two options for this URL:
 
@@ -130,8 +221,11 @@ The state parameter should match the one you sent in the authorization request.
 
 ### Step 4: Token Exchange
 
-Your application must exchange this code for access and refresh tokens. You can authenticate using either Basic
-Authentication in the header or by including client credentials in the request body.
+Your application must exchange this code for access and refresh tokens. The authentication method depends on your client type.
+
+#### For Confidential Clients
+
+You can authenticate using either Basic Authentication in the header or by including client credentials in the request body.
 
 **Method 1: Using Basic Authentication (recommended)**
 
@@ -152,14 +246,32 @@ Content-Type: application/x-www-form-urlencoded
 grant_type=authorization_code&code=AUTHORIZATION_CODE&nonce=RANDOM_STRING&redirect_uri=YOUR_REDIRECT_URI&client_id=YOUR_CLIENT_ID&client_secret=YOUR_CLIENT_SECRET
 ```
 
-Parameters:
+If you used PKCE during authorization, include the `code_verifier` parameter:
+
+```
+grant_type=authorization_code&code=AUTHORIZATION_CODE&nonce=RANDOM_STRING&redirect_uri=YOUR_REDIRECT_URI&code_verifier=YOUR_CODE_VERIFIER
+```
+
+#### For Public Clients (PKCE Required)
+
+Public clients must include the `code_verifier` and cannot use client secret authentication:
+
+```
+POST https://api.orbitar.space/api/v1/oauth2/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code&code=AUTHORIZATION_CODE&redirect_uri=YOUR_REDIRECT_URI&client_id=YOUR_CLIENT_ID&code_verifier=YOUR_CODE_VERIFIER
+```
+
+#### Parameters
 
 - `grant_type`: Must be "authorization_code"
 - `code`: The authorization code received from the previous step
 - `nonce`: Optional random string for additional security
 - `redirect_uri`: Must match the URI used in the authorization request
-- `client_id`: Your application's Client ID (if using Method 2)
-- `client_secret`: Your application's Client Secret (if using Method 2)
+- `client_id`: Your application's Client ID (required for public clients, optional for confidential clients using Method 2)
+- `client_secret`: Your application's Client Secret (confidential clients only)
+- `code_verifier`: The original PKCE code verifier (required for public clients, optional for confidential clients that used PKCE)
 
 The response contains:
 
@@ -187,8 +299,11 @@ example, to access the `/api/v1/status` endpoint, your authorized scopes must in
 
 ### Step 6: Refreshing Tokens
 
-Access tokens expire after a period of time (usually 30 minutes). Use the refresh token to get a new access token. You
-can authenticate using either Basic Authentication in the header or by including client credentials in the request body.
+Access tokens expire after a period of time (usually 30 minutes). Use the refresh token to get a new access token.
+
+#### For Confidential Clients
+
+You can authenticate using either Basic Authentication in the header or by including client credentials in the request body.
 
 **Method 1: Using Basic Authentication (recommended)**
 
@@ -207,6 +322,17 @@ POST https://api.orbitar.space/api/v1/oauth2/token
 Content-Type: application/x-www-form-urlencoded
 
 grant_type=refresh_token&refresh_token=REFRESH_TOKEN&client_id=YOUR_CLIENT_ID&client_secret=YOUR_CLIENT_SECRET
+```
+
+#### For Public Clients
+
+Public clients include only the client_id (no secret):
+
+```
+POST https://api.orbitar.space/api/v1/oauth2/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=refresh_token&refresh_token=REFRESH_TOKEN&client_id=YOUR_CLIENT_ID
 ```
 
 If the refresh token has expired, you'll need to initiate a new authorization flow for the user starting from Step 1.
@@ -273,22 +399,26 @@ automatically remove redundant scopes. For example, if you request both `user` a
 
 ## Security Best Practices
 
-1. **Keep Client Secret secure**: Never expose it in client-side code
+1. **Keep Client Secret secure**: Never expose it in client-side code (confidential clients only)
 2. **Use HTTPS**: Always use secure connections
 3. **Validate redirect URIs**: Prevent open redirector attacks
 4. **Request minimum scopes**: Only ask for permissions you need
 5. **Handle token expiration**: Properly refresh tokens when needed
-6. Make sure to pass and validate the `state` parameter during the authorization process
+6. **Validate the state parameter**: Always verify the `state` parameter matches during the authorization callback
+7. **Use PKCE**: Even for confidential clients, PKCE adds an extra layer of security
+8. **Choose the right client type**: Use public clients for SPAs, mobile, and desktop apps; use confidential clients for server-side applications
 
 ## Troubleshooting
 
 Common issues and solutions:
 
 - **Invalid redirect URI**: Make sure the URI matches exactly what you registered
-- **Invalid client credentials**: Check your client ID and secret
+- **Invalid client credentials**: Check your client ID and secret (confidential clients only)
 - **Invalid scopes**: Make sure requested scopes are valid
 - **Expired authorization code**: Codes expire quickly, exchange them immediately
 - **Expired access token**: Use refresh token to get a new access token
+- **Missing code_challenge**: Public clients must include PKCE parameters in the authorization request
+- **Invalid code_verifier**: The code_verifier must match the code_challenge sent during authorization
 
 ## Sample Applications
 

--- a/frontend/src/API/OAuth2Api.ts
+++ b/frontend/src/API/OAuth2Api.ts
@@ -15,6 +15,7 @@ export type OAuth2RegisterRequest = {
   logoUrl?: string
   redirectUris: string
   initialAuthorizationUrl?: string
+  clientType: 'public' | 'confidential'
 }
 
 export type OAuth2EditRequest = {
@@ -99,6 +100,7 @@ export default class OAuth2Api {
     redirectUris: string,
     logoUrl = '',
     initialAuthorizationUrl = '',
+    clientType: 'public' | 'confidential' = 'confidential',
   ): Promise<OAuth2RegisterResponse> {
     return await this.api.request<OAuth2RegisterRequest, OAuth2RegisterResponse>('/oauth2/client/register', {
       name,
@@ -106,6 +108,7 @@ export default class OAuth2Api {
       logoUrl,
       redirectUris: redirectUris,
       initialAuthorizationUrl,
+      clientType,
     })
   }
 

--- a/frontend/src/Components/OAuth2AppCardModalComponent.tsx
+++ b/frontend/src/Components/OAuth2AppCardModalComponent.tsx
@@ -252,10 +252,12 @@ export function OAuth2AppCardModalComponent(props: OAuth2AppCardModalProps) {
               <FaEdit />
               редактировать
             </Button>
-            <Button onClick={handleClientSecretUpdate}>
-              <FaKey />
-              сбросить секрет
-            </Button>
+            {client.clientType === 'confidential' && (
+              <Button onClick={handleClientSecretUpdate}>
+                <FaKey />
+                сбросить секрет
+              </Button>
+            )}
             {!client.installationsCount && (
               <Button variant='danger' onClick={handleClientDelete}>
                 <FaTrash />

--- a/frontend/src/Components/OAuth2AuthorizeComponent.tsx
+++ b/frontend/src/Components/OAuth2AuthorizeComponent.tsx
@@ -14,6 +14,8 @@ interface OAuth2AuthorizeComponentProps {
   redirectUri?: string
   state?: string
   sessionId?: string
+  codeChallenge?: string
+  codeChallengeMethod?: string
   onAuthorizeDeny?: () => void
 }
 
@@ -34,6 +36,10 @@ export function OAuth2AuthorizeComponent(props: OAuth2AuthorizeComponentProps) {
             <input type='hidden' name='redirect_uri' value={props.redirectUri} />
             <input type='hidden' name='X-Session-Id' value={props.sessionId} />
             <input type='hidden' name='response_type' value='code' />
+            {props.codeChallenge && <input type='hidden' name='code_challenge' value={props.codeChallenge} />}
+            {props.codeChallengeMethod && (
+              <input type='hidden' name='code_challenge_method' value={props.codeChallengeMethod} />
+            )}
 
             <div className={styles.buttonsContainer}>
               <Button variant='primary' size='big' type='submit'>

--- a/frontend/src/Components/UserProfileClientAppsCreateForm.tsx
+++ b/frontend/src/Components/UserProfileClientAppsCreateForm.tsx
@@ -17,6 +17,7 @@ type AppSubmitFormValues = {
   grants: string
   logoUrl?: string
   initialAuthorizationUrl: string
+  clientType: 'public' | 'confidential'
 }
 
 type UserProfileClientAppsCreateFormProps = {
@@ -31,9 +32,10 @@ export default function UserProfileClientAppsCreateForm(props: UserProfileClient
 
   const onSubmit: SubmitHandler<AppSubmitFormValues> = (data) => {
     setSubmitting(true)
-    const { name, description, redirectUris, logoUrl, initialAuthorizationUrl } = data
+    const { name, description, redirectUris, logoUrl, initialAuthorizationUrl, clientType } = data
 
     if (editingClient) {
+      // Client type cannot be changed after creation
       api.oauth2Api
         .editClient(editingClient.clientId, description, redirectUris, initialAuthorizationUrl)
         .then((newClient) => {
@@ -51,7 +53,7 @@ export default function UserProfileClientAppsCreateForm(props: UserProfileClient
     }
 
     api.oauth2Api
-      .registerClient(name, description, redirectUris, logoUrl, initialAuthorizationUrl)
+      .registerClient(name, description, redirectUris, logoUrl, initialAuthorizationUrl, clientType)
       .then((data) => {
         if (onClientRegisterSuccess) {
           onClientRegisterSuccess(data.client)
@@ -79,17 +81,38 @@ export default function UserProfileClientAppsCreateForm(props: UserProfileClient
 
   const validateUrls = (value: string) => {
     const urls = value.split(',').map((url) => url.trim())
-    return (
-      urls.every((url) =>
-        isURL(url, {
-          require_tld: process.env.NODE_ENV !== 'development',
-          require_protocol: true,
-          allow_fragments:
-            false /*RFC 6749 Section 3.1.2: The redirection endpoint URI MUST NOT include a fragment component.*/,
-          protocols: ['https', ...(process.env.NODE_ENV === 'development' ? ['https', 'http'] : [])],
-        }),
-      ) || 'Введите URL-адреса, разделенные запятыми'
-    )
+    for (const url of urls) {
+      try {
+        const urlObj = new URL(url)
+
+        // RFC 6749 Section 3.1.2: no fragments
+        if (urlObj.hash && urlObj.hash !== '#') {
+          return 'Redirect URIs must not include fragment components'
+        }
+
+        // Strict validation for http/https
+        if (urlObj.protocol === 'http:' || urlObj.protocol === 'https:') {
+          if (
+            !isURL(url, {
+              require_tld: process.env.NODE_ENV !== 'development',
+              require_protocol: true,
+              allow_fragments: false,
+              protocols: ['https', ...(process.env.NODE_ENV === 'development' ? ['http'] : [])],
+            })
+          ) {
+            return 'Invalid HTTP/HTTPS URL'
+          }
+        } else {
+          // Custom protocols: minimal validation
+          if (!urlObj.protocol || urlObj.protocol === ':') {
+            return 'Custom protocol URIs must have a valid protocol scheme'
+          }
+        }
+      } catch (err) {
+        return 'Invalid URI format'
+      }
+    }
+    return true
   }
 
   const validateOptionalUrl = (value: string) => {
@@ -153,12 +176,39 @@ export default function UserProfileClientAppsCreateForm(props: UserProfileClient
           </label>
 
           <label>
+            <b>Тип клиента:</b>
+            <select
+              {...(!editingClient
+                ? register('clientType', {
+                    required: 'Выберите тип клиента',
+                  })
+                : {})}
+              disabled={Boolean(editingClient)}
+              defaultValue={editingClient ? editingClient.clientType : 'confidential'}
+            >
+              <option value='confidential'>Confidential (серверное приложение с client_secret)</option>
+              <option value='public'>Public (мобильное/десктопное приложение с PKCE)</option>
+            </select>
+            <p>
+              <span className={classNames('i', 'i-info')}></span> Confidential клиенты используют client_secret для
+              аутентификации (веб-приложения, серверные приложения). Public клиенты используют PKCE и не имеют
+              client_secret (мобильные и десктопные приложения).
+            </p>
+            {errors.clientType && <p className={styles.error}>{errors.clientType.message}</p>}
+          </label>
+
+          <label>
             <b>Разрешённые URL для редиректов (через запятую):</b>
             <input
               type='text'
               {...register('redirectUris', { validate: validateUrls })}
               defaultValue={editingClient ? editingClient.redirectUris : ''}
+              placeholder='https://example.com/callback, myapp://callback'
             />
+            <p>
+              <span className={classNames('i', 'i-info')}></span> Поддерживаются HTTPS URLs и custom protocol URIs
+              (например, myapp://callback для мобильных приложений). В development режиме также разрешены HTTP URLs.
+            </p>
             {errors.redirectUris && <p className={styles.error}>{errors.redirectUris.message}</p>}
           </label>
 

--- a/frontend/src/Components/UserProfileClientsApps.tsx
+++ b/frontend/src/Components/UserProfileClientsApps.tsx
@@ -92,25 +92,27 @@ export default function UserProfileClientsApps() {
               <h4>ID вашего приложения (client_id)</h4>
               <CopyableEmbedCodeComponent text={generatedSecret.clientId} />
             </div>
-            <div>
-              <h4>Секретный код приложения (client_secret)</h4>
-              <CopyableEmbedCodeComponent text={generatedSecret.secret} />
+            {generatedSecret.secret && (
+              <div>
+                <h4>Секретный код приложения (client_secret)</h4>
+                <CopyableEmbedCodeComponent text={generatedSecret.secret} />
 
-              <span className={styles.codeInfo}>
-                Скопируйте ID приложения (client_id) и секретный код и сохраните эти данные в надёжном месте.
-                <br />
-                Мы храним секретные коды в зашифрованном виде и не можем их восстановить.
-                <br />
-                <br />
-                {generatedSecret.type !== 'new' && (
-                  <>
-                    Правда, вы сможете перегенерировать его в любое время, но тогда вам также придётся обновить код в
-                    своём приложении.
-                  </>
-                )}
-              </span>
-              <span className={styles.clientSecret}>{}</span>
-            </div>
+                <span className={styles.codeInfo}>
+                  Скопируйте ID приложения (client_id) и секретный код и сохраните эти данные в надёжном месте.
+                  <br />
+                  Мы храним секретные коды в зашифрованном виде и не можем их восстановить.
+                  <br />
+                  <br />
+                  {generatedSecret.type !== 'new' && (
+                    <>
+                      Правда, вы сможете перегенерировать его в любое время, но тогда вам также придётся обновить код в
+                      своём приложении.
+                    </>
+                  )}
+                </span>
+                <span className={styles.clientSecret}>{}</span>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/Pages/OAuthClientPage.tsx
+++ b/frontend/src/Pages/OAuthClientPage.tsx
@@ -20,6 +20,8 @@ export const OAuthClientPage = observer(() => {
   const responseType = urlParams.get('response_type') || 'code'
   const redirectUri = urlParams.get('redirect_uri') || ''
   const state = urlParams.get('state') || ''
+  const codeChallenge = urlParams.get('code_challenge') || ''
+  const codeChallengeMethod = urlParams.get('code_challenge_method') || ''
 
   const sessionId = Cookies.get('session') || ''
 
@@ -127,6 +129,8 @@ export const OAuthClientPage = observer(() => {
           redirectUri={redirectUri}
           state={state}
           sessionId={sessionId}
+          codeChallenge={codeChallenge}
+          codeChallengeMethod={codeChallengeMethod}
           onAuthorizeDeny={onDecline}
         />
       </OAuth2AppCardModalComponent>

--- a/frontend/src/Types/OAuth2.ts
+++ b/frontend/src/Types/OAuth2.ts
@@ -11,6 +11,7 @@ export type OAuth2ClientEntity = {
   initialAuthorizationUrl: string
   redirectUris: string
   grants: string[]
+  clientType: 'public' | 'confidential'
   author: UserBaseInfo
   scopes?: string
   installationsCount?: number

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -15,7 +15,7 @@ Each theme is defined using key colors
 - glass          semi-transparent background
 
 All other color variants are generated automatically (if not defined manually)
-preview of all theme colors is available at http://orbitar.local/theme
+preview of all theme colors is available at http://orbitar.test/theme
 
 
 */

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -15,7 +15,7 @@ Each theme is defined using key colors
 - glass          semi-transparent background
 
 All other color variants are generated automatically (if not defined manually)
-preview of all theme colors is available at http://orbitar.test/theme
+preview of all theme colors is available at http://orbitar.local/theme
 
 
 */


### PR DESCRIPTION
- Add client_type column (public/confidential) to oauth_clients table
- Public clients must use PKCE and cannot have client secrets
- Confidential clients can optionally use PKCE alongside client secrets
- Add code_challenge and code_challenge_method to authorization flow
- Add code_verifier validation during token exchange
- Update frontend with client type selection and conditional secret display
- Add comprehensive PKCE documentation to OAuth2 developer guide
- Improve redirect URI validation with fragment and protocol checks


https://github.com/user-attachments/assets/31d4b8c9-33a8-42ca-90d0-76cc62447c26

