### PR TITLE
Simplify review-check workflow logic

### DIFF
--- a/.github/workflows/review-check.yml
+++ b/.github/workflows/review-check.yml
@@ -67,44 +67,28 @@ jobs:
             const approvals = reviews.filter(r => r.state === 'APPROVED');
             const approverLogins = [...new Set(approvals.map(r => r.user.login))];
 
-            // Automated/bot accounts whose reviews alone don't count as
-            // independent review. If ALL approvers are in this set, the PR
-            // is flagged regardless of who authored it.
-            const automatedAccounts = new Set(['Aivean2']);
-
-            // Associated accounts map — flag when ALL approvers are "associated"
-            // with the PR author (e.g., same person's alt, or tight creator-agent pair).
-            // Add entries here as needed. Format: author → set of associated reviewers.
-            const associatedAccounts = {
-              'Aivean':  new Set(['Aivean2']),
-              'Aivean2': new Set(['Aivean']),
-            };
+            // Automated account — PRs authored by this account or where this
+            // account is the sole reviewer always require post-merge review.
+            const automatedAccount = 'Aivean2';
 
             let shouldFlag = false;
             let reason = '';
 
-            if (approverLogins.length === 0) {
-              // Case 1: Merged with zero approved reviews
+            if (prAuthor === automatedAccount) {
+              // Case 1: PR authored by automated account — always flag
+              shouldFlag = true;
+              reason = `authored by automated account ${automatedAccount}`;
+            } else if (approverLogins.length === 0) {
+              // Case 2: Merged with zero approved reviews
               shouldFlag = true;
               reason = 'no approved reviews';
-            } else if (approverLogins.every(login => automatedAccounts.has(login))) {
-              // Case 2: All approvers are automated accounts
+            } else if (
+              approverLogins.length === 1 &&
+              approverLogins[0] === automatedAccount
+            ) {
+              // Case 3: Only reviewer is the automated account
               shouldFlag = true;
-              const reviewerList = approverLogins.join(', ');
-              reason = `only reviewed by automated account(s): ${reviewerList}`;
-            } else {
-              // Case 3: All approvers are associated accounts of the author
-              const associated = associatedAccounts[prAuthor];
-              if (associated) {
-                const allAssociated = approverLogins.every(
-                  login => associated.has(login)
-                );
-                if (allAssociated) {
-                  shouldFlag = true;
-                  const reviewerList = approverLogins.join(', ');
-                  reason = `only reviewed by associated account(s): ${reviewerList}`;
-                }
-              }
+              reason = `only reviewed by automated account ${automatedAccount}`;
             }
 
             if (shouldFlag) {


### PR DESCRIPTION
## Summary

Simplifies the review-check workflow per [feedback on PR #506](https://github.com/spaceshelter/orbitar/pull/506#issuecomment-3875191362).

**Before:** Three-tier check with `automatedAccounts` Set + `associatedAccounts` map:
1. No approved reviews → flag
2. All approvers in `automatedAccounts` → flag
3. All approvers in `associatedAccounts[prAuthor]` → flag

**After:** Simple two-condition check on a single `automatedAccount`:
1. PR authored by `Aivean2` → always flag (regardless of reviewers)
2. No approved reviews → flag
3. `Aivean2` is the sole reviewer → flag (regardless of PR author)

Removes the `associatedAccounts` map entirely. The `Aivean ↔ Aivean2` pair is now covered by cases 1 and 3 without needing a separate mapping.

## Test plan

- [ ] Use `workflow_dispatch` to test against PR #506 (Aivean2 authored, Aivean reviewed) — should flag as "authored by automated account"
- [ ] Test against PR #505 (Aivean2 authored) — should flag as "authored by automated account"
- [ ] Test against a PR with independent reviewer — should pass without flagging