### PR TITLE
Implemented dynamic gallery height

### DIFF
--- a/frontend/src/Components/GalleryComponent.module.scss
+++ b/frontend/src/Components/GalleryComponent.module.scss
@@ -36,6 +36,10 @@ $transition-easing: ease-in-out;
   width: 100%;
 }
 
+.main {
+  transition: height $transition-duration $transition-easing;
+}
+
 // Embla styles
 .embla {
   overflow: hidden;

--- a/frontend/src/Components/GalleryComponent.tsx
+++ b/frontend/src/Components/GalleryComponent.tsx
@@ -119,7 +119,7 @@ function LazyThumbnail({ src, alt, className }: { src?: string; alt?: string; cl
 
 const GalleryComponent: React.FC<GalleryComponentProps> = ({
   elements,
-  height = 'auto',
+  height = 0,
   showThumbnails = true,
   showIndicators = true,
   showArrows = true,
@@ -173,6 +173,16 @@ const GalleryComponent: React.FC<GalleryComponentProps> = ({
     }
   }, [isControlled, onCollapseProp])
 
+  // Calculate the display height for an image maintaining aspect ratio, capped at MAX_HEIGHT
+  const calculateDisplayHeight = useCallback(
+    (naturalWidth: number, naturalHeight: number, containerWidth: number): number => {
+      if (!naturalWidth || !naturalHeight || !containerWidth) return 0
+      const aspectRatio = naturalHeight / naturalWidth
+      return Math.min(containerWidth * aspectRatio, MAX_HEIGHT)
+    },
+    [],
+  )
+
   // Calculate and update gallery height based on image dimensions
   const handleImageLoad = useCallback(
     (index: number, naturalWidth: number, naturalHeight: number) => {
@@ -181,16 +191,18 @@ const GalleryComponent: React.FC<GalleryComponentProps> = ({
       // Only update height for the current image
       if (index !== currentIndexRef.current) return
 
-      const containerWidth = containerRef.current.offsetWidth
-      // Calculate the height the image will be displayed at (maintaining aspect ratio)
-      const aspectRatio = naturalHeight / naturalWidth
-      const displayHeight = Math.min(containerWidth * aspectRatio, MAX_HEIGHT)
+      const displayHeight = calculateDisplayHeight(naturalWidth, naturalHeight, containerRef.current.offsetWidth)
 
       // Update gallery height if this image is taller (only increase, never decrease)
       setGalleryHeight((prevHeight) => Math.max(prevHeight, displayHeight))
     },
-    [expanded],
+    [expanded, calculateDisplayHeight],
   )
+
+  // Reset gallery height when elements change
+  useEffect(() => {
+    setGalleryHeight(0)
+  }, [elements])
 
   // Disable drag in expanded mode to allow zoom-pan-pinch to work (except for videos)
   const emblaPlugins = useMemo(() => (expanded ? [] : [WheelGesturesPlugin({ forceWheelAxis: 'x' })]), [expanded])
@@ -279,11 +291,15 @@ const GalleryComponent: React.FC<GalleryComponentProps> = ({
         const currentSlide = slides[newIndex]
         const img = currentSlide?.querySelector('img')
 
-        if (img && img.naturalWidth && img.naturalHeight) {
-          const containerWidth = containerRef.current.offsetWidth
-          const aspectRatio = img.naturalHeight / img.naturalWidth
-          const displayHeight = Math.min(containerWidth * aspectRatio, MAX_HEIGHT)
-          setGalleryHeight((prevHeight) => Math.max(prevHeight, displayHeight))
+        if (img) {
+          const displayHeight = calculateDisplayHeight(
+            img.naturalWidth,
+            img.naturalHeight,
+            containerRef.current.offsetWidth,
+          )
+          if (displayHeight > 0) {
+            setGalleryHeight((prevHeight) => Math.max(prevHeight, displayHeight))
+          }
         }
       }
     }
@@ -294,7 +310,29 @@ const GalleryComponent: React.FC<GalleryComponentProps> = ({
     return () => {
       emblaApi.off('select', onSelect)
     }
-  }, [emblaApi, onChangeIndex, onSlideLeave, expanded])
+  }, [emblaApi, onChangeIndex, onSlideLeave, expanded, calculateDisplayHeight])
+
+  // Recalculate gallery height on container resize
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container || expanded) return
+
+    const observer = new ResizeObserver(() => {
+      const slides = emblaApi?.slideNodes()
+      if (!slides) return
+      const currentSlide = slides[currentIndexRef.current]
+      const img = currentSlide?.querySelector('img')
+      if (img) {
+        const displayHeight = calculateDisplayHeight(img.naturalWidth, img.naturalHeight, container.offsetWidth)
+        if (displayHeight > 0) {
+          setGalleryHeight(displayHeight)
+        }
+      }
+    })
+
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [emblaApi, expanded, calculateDisplayHeight])
 
   // Scroll to index when prop changes
   useEffect(() => {
@@ -425,9 +463,15 @@ const GalleryComponent: React.FC<GalleryComponentProps> = ({
       {expanded && <div className={styles.overlay} onPointerDown={handlePointerDown} onClick={handleOverlayClick} />}
       <div
         ref={containerRef}
-        className={classNames(styles.main)}
+        className={styles.main}
         style={{
-          height: expanded ? undefined : galleryHeight > 0 ? `${galleryHeight}px` : `${height}px`,
+          height: expanded
+            ? undefined
+            : galleryHeight > 0
+              ? `${galleryHeight}px`
+              : height > 0
+                ? `${height}px`
+                : undefined,
         }}
       >
         <div className={styles.embla} ref={emblaRef}>

--- a/frontend/src/Components/GalleryComponent.tsx
+++ b/frontend/src/Components/GalleryComponent.tsx
@@ -119,7 +119,7 @@ function LazyThumbnail({ src, alt, className }: { src?: string; alt?: string; cl
 
 const GalleryComponent: React.FC<GalleryComponentProps> = ({
   elements,
-  height = MAX_HEIGHT,
+  height = 'auto',
   showThumbnails = true,
   showIndicators = true,
   showArrows = true,
@@ -136,6 +136,8 @@ const GalleryComponent: React.FC<GalleryComponentProps> = ({
   const [currentIndex, setCurrentIndex] = useState<number>(0)
   const [internalExpanded, setInternalExpanded] = useState(false)
   const [captionExpanded, setCaptionExpanded] = useState(false)
+  // Dynamic gallery height - grows to fit taller images, never shrinks
+  const [galleryHeight, setGalleryHeight] = useState<number>(0)
   const containerRef = useRef<HTMLDivElement>(null)
   const thumbnailsRef = useRef<HTMLDivElement>(null)
   const currentIndexRef = useRef<number>(0)
@@ -170,6 +172,25 @@ const GalleryComponent: React.FC<GalleryComponentProps> = ({
       setInternalExpanded(false)
     }
   }, [isControlled, onCollapseProp])
+
+  // Calculate and update gallery height based on image dimensions
+  const handleImageLoad = useCallback(
+    (index: number, naturalWidth: number, naturalHeight: number) => {
+      if (!containerRef.current || expanded) return
+
+      // Only update height for the current image
+      if (index !== currentIndexRef.current) return
+
+      const containerWidth = containerRef.current.offsetWidth
+      // Calculate the height the image will be displayed at (maintaining aspect ratio)
+      const aspectRatio = naturalHeight / naturalWidth
+      const displayHeight = Math.min(containerWidth * aspectRatio, MAX_HEIGHT)
+
+      // Update gallery height if this image is taller (only increase, never decrease)
+      setGalleryHeight((prevHeight) => Math.max(prevHeight, displayHeight))
+    },
+    [expanded],
+  )
 
   // Disable drag in expanded mode to allow zoom-pan-pinch to work (except for videos)
   const emblaPlugins = useMemo(() => (expanded ? [] : [WheelGesturesPlugin({ forceWheelAxis: 'x' })]), [expanded])
@@ -251,6 +272,20 @@ const GalleryComponent: React.FC<GalleryComponentProps> = ({
       setCurrentIndex(newIndex)
       setCaptionExpanded(false) // Reset caption expanded state on slide change
       onChangeIndex?.(newIndex)
+
+      // Update gallery height if the new slide's image is taller (only increase, never decrease)
+      if (!expanded && containerRef.current) {
+        const slides = emblaApi.slideNodes()
+        const currentSlide = slides[newIndex]
+        const img = currentSlide?.querySelector('img')
+
+        if (img && img.naturalWidth && img.naturalHeight) {
+          const containerWidth = containerRef.current.offsetWidth
+          const aspectRatio = img.naturalHeight / img.naturalWidth
+          const displayHeight = Math.min(containerWidth * aspectRatio, MAX_HEIGHT)
+          setGalleryHeight((prevHeight) => Math.max(prevHeight, displayHeight))
+        }
+      }
     }
 
     emblaApi.on('select', onSelect)
@@ -259,7 +294,7 @@ const GalleryComponent: React.FC<GalleryComponentProps> = ({
     return () => {
       emblaApi.off('select', onSelect)
     }
-  }, [emblaApi, onChangeIndex, onSlideLeave])
+  }, [emblaApi, onChangeIndex, onSlideLeave, expanded])
 
   // Scroll to index when prop changes
   useEffect(() => {
@@ -390,9 +425,9 @@ const GalleryComponent: React.FC<GalleryComponentProps> = ({
       {expanded && <div className={styles.overlay} onPointerDown={handlePointerDown} onClick={handleOverlayClick} />}
       <div
         ref={containerRef}
-        className={styles.main}
+        className={classNames(styles.main)}
         style={{
-          height: expanded ? undefined : `${height}px`,
+          height: expanded ? undefined : galleryHeight > 0 ? `${galleryHeight}px` : `${height}px`,
         }}
       >
         <div className={styles.embla} ref={emblaRef}>
@@ -416,11 +451,13 @@ const GalleryComponent: React.FC<GalleryComponentProps> = ({
                   {shouldRender ? (
                     <GalleryElementComponent
                       {...el}
+                      index={index}
                       disableZoom={disableZoom}
                       expanded={expanded}
                       onExpand={() => handleExpand(index)}
                       onNavigatePrev={() => emblaApi?.scrollPrev()}
                       onNavigateNext={() => emblaApi?.scrollNext()}
+                      onImageLoad={handleImageLoad}
                     />
                   ) : null}
                 </div>
@@ -605,12 +642,14 @@ interface GalleryElementProps {
   htmlElement?: HTMLElement
   isVideo?: boolean
   element?: React.ReactNode
+  index?: number
   disableZoom?: boolean
   expanded?: boolean
   rotation?: number // Rotation angle in degrees (0, 90, 180, 270)
   onExpand?: () => void
   onNavigatePrev?: () => void
   onNavigateNext?: () => void
+  onImageLoad?: (index: number, naturalWidth: number, naturalHeight: number) => void
 }
 
 // Custom swipe wrapper for videos that doesn't block clicks (unlike TransformWrapper)
@@ -693,15 +732,28 @@ function GalleryElementComponent({
   image,
   htmlElement,
   element,
+  index,
   disableZoom,
   expanded,
   rotation,
   onExpand,
   onNavigatePrev,
   onNavigateNext,
+  onImageLoad,
 }: GalleryElementProps) {
   const ref = useRef<HTMLSpanElement>(null)
   const imgRef = useRef<HTMLImageElement>(null)
+
+  // Handle image load to report dimensions for dynamic height calculation
+  const handleImageLoadEvent = useCallback(
+    (e: React.SyntheticEvent<HTMLImageElement>) => {
+      const img = e.currentTarget
+      if (index !== undefined && onImageLoad) {
+        onImageLoad(index, img.naturalWidth, img.naturalHeight)
+      }
+    },
+    [index, onImageLoad],
+  )
 
   // Generate rotation style for preview
   const isRotated = typeof rotation === 'number'
@@ -814,6 +866,7 @@ function GalleryElementComponent({
               alt={image.alt}
               className={classNames(styles.image, styles.noDragging, styles.imageExpanded)}
               onClick={handleImageClick}
+              onLoad={handleImageLoadEvent}
             />
           </TransformComponent>
         </TransformWrapper>
@@ -828,6 +881,7 @@ function GalleryElementComponent({
         className={classNames(styles.image, styles.noDragging, !disableZoom && 'image-scalable')}
         style={rotationStyle}
         onClick={handleImageClick}
+        onLoad={handleImageLoadEvent}
       />
     )
   }


### PR DESCRIPTION
Automatic, animated gallery height adjustment has been implemented in `GalleryComponent.tsx`.

The maximum height is controlled by the `MAX_HEIGHT` constant. On initial render, the gallery height is set to match the height of the first image. When switching between images, the gallery height increases smoothly (with animation) if the newly displayed image is taller than the current height. The height never decreases.

Example behavior:

* If the first image has a height of 200, the initial gallery height is 200.
* When navigating to an image with a height of 400, the gallery height animates to 400.
* When navigating to an image with a height of 200, the gallery height remains 400.
