### PR TITLE
New comments navigation & scroll to top\bottom

### DIFF
--- a/frontend/src/Assets/chevron-down.svg
+++ b/frontend/src/Assets/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-down-icon lucide-chevron-down">
+    <path d="m6 9 6 6 6-6"/>
+</svg>

--- a/frontend/src/Assets/chevron-up.svg
+++ b/frontend/src/Assets/chevron-up.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-chevron-up-icon lucide-chevron-up">
+  <path d="m18 15-6-6-6 6"/>
+</svg>

--- a/frontend/src/Assets/double-arrow-down.svg
+++ b/frontend/src/Assets/double-arrow-down.svg
@@ -1,0 +1,4 @@
+<svg focusable="false" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M18 6.41 16.59 5 12 9.58 7.41 5 6 6.41l6 6z"></path>
+  <path d="m18 13-1.41-1.41L12 16.17l-4.59-4.58L6 13l6 6z"></path>
+</svg>

--- a/frontend/src/Assets/double-arrow-up.svg
+++ b/frontend/src/Assets/double-arrow-up.svg
@@ -1,0 +1,4 @@
+<svg focusable="false" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M6 17.59 7.41 19 12 14.42 16.59 19 18 17.59l-6-6z"></path>
+  <path d="m6 11 1.41 1.41L12 7.83l4.59 4.58L18 11l-6-6z"></path>
+</svg>

--- a/frontend/src/Components/UserProfileSettings.tsx
+++ b/frontend/src/Components/UserProfileSettings.tsx
@@ -75,6 +75,10 @@ export function getShowInlineTranslateButton(): boolean {
   return localStorage.getItem('showInlineTranslateButton') === 'true'
 }
 
+export function getEnableCommentNavigation(): boolean {
+  return localStorage.getItem('enableCommentNavigation') !== 'false'
+}
+
 export default function UserProfileSettings(props: UserProfileSettingsProps) {
   useEffect(() => {
     window.scrollTo({ top: 0 })
@@ -92,6 +96,7 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
   const [autoMute, setAutoMute] = useState<boolean>(getAutoMuteVideos())
   const [preferredLang, setPreferredLang] = useState<string>(getPreferredLang())
   const [showInlineTranslateButton, setShowInlineTranslateButton] = useState<boolean>(getShowInlineTranslateButton())
+  const [enableCommentNavigation, setEnableCommentNavigation] = useState<boolean>(getEnableCommentNavigation())
 
   const confirmWrapper = (message: string, callback: () => void) => async (e: React.MouseEvent) => {
     e.preventDefault()
@@ -151,6 +156,10 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
     setShowInlineTranslateButton(!showInlineTranslateButton)
   }
 
+  const toggleEnableCommentNavigation = () => {
+    setEnableCommentNavigation(!enableCommentNavigation)
+  }
+
   const changeLang = (ev: React.FormEvent<HTMLSelectElement>) => {
     const lang = ev.currentTarget.value
     setPreferredLang(lang)
@@ -192,6 +201,10 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
   }, [showInlineTranslateButton])
 
   useEffect(() => {
+    localStorage.setItem('enableCommentNavigation', JSON.stringify(enableCommentNavigation))
+  }, [enableCommentNavigation])
+
+  useEffect(() => {
     localStorage.setItem('preferredLang', preferredLang)
   }, [preferredLang])
 
@@ -206,6 +219,9 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
         )}
         <Button onClick={toggleAutoStop}>Видео автопауза: {autoStop ? 'Вкл' : 'Выкл'}</Button>
         <Button onClick={toggleAutoMute}>Видео без звука: {autoMute ? 'Вкл' : 'Выкл'}</Button>
+        <Button onClick={toggleEnableCommentNavigation}>
+          Навигация по комментариям: {enableCommentNavigation ? 'Вкл' : 'Выкл'}
+        </Button>
         {<ThemeToggleComponent dynamic={true} buttonLabel='Сменить тему' />}
       </div>
       <div className={styles.select}>

--- a/frontend/src/Pages/PostPage.module.css
+++ b/frontend/src/Pages/PostPage.module.css
@@ -63,3 +63,123 @@
 .anon > * {
   display: inline !important; /* FIXME it's a hack to override flex in UserName component styles. */
 }
+
+/* Unread comment navigation buttons */
+.unreadNavContainer {
+  position: fixed;
+  right: 0.5rem;
+  top: 40%;
+
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  z-index: 200;
+}
+
+.unreadNav {
+  background-color: color-mix(in srgb, var(--primary) 60%, transparent);
+  color: var(--button-fg);
+  border: none;
+  border-radius: 10%;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  z-index: 200;
+  opacity: 0.5;
+}
+
+.unreadNav:hover:not(:disabled) {
+  background-color: var(--primary);
+  transform: scale(1.1);
+}
+
+.unreadNav:focus:not(:disabled) {
+  background-color: var(--primary);
+}
+
+.unreadNav:active:not(:disabled) {
+  transform: scale(0.95);
+}
+
+.unreadNav:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: unset;
+  cursor: default;
+}
+
+.unreadNav svg {
+  width: 24px;
+  height: 24px;
+  pointer-events: none;
+}
+
+.unreadNav:hover:not(:disabled) {
+  transform: scale(1.1);
+}
+
+.unreadNav:active:not(:disabled) {
+  transform: scale(0.95);
+}
+
+/* Scroll to top/bottom buttons */
+.scrollButtons {
+  position: fixed;
+  right: 0.5rem;
+  bottom: 1rem;
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  z-index: 199;
+}
+
+.scrollButton {
+  background-color: color-mix(in srgb, var(--primary) 60%, transparent);
+  color: var(--button-fg);
+  border: none;
+  border-radius: 10%;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  opacity: 0.5;
+}
+
+.scrollButton:hover:not(:disabled) {
+  background-color: var(--primary);
+  transform: scale(1.1);
+}
+
+.scrollButton:focus:not(:disabled) {
+  background-color: var(--primary);
+}
+
+.scrollButton:active:not(:disabled) {
+  transform: scale(0.95);
+}
+
+.scrollButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: unset;
+  cursor: default;
+}
+
+.scrollButton svg {
+  width: 24px;
+  height: 24px;
+  pointer-events: none;
+}
+
+/* Active unread comment indicator */
+:global(.commentBody.activeUnread) {
+  outline: 1px dashed var(--primary);
+  outline-offset: 0.25rem;
+}

--- a/frontend/src/Pages/PostPage.tsx
+++ b/frontend/src/Pages/PostPage.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useLocation, useParams, useSearchParams } from 'react-router-dom'
 
 import Button from '@ui/Button'
+import classNames from 'classnames'
 
 import { usePost } from '../API/use/usePost'
 import { useAppState } from '../AppState/AppState'
@@ -9,10 +10,17 @@ import CommentComponent from '../Components/CommentComponent'
 import { CreateCommentComponentRestricted } from '../Components/CreateCommentComponent'
 import PostComponent from '../Components/PostComponent'
 import Username from '../Components/Username'
+import { getEnableCommentNavigation } from '../Components/UserProfileSettings'
 import { CommentInfo, PostInfo, PostLinkInfo } from '../Types/PostInfo'
 import { scrollUnderTopbar } from '../Utils/utils'
 
+import { ReactComponent as ChevronDown } from '../Assets/chevron-down.svg'
+import { ReactComponent as ChevronUp } from '../Assets/chevron-up.svg'
+import { ReactComponent as DoubleArrowDown } from '../Assets/double-arrow-down.svg'
+import { ReactComponent as DoubleArrowUp } from '../Assets/double-arrow-up.svg'
 import styles from './PostPage.module.css'
