### PR TITLE
Add review-check workflow for merged PRs

### DIFF
--- a/.github/workflows/review-check.yml
+++ b/.github/workflows/review-check.yml
@@ -1,0 +1,121 @@
+name: Review Check
+
+# Uses pull_request_target instead of pull_request so that:
+# 1. The workflow runs in the context of the base repo, not the fork
+# 2. GITHUB_TOKEN has write permissions (can comment on the PR)
+# 3. Works for PRs from forks as well as internal branches
+#
+# Safety: This workflow only reads PR metadata (reviews, authors) and posts
+# a comment. It never checks out, builds, or executes code from the PR branch,
+# so pull_request_target is safe here — no untrusted code path.
+#
+# Alternative considered: Using the standard `pull_request` trigger with a
+# stored PAT for the comment step. This would work for internal branches but
+# fork PRs would get a read-only GITHUB_TOKEN, requiring the PAT workaround.
+# pull_request_target is the cleaner, purpose-built solution for this case.
+
+on:
+  pull_request_target:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to check (for testing)'
+        required: true
+        type: number
+
+jobs:
+  review-check:
+    # Only run on merged PRs (skip closed-without-merge), or on manual dispatch
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check reviews
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Determine PR number — from event (merge trigger) or input (manual dispatch)
+            const prNumber = context.payload.pull_request?.number
+              || parseInt('${{ github.event.inputs.pr_number }}', 10);
+
+            if (!prNumber || isNaN(prNumber)) {
+              core.setFailed('Could not determine PR number');
+              return;
+            }
+
+            // Fetch PR details
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const prAuthor = pr.user.login;
+
+            // Fetch all reviews
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            // Only count APPROVED reviews (not comments, changes_requested, etc.)
+            const approvals = reviews.filter(r => r.state === 'APPROVED');
+            const approverLogins = [...new Set(approvals.map(r => r.user.login))];
+
+            // Associated accounts map — flag when ALL approvers are "associated"
+            // with the PR author (e.g., same person's alt, or tight creator-agent pair).
+            // Add entries here as needed. Format: author → set of associated reviewers.
+            const associatedAccounts = {
+              'Aivean2': new Set(['Aivean']),
+              'Aivean':  new Set(['Aivean2']),
+            };
+
+            let shouldFlag = false;
+            let reason = '';
+
+            if (approverLogins.length === 0) {
+              // Case 1: Merged with zero approved reviews
+              shouldFlag = true;
+              reason = 'no approved reviews';
+            } else {
+              // Case 2: All approvers are associated accounts of the author
+              const associated = associatedAccounts[prAuthor];
+              if (associated) {
+                const allAssociated = approverLogins.every(
+                  login => associated.has(login)
+                );
+                if (allAssociated) {
+                  shouldFlag = true;
+                  const reviewerList = approverLogins.join(', ');
+                  reason = `only reviewed by associated account(s): ${reviewerList}`;
+                }
+              }
+            }
+
+            if (shouldFlag) {
+              const body = [
+                `> [!WARNING]`,
+                `> **This PR was merged with ${reason}.**`,
+                `> Post-merge review may be required.`,
+                `>`,
+                `> cc @spaceshelter/reviewers`,
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body,
+              });
+
+              core.info(`Flagged PR #${prNumber}: ${reason}`);
+            } else {
+              core.info(
+                `PR #${prNumber} has independent review from: ${approverLogins.join(', ')}`
+              );
+            }

--- a/.github/workflows/review-check.yml
+++ b/.github/workflows/review-check.yml
@@ -67,12 +67,17 @@ jobs:
             const approvals = reviews.filter(r => r.state === 'APPROVED');
             const approverLogins = [...new Set(approvals.map(r => r.user.login))];
 
+            // Automated/bot accounts whose reviews alone don't count as
+            // independent review. If ALL approvers are in this set, the PR
+            // is flagged regardless of who authored it.
+            const automatedAccounts = new Set(['Aivean2']);
+
             // Associated accounts map — flag when ALL approvers are "associated"
             // with the PR author (e.g., same person's alt, or tight creator-agent pair).
             // Add entries here as needed. Format: author → set of associated reviewers.
             const associatedAccounts = {
-              'Aivean2': new Set(['Aivean']),
               'Aivean':  new Set(['Aivean2']),
+              'Aivean2': new Set(['Aivean']),
             };
 
             let shouldFlag = false;
@@ -82,8 +87,13 @@ jobs:
               // Case 1: Merged with zero approved reviews
               shouldFlag = true;
               reason = 'no approved reviews';
+            } else if (approverLogins.every(login => automatedAccounts.has(login))) {
+              // Case 2: All approvers are automated accounts
+              shouldFlag = true;
+              const reviewerList = approverLogins.join(', ');
+              reason = `only reviewed by automated account(s): ${reviewerList}`;
             } else {
-              // Case 2: All approvers are associated accounts of the author
+              // Case 3: All approvers are associated accounts of the author
               const associated = associatedAccounts[prAuthor];
               if (associated) {
                 const allAssociated = approverLogins.every(


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/review-check.yml`) that automatically flags PRs merged without independent team review by posting a warning comment.

### What it does

When a PR is merged, the workflow checks reviews and flags two cases:
1. **No approved reviews** — PR was merged without any review
2. **Only associated-account reviews** — e.g., Aivean2's PR reviewed only by Aivean (or vice versa)

When flagged, posts a warning comment and pings `@spaceshelter/reviewers` for post-merge review.

### Design decisions & alternatives considered

**Trigger: `pull_request_target` vs `pull_request`**
- `pull_request` gives fork PRs a **read-only** GITHUB_TOKEN — the workflow could read reviews but couldn't comment
- `pull_request_target` runs in the base repo's context with full write permissions
- Since this workflow **only reads review metadata and posts a comment** (never checks out, builds, or executes code from the PR branch), `pull_request_target` is safe — no untrusted code path
- Alternative: keep `pull_request` + store a PAT as repo secret for the comment step. Works but adds a secret to manage. `pull_request_target` is the purpose-built solution for this exact use case

**Token identity**
- Comments are posted as `github-actions[bot]` (the default GITHUB_TOKEN identity) — standard convention for workflow-generated comments
- Alternative: use a stored PAT for a custom identity (e.g., Aivean2). More explicit but one more secret to manage for no functional benefit

**Associated accounts**
- Uses a configurable map (`associatedAccounts`) to define author-reviewer pairs that don't count as independent review
- Currently configured: `Aivean2 <-> Aivean` (symmetric)
- Easily extensible for additional pairs

**Testing**
- Includes `workflow_dispatch` trigger for manual testing against any PR number
- The workflow itself can't be tested until it's on the default branch (`dev`), since `pull_request_target` runs the base branch's copy of the workflow
- Recommended first test after merge: open + merge a dummy PR with no reviews, or use workflow_dispatch

## Test plan

- [ ] Merge this PR, then open and merge a dummy PR without reviews -> verify warning comment appears
- [ ] Use `workflow_dispatch` with an existing PR number to test against historical PRs
- [ ] Verify no comment is posted for PRs with independent review