### PR TITLE
impoved gallery dot indicators

### DIFF
--- a/frontend/src/Components/GalleryComponent.module.scss
+++ b/frontend/src/Components/GalleryComponent.module.scss
@@ -6,8 +6,8 @@ $thumbnail-height: 4rem;
 $arrow-size: 2rem;
 $arrow-icon-size: 1rem;
 
-$indicator-size: 0.75rem;
-$indicator-spacing: 0.5rem;
+$indicator-size: 0.5rem;
+$indicator-spacing: 0.4rem;
 
 $transition-duration: 300ms;
 $transition-easing: ease-in-out;
@@ -188,6 +188,8 @@ $transition-easing: ease-in-out;
   padding: 0.2rem 0.4rem;
   border-radius: 4px;
   background-color: var(--bg);
+  opacity: 0.7;
+  touch-action: none;
 }
 
 .indicator {
@@ -221,18 +223,24 @@ $transition-easing: ease-in-out;
   border-radius: 50%;
   background-color: var(--fg);
   transition: all $transition-duration $transition-easing;
+}
 
-  .indicator:hover:not(:disabled) & {
+.indicator[data-hovered] .indicatorDot {
+  background-color: var(--primary);
+  transform: scale(1.2);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .indicator:hover:not(:disabled) .indicatorDot {
     background-color: var(--primary);
     transform: scale(1.2);
   }
 }
 
-.indicatorActive {
-  .indicatorDot {
-    background-color: var(--primary);
-    transform: scale(1.1);
-  }
+.indicatorActive .indicatorDot,
+.indicator[data-active] .indicatorDot {
+  background-color: var(--primary);
+  transform: scale(1.1);
 }
 
 .thumbnails {
@@ -382,21 +390,22 @@ $transition-easing: ease-in-out;
   }
 
   .arrow {
-    width: 2rem;
-    height: 2rem;
-
-    svg {
-      width: 1rem;
-      height: 1rem;
-    }
+    display: none;
   }
 
-  .arrowPrev {
-    left: 0.25rem;
+  .indicatorPlaceholder {
+    width: calc($indicator-size * 2 * 0.6) !important;
+    height: calc($indicator-size * 2 * 0.6) !important;
   }
 
-  .arrowNext {
-    right: 0.25rem;
+  .indicator {
+    width: $indicator-size * 2;
+    height: $indicator-size * 2;
+  }
+
+  .indicators {
+    gap: $indicator-spacing * 1.5;
+    padding: 0.3rem 0.5rem;
   }
 }
 
@@ -523,7 +532,7 @@ $transition-easing: ease-in-out;
   background: none;
   border: none;
   cursor: pointer;
-  z-index: 200;
+  z-index: 10;
   color: white;
   font-size: 40px;
   text-shadow:

--- a/frontend/src/Components/GalleryComponent.tsx
+++ b/frontend/src/Components/GalleryComponent.tsx
@@ -503,13 +503,10 @@ interface SlidingIndicatorsProps {
   onSelect: (index: number) => void
 }
 
-const INDICATOR_SIZE = 12
-const INDICATOR_GAP = 8
-const CONTAINER_PADDING = 12
-
 function SlidingIndicators({ total, currentIndex, onSelect }: SlidingIndicatorsProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [maxVisible, setMaxVisible] = useState(total)
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
 
   useEffect(() => {
     const container = containerRef.current
@@ -519,20 +516,40 @@ function SlidingIndicators({ total, currentIndex, onSelect }: SlidingIndicatorsP
       const parent = container.parentElement
       if (!parent) return
 
-      const availableWidth = parent.offsetWidth * 0.8 - CONTAINER_PADDING * 2
-      const dotWidth = INDICATOR_SIZE + INDICATOR_GAP
-      const max = Math.floor((availableWidth + INDICATOR_GAP) / dotWidth)
+      // Get computed styles from actual DOM elements
+      const containerStyles = window.getComputedStyle(container)
+      const containerPadding = parseFloat(containerStyles.paddingLeft) + parseFloat(containerStyles.paddingRight)
+      const gap = parseFloat(containerStyles.gap) || 0
+
+      // Try to get indicator size from first indicator element
+      const firstIndicator = container.querySelector(`.${styles.indicator}`) as HTMLElement
+      let indicatorSize = 12 // fallback
+      if (firstIndicator) {
+        const indicatorStyles = window.getComputedStyle(firstIndicator)
+        indicatorSize = parseFloat(indicatorStyles.width)
+      }
+
+      const availableWidth = parent.offsetWidth * 0.8 - containerPadding
+      const dotWidth = indicatorSize + gap
+      const max = Math.floor((availableWidth + gap) / dotWidth)
       setMaxVisible(Math.max(3, max))
     }
 
+    // Initial calculation might not have indicators yet, so calculate twice
     calculateMaxVisible()
+    const timer = setTimeout(calculateMaxVisible, 0)
 
     if (container.parentElement) {
       const resizeObserver = new ResizeObserver(calculateMaxVisible)
       resizeObserver.observe(container.parentElement)
 
-      return () => resizeObserver.disconnect()
+      return () => {
+        resizeObserver.disconnect()
+        clearTimeout(timer)
+      }
     }
+
+    return () => clearTimeout(timer)
   }, [])
 
   const { visibleStart, visibleEnd, showStartPlaceholder, showEndPlaceholder } = useMemo(() => {
@@ -572,8 +589,48 @@ function SlidingIndicators({ total, currentIndex, onSelect }: SlidingIndicatorsP
     visibleIndices.push(i)
   }
 
+  const handleTouchAction = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.pointerType === 'mouse') return
+
+      const { clientX: x, clientY: y } = e
+      const target = document.elementFromPoint(x, y)
+      const button = target?.closest<HTMLElement>('[data-indicator-index]')
+
+      if (!button) {
+        setHoveredIndex(null)
+        return
+      }
+
+      const index = Number(button.dataset.indicatorIndex)
+      if (Number.isNaN(index)) return
+
+      setHoveredIndex(index)
+
+      if (index !== currentIndex) {
+        onSelect(index)
+      }
+    },
+    [currentIndex, onSelect],
+  )
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.target instanceof Element) {
+      e.target.releasePointerCapture(e.pointerId)
+    }
+
+    handleTouchAction(e)
+  }
+
   return (
-    <div ref={containerRef} className={styles.indicators}>
+    <div
+      ref={containerRef}
+      className={styles.indicators}
+      onPointerMove={handleTouchAction}
+      onPointerDown={handlePointerDown}
+      onPointerUp={() => setHoveredIndex(null)}
+      onPointerLeave={() => setHoveredIndex(null)}
+    >
       {showStartPlaceholder && (
         <span className={classNames(styles.indicator, styles.indicatorPlaceholder)}>
           <span className={styles.indicatorDot} />
@@ -584,6 +641,9 @@ function SlidingIndicators({ total, currentIndex, onSelect }: SlidingIndicatorsP
         <Button
           key={index}
           onClick={() => onSelect(index)}
+          data-indicator-index={index}
+          data-active={index === currentIndex || undefined}
+          data-hovered={index === hoveredIndex || undefined}
           className={classNames(styles.indicator, { [styles.indicatorActive]: index === currentIndex })}
           aria-label={`Перейти к изображению ${index + 1}`}
         >


### PR DESCRIPTION
Slightly improved the UI\UX of the indicator points in the gallery
Here is what was done:
- Made the indicators semi-transparent
- Reduced the size of indicators on PCs:
<img width="1920" height="957" alt="image" src="https://github.com/user-attachments/assets/aa2073ba-3eef-4952-b5aa-274d9769cc15" />

- Removed arrow buttons on smartphones, you can easily swipe there
- Increased the size of indicators on smartphones
<img width="369" height="666" alt="image" src="https://github.com/user-attachments/assets/11e9c993-c3f8-4a7b-a57b-d94792b49e8f" />

- Made it possible to scroll with a finger on indicators, now switching not by tap, but by swipe on indicators

https://github.com/user-attachments/assets/07e80d41-1658-4263-9809-015d4ccbb4fe