+
+const TOP_BOTTOM_THRESHOLD = 1000
 
 export default function PostPage() {
   const params = useParams<{ postId: string }>()
@@ -28,6 +36,12 @@ export default function PostPage() {
     postId,
     unreadOnly,
   )
+  const [unreadElements, setUnreadElements] = useState<HTMLElement[]>([])
+  const [currentUnreadIndex, setCurrentUnreadIndex] = useState<number>(-1)
+  const [isNearTop, setIsNearTop] = useState<boolean>(true)
+  const [isNearBottom, setIsNearBottom] = useState<boolean>(false)
+  const isScrollingRef = useRef<boolean>(false)
+  const enableCommentNavigation = getEnableCommentNavigation()
 
   useEffect(() => {
     let docTitle = `Пост #${postId}`
@@ -39,6 +53,56 @@ export default function PostPage() {
     }
     document.title = docTitle
   }, [post, postId])
+
+  // Collect unread comment elements when comments are loaded
+  useEffect(() => {
+    // Cleanup: remove active class from previous unread elements
+    const cleanupActiveClass = () => {
+      document.querySelectorAll('.isNew .commentBody').forEach((el) => {
+        el.classList.remove('activeUnread')
+      })
+    }
+
+    if (!comments) {
+      cleanupActiveClass()
+      setUnreadElements([])
+      setCurrentUnreadIndex(-1)
+      return
+    }
+
+    const elements: HTMLElement[] = Array.from(document.querySelectorAll('.isNew'))
+    setUnreadElements(elements)
+
+    // Initialize to first unread comment if available and not already scrolled
+    if (elements.length > 0 && enableCommentNavigation) {
+      cleanupActiveClass()
+
+      if (scrolledToComment) {
+        const index = elements.findIndex((el) => el.dataset.commentId === String(scrolledToComment.commentId))
+        const actualIndex = index >= 0 ? index : 0
+        setCurrentUnreadIndex(actualIndex)
+        // Add active class to the found comment
+        const element = elements[actualIndex]
+        const commentBody = element.querySelector<HTMLDivElement>('.commentBody')
+        if (commentBody) {
+          commentBody.classList.add('activeUnread')
+        }
+      } else {
+        setCurrentUnreadIndex(0)
+        // Add active class to first unread comment
+        const firstElement = elements[0]
+        const commentBody = firstElement.querySelector<HTMLDivElement>('.commentBody')
+        if (commentBody) {
+          commentBody.classList.add('activeUnread')
+        }
+      }
+    } else {
+      cleanupActiveClass()
+      setCurrentUnreadIndex(-1)
+    }
+
+    return cleanupActiveClass
+  }, [comments, scrolledToComment, enableCommentNavigation])
 
   const handleCommentEdit = async (text: string, comment: CommentInfo) => {
     return await editComment(text, comment.id)
@@ -93,6 +157,15 @@ export default function PostPage() {
 
     commentId && setScrolledToComment({ postId, commentId })
 
+    // Update current unread index if scrolling to an unread comment
+    if (enableCommentNavigation && scrollToComment.classList.contains('isNew')) {
+      const allUnreadElements = Array.from(document.querySelectorAll<HTMLElement>('.isNew'))
+      const index = allUnreadElements.findIndex((el) => el.dataset.commentId === scrollToComment?.dataset.commentId)
+      if (index !== -1) {
+        setCurrentUnreadIndex(index)
+      }
+    }
+
     scrollUnderTopbar(commentBody)
 
     return () => {
@@ -104,6 +177,173 @@ export default function PostPage() {
 
   const handlePostEdit = async (post: PostInfo, text: string, title?: string): Promise<PostInfo | undefined> => {
     return await editPost(title || '', text)
+  }
+
+  // Navigation functions for unread comments (based on reference algorithm)
+  const goToNextUnread = useCallback(() => {
+    if (unreadElements.length === 0 || currentUnreadIndex < 0) return
+
+    if (currentUnreadIndex >= 0 && currentUnreadIndex < unreadElements.length - 1) {
+      // Remove active class from current element
+      const currentElement = unreadElements[currentUnreadIndex]
+      const currentCommentBody = currentElement.querySelector<HTMLDivElement>('.commentBody')
+      if (currentCommentBody) {
+        currentCommentBody.classList.remove('activeUnread')
+      }
+
+      // Move to next
+      const nextIndex = currentUnreadIndex + 1
+      const nextElement = unreadElements[nextIndex]
+      const nextCommentBody = nextElement.querySelector<HTMLDivElement>('.commentBody')
+
+      if (nextCommentBody) {
+        // Add active class to next element
+        nextCommentBody.classList.add('activeUnread')
+
+        // Scroll to element
+        nextCommentBody.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+          inline: 'start',
+        })
+
+        // Wait for scroll to complete before updating state
+        // Use a timeout that's longer than the smooth scroll duration
+        setTimeout(() => {
+          setCurrentUnreadIndex(nextIndex)
+          const commentId = nextElement.dataset.commentId
+          if (commentId) {
+            setScrolledToComment({ postId, commentId: parseInt(commentId, 10) })
+          }
+        }, 500)
+      }
+    }
+  }, [unreadElements, currentUnreadIndex, postId])
+
+  const goToPreviousUnread = useCallback(() => {
+    if (unreadElements.length === 0 || currentUnreadIndex < 0) return
+
+    if (currentUnreadIndex > 0) {
+      // Remove active class from current element
+      const currentElement = unreadElements[currentUnreadIndex]
+      const currentCommentBody = currentElement.querySelector<HTMLDivElement>('.commentBody')
+      if (currentCommentBody) {
+        currentCommentBody.classList.remove('activeUnread')
+      }
+
+      // Move to previous
+      const prevIndex = currentUnreadIndex - 1
+      const prevElement = unreadElements[prevIndex]
+      const prevCommentBody = prevElement.querySelector<HTMLDivElement>('.commentBody')
+
+      if (prevCommentBody) {
+        // Add active class to previous element
+        prevCommentBody.classList.add('activeUnread')
+
+        // Scroll to element
+        prevCommentBody.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+          inline: 'start',
+        })
+
+        // Wait for scroll to complete before updating state
+        // Use a timeout that's longer than the smooth scroll duration
+        setTimeout(() => {
+          setCurrentUnreadIndex(prevIndex)
+          const commentId = prevElement.dataset.commentId
+          if (commentId) {
+            setScrolledToComment({ postId, commentId: parseInt(commentId, 10) })
+          }
+        }, 500)
+      }
+    }
+  }, [unreadElements, currentUnreadIndex, postId])
+
+  // Keyboard navigation for unread comments (J = next, K = previous)
+  useEffect(() => {
+    if (!enableCommentNavigation || unreadElements.length === 0) return
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      const activeElement = document.activeElement as HTMLElement
+      // Don't trigger if user is typing in a textarea or input
+      if (activeElement.tagName === 'TEXTAREA' || activeElement.tagName === 'INPUT') {
+        return
+      }
+
+      if (e.code === 'KeyJ') {
+        goToNextUnread()
+      } else if (e.code === 'KeyK') {
+        goToPreviousUnread()
+      }
+    }
+
+    document.addEventListener('keyup', handleKeyUp)
+    return () => document.removeEventListener('keyup', handleKeyUp)
+  }, [goToNextUnread, goToPreviousUnread, unreadElements.length, enableCommentNavigation])
+
+  // Track scroll position to disable buttons near top/bottom
+  useEffect(() => {
+    const handleScroll = () => {
+      if (isScrollingRef.current) return
+
+      const scrollTop = window.scrollY || document.documentElement.scrollTop
+      const scrollHeight = document.documentElement.scrollHeight
+      const clientHeight = window.innerHeight
+
+      setIsNearTop(scrollTop < TOP_BOTTOM_THRESHOLD)
+      setIsNearBottom(scrollTop + clientHeight > scrollHeight - TOP_BOTTOM_THRESHOLD)
+    }
+
+    // Initial check
+    handleScroll()
+
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  // Scroll to top/bottom functions
+  const scrollToTop = () => {
+    isScrollingRef.current = true
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+
+    // Wait after scroll completes
+    const intervalId = setInterval(() => {
+      // Force state update after scroll
+      const scrollTop = window.scrollY || document.documentElement.scrollTop
+      const scrollHeight = document.documentElement.scrollHeight
+      const clientHeight = window.innerHeight
+
+      if (scrollTop !== 0) return
+
+      isScrollingRef.current = false
+      clearInterval(intervalId)
+
+      setIsNearTop(scrollTop < TOP_BOTTOM_THRESHOLD)
+      setIsNearBottom(scrollTop + clientHeight > scrollHeight - TOP_BOTTOM_THRESHOLD)
+    }, 100)
+  }
+
+  const scrollToBottom = () => {
+    isScrollingRef.current = true
+    const scrollHeight = document.documentElement.scrollHeight
+
+    window.scrollTo({ top: scrollHeight, behavior: 'smooth' })
+
+    // Wait after scroll completes
+    const intervalId = setInterval(() => {
+      // Force state update after scroll
+      const scrollTop = window.scrollY || document.documentElement.scrollTop
+      const clientHeight = window.innerHeight
+
+      if (scrollTop + clientHeight !== scrollHeight) return
+
+      isScrollingRef.current = false
+      clearInterval(intervalId)
+
+      setIsNearTop(scrollTop < TOP_BOTTOM_THRESHOLD)
+      setIsNearBottom(scrollTop + clientHeight > scrollHeight - TOP_BOTTOM_THRESHOLD)
+    }, 100)
   }
 
   const baseRoute = site === 'main' ? '/' : `/s/${site}/`
@@ -177,6 +417,49 @@ export default function PostPage() {
         ) : (
           <div className={styles.loading}>Загрузка...</div>
         )}
+      </div>
+
+      {/* Navigation buttons for unread comments */}
+      {enableCommentNavigation && unreadElements.length > 0 && (
+        <div className={styles.unreadNavContainer}>
+          <Button
+            onClick={goToPreviousUnread}
+            className={classNames(styles.unreadNav, styles.unreadNavPrev)}
+            aria-label='Предыдущий непрочитанный комментарий'
+            disabled={currentUnreadIndex <= 0}
+          >
+            <ChevronUp />
+          </Button>
+
+          <Button
+            onClick={goToNextUnread}
+            className={classNames(styles.unreadNav, styles.unreadNavNext)}
+            aria-label='Следующий непрочитанный комментарий'
+            disabled={currentUnreadIndex >= unreadElements.length - 1}
+          >
+            <ChevronDown />
+          </Button>
+        </div>
+      )}
+
+      {/* Scroll to top/bottom buttons */}
+      <div className={styles.scrollButtons}>
+        <Button
+          onClick={scrollToTop}
+          className={classNames(styles.scrollButton, styles.scrollButtonTop)}
+          aria-label='Прокрутить наверх'
+          disabled={isNearTop}
+        >
+          <DoubleArrowUp />
+        </Button>
+        <Button
+          onClick={scrollToBottom}
+          className={classNames(styles.scrollButton, styles.scrollButtonBottom)}
+          aria-label='Прокрутить вниз'
+          disabled={isNearBottom}
+        >
+          <DoubleArrowDown />
+        </Button>
       </div>
     </div>
   )


### PR DESCRIPTION
I added 2 buttons for quick scrolling to the top and bottom, it can be quite useful when you want to go back to the post and read it again, or when you want to write a root comment, but have to scroll to the bottom for a long time to do it

Also, added buttons for cyclic navigation through new comments - this is a very useful feature that allows you to focus on new content at once, without having to scroll through large branches for a long time. The active comment is circled by a dotted line - it's thin and unobtrusive, but you can change it if you need to
Navigation by comments can be disabled in the account settings, if this feature will bother someone.

<img width="340" height="659" alt="image" src="https://github.com/user-attachments/assets/28e39138-c1f9-4248-bd7c-344de648d8da" />

https://github.com/user-attachments/assets/4e6f8719-d2d5-4bf2-86f6-2181811a938c

