### PR TITLE
Whole-body encrypted content v2.1

### DIFF
--- a/backend/migrations/20260308000000-public-key-alg.js
+++ b/backend/migrations/20260308000000-public-key-alg.js
@@ -1,0 +1,36 @@
+'use strict'
+
+var dbm
+var type
+var seed
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+}
+
+exports.up = async function (db) {
+  await db.runSql(`
+        ALTER TABLE users ADD COLUMN public_key_alg VARCHAR(32) NOT NULL DEFAULT ''
+    `)
+
+  await db.runSql(`
+        UPDATE users
+        SET public_key = '', public_key_alg = ''
+    `)
+}
+
+exports.down = async function (db) {
+  await db.runSql(`
+        ALTER TABLE users DROP COLUMN public_key_alg
+    `)
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/backend/migrations/20260308000001-encrypted-payloads.js
+++ b/backend/migrations/20260308000001-encrypted-payloads.js
@@ -1,0 +1,100 @@
+'use strict'
+
+var dbm
+var type
+var seed
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+}
+
+exports.up = async function (db) {
+  await db.runSql(`
+        CREATE TABLE encrypted_payloads (
+            encrypted_payload_id INT NOT NULL AUTO_INCREMENT,
+            v TINYINT NOT NULL,
+            parser_profile VARCHAR(32) NOT NULL DEFAULT 'lite-v1',
+            ciphertext MEDIUMTEXT NOT NULL,
+            iv VARCHAR(32) NOT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (encrypted_payload_id)
+        )
+    `)
+
+  await db.runSql(`
+        CREATE TABLE encrypted_payload_keys (
+            encrypted_payload_key_id INT NOT NULL AUTO_INCREMENT,
+            encrypted_payload_id INT NOT NULL,
+            user_id INT NOT NULL,
+            role VARCHAR(16) NOT NULL,
+            public_key VARCHAR(128) NOT NULL,
+            public_key_alg VARCHAR(32) NOT NULL,
+            ephemeral_public_key VARCHAR(128) NOT NULL,
+            iv VARCHAR(32) NOT NULL,
+            encrypted_key VARCHAR(128) NOT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (encrypted_payload_key_id),
+            UNIQUE KEY uq_encrypted_payload_user_role (encrypted_payload_id, user_id, role),
+            KEY idx_encrypted_payload_id (encrypted_payload_id),
+            KEY idx_user_id (user_id),
+            CONSTRAINT fk_encrypted_payload_keys_payload FOREIGN KEY (encrypted_payload_id) REFERENCES encrypted_payloads (encrypted_payload_id) ON DELETE CASCADE ON UPDATE CASCADE,
+            CONSTRAINT fk_encrypted_payload_keys_user FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE ON UPDATE CASCADE
+        )
+    `)
+
+  await db.runSql(`
+        ALTER TABLE content_source
+            ADD COLUMN encrypted_payload_id INT NULL,
+            ADD CONSTRAINT fk_content_source_encrypted_payload FOREIGN KEY (encrypted_payload_id) REFERENCES encrypted_payloads (encrypted_payload_id) ON DELETE RESTRICT ON UPDATE RESTRICT
+    `)
+
+  await db.runSql(`
+        ALTER TABLE posts
+            ADD COLUMN encrypted_payload_id INT NULL,
+            ADD CONSTRAINT fk_posts_encrypted_payload FOREIGN KEY (encrypted_payload_id) REFERENCES encrypted_payloads (encrypted_payload_id) ON DELETE RESTRICT ON UPDATE RESTRICT
+    `)
+
+  await db.runSql(`
+        ALTER TABLE comments
+            ADD COLUMN encrypted_payload_id INT NULL,
+            ADD CONSTRAINT fk_comments_encrypted_payload FOREIGN KEY (encrypted_payload_id) REFERENCES encrypted_payloads (encrypted_payload_id) ON DELETE RESTRICT ON UPDATE RESTRICT
+    `)
+}
+
+exports.down = async function (db) {
+  await db.runSql(`
+        ALTER TABLE comments
+            DROP FOREIGN KEY fk_comments_encrypted_payload,
+            DROP COLUMN encrypted_payload_id
+    `)
+
+  await db.runSql(`
+        ALTER TABLE posts
+            DROP FOREIGN KEY fk_posts_encrypted_payload,
+            DROP COLUMN encrypted_payload_id
+    `)
+
+  await db.runSql(`
+        ALTER TABLE content_source
+            DROP FOREIGN KEY fk_content_source_encrypted_payload,
+            DROP COLUMN encrypted_payload_id
+    `)
+
+  await db.runSql(`
+        DROP TABLE encrypted_payload_keys
+    `)
+
+  await db.runSql(`
+        DROP TABLE encrypted_payloads
+    `)
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/backend/src/api/AuthController.ts
+++ b/backend/src/api/AuthController.ts
@@ -145,6 +145,7 @@ export default class AuthController {
         return response.error('wrong-credentials', 'Wrong username or password')
       }
 
+      const mailboxPublicKey = await this.userManager.getPublicKey(userInfo.id)
       const sessionId = await request.session.init()
 
       const user: UserEntity = {
@@ -153,6 +154,8 @@ export default class AuthController {
         username: userInfo.username,
         name: userInfo.name,
         karma: userInfo.karma,
+        publicKey: mailboxPublicKey?.publicKey || '',
+        publicKeyAlg: mailboxPublicKey?.publicKeyAlg || '',
       }
 
       request.session.data.userId = userInfo.id

--- a/backend/src/api/EncryptedPayloadController.ts
+++ b/backend/src/api/EncryptedPayloadController.ts
@@ -1,0 +1,48 @@
+import { Router } from 'express'
+import Joi from 'joi'
+import { Logger } from 'winston'
+
+import EncryptedPayloadManager from '../managers/EncryptedPayloadManager'
+import { APIRequest, APIResponse, validate } from './ApiMiddleware'
+import { OAuth2MiddlewareGenerator } from './OAuth2Middleware'
+import { EncryptedPayloadBatchRequest, EncryptedPayloadBatchResponse } from './types/requests/EncryptedPayload'
+
+export default class EncryptedPayloadController {
+  public readonly router = Router()
+  private readonly encryptedPayloadManager: EncryptedPayloadManager
+  private readonly logger: Logger
+
+  constructor(encryptedPayloadManager: EncryptedPayloadManager, oauth: OAuth2MiddlewareGenerator, logger: Logger) {
+    this.encryptedPayloadManager = encryptedPayloadManager
+    this.logger = logger
+
+    const batchSchema = Joi.object<EncryptedPayloadBatchRequest>({
+      ids: Joi.array().items(Joi.number().integer()).min(1).max(256).required(),
+    })
+
+    this.router.post('/encrypted-payload/get', validate(batchSchema), oauth('читать шифрованный контент'), (req, res) =>
+      this.getPayloads(req, res),
+    )
+  }
+
+  async getPayloads(
+    request: APIRequest<EncryptedPayloadBatchRequest>,
+    response: APIResponse<EncryptedPayloadBatchResponse>,
+  ) {
+    const userId = request.session.data.userId
+    if (!userId) {
+      return response.authRequired()
+    }
+
+    try {
+      const payloads = await this.encryptedPayloadManager.getEncryptedPayloadsByIds(
+        [...new Set(request.body.ids)],
+        userId,
+      )
+      return response.success({ payloads })
+    } catch (error) {
+      this.logger.error('Get encrypted payloads error', { error, payloadIds: request.body.ids, userId })
+      return response.error('error', 'Unknown error', 500)
+    }
+  }
+}

--- a/backend/src/api/PostController.ts
+++ b/backend/src/api/PostController.ts
@@ -9,10 +9,12 @@ import FeedManager from '../managers/FeedManager'
 import PostManager from '../managers/PostManager'
 import SiteManager from '../managers/SiteManager'
 import TranslationManager, { TRANSLATION_LANGUAGES, TRANSLATION_MODES } from '../managers/TranslationManager'
+import { MAILBOX_PUBLIC_KEY_ALG } from '../managers/types/MailboxPublicKey'
 import UserManager from '../managers/UserManager'
 import { APIRequest, APIResponse, joiFormat, validate } from './ApiMiddleware'
 import { OAuth2MiddlewareGenerator } from './OAuth2Middleware'
 import { CommentEntity } from './types/entities/CommentEntity'
+import { EncryptedPayloadWrapDraftEntity } from './types/entities/EncryptedPayloadEntity'
 import { HistoryEntity } from './types/entities/HistoryEntity'
 import { UserEntity } from './types/entities/UserEntity'
 import {
@@ -38,6 +40,38 @@ const commonRateLimitConfig = {
   standardHeaders: false,
   legacyHeaders: false,
   keyGenerator: (req) => String(req.session.data?.userId),
+}
+
+const encryptedPayloadWrapSchema = Joi.object<EncryptedPayloadWrapDraftEntity>({
+  userId: Joi.number().integer().required(),
+  role: Joi.string().valid('sender', 'recipient').required(),
+  publicKey: Joi.string().max(128).required(),
+  publicKeyAlg: Joi.string().valid(MAILBOX_PUBLIC_KEY_ALG).required(),
+  ephemeralPublicKey: Joi.string().max(128).required(),
+  iv: Joi.string().max(32).required(),
+  encryptedKey: Joi.string().max(128).required(),
+})
+
+const encryptedPayloadSchema = Joi.object({
+  v: Joi.number().integer().valid(1).required(),
+  parserProfile: Joi.string().valid('lite-v1').required(),
+  ciphertext: Joi.string().max(100000).required(),
+  iv: Joi.string().max(32).required(),
+  wraps: Joi.array().items(encryptedPayloadWrapSchema).min(1).max(64).required(),
+})
+
+const requirePlaintextOrEncrypted = <T extends { content: string; encryptedPayload?: unknown }>(
+  value: T,
+  helpers: Joi.CustomHelpers,
+) => {
+  const hasContent = value.content.trim().length > 0
+  const hasEncryptedPayload = !!value.encryptedPayload
+
+  if (hasContent === hasEncryptedPayload) {
+    return helpers.error('any.invalid')
+  }
+
+  return value
 }
 
 export default class PostController {
@@ -102,15 +136,17 @@ export default class PostController {
     const postCreateSchema = Joi.object<PostCreateRequest>({
       site: Joi.string().required(),
       title: Joi.alternatives(Joi.string().max(64), Joi.valid('').optional()),
-      content: Joi.string().min(1).max(50000).required(),
+      content: Joi.string().max(50000).allow('').required(),
+      encryptedPayload: encryptedPayloadSchema.optional(),
       format: joiFormat,
-    })
+    }).custom(requirePlaintextOrEncrypted)
     const commentSchema = Joi.object<PostCommentRequest>({
       comment_id: Joi.number().optional(),
       post_id: Joi.number().required(),
-      content: Joi.string().min(1).max(50000).required(),
+      content: Joi.string().max(50000).allow('').required(),
+      encryptedPayload: encryptedPayloadSchema.optional(),
       format: joiFormat,
-    })
+    }).custom(requirePlaintextOrEncrypted)
     const previewSchema = Joi.object<PostPreviewRequest>({
       content: Joi.string().min(1).max(50000).required(),
     })
@@ -128,15 +164,17 @@ export default class PostController {
     })
     const editCommentSchema = Joi.object<PostCommentEditRequest>({
       id: Joi.number().required(),
-      content: Joi.string().min(1).max(50000).required(),
+      content: Joi.string().max(50000).allow('').required(),
+      encryptedPayload: encryptedPayloadSchema.optional(),
       format: joiFormat,
-    })
+    }).custom(requirePlaintextOrEncrypted)
     const editSchema = Joi.object<PostEditRequest>({
       id: Joi.number().required(),
       title: Joi.alternatives(Joi.string().max(64), Joi.valid('').optional()),
-      content: Joi.string().min(1).max(50000).required(),
+      content: Joi.string().max(50000).allow('').required(),
+      encryptedPayload: encryptedPayloadSchema.optional(),
       format: joiFormat,
-    })
+    }).custom(requirePlaintextOrEncrypted)
     const translateSchema = Joi.object<TranslateRequest>({
       id: Joi.number().required(),
       type: Joi.string().valid('post', 'comment').required(),
@@ -286,7 +324,7 @@ export default class PostController {
     }
 
     const userId = request.session.data.userId
-    const { id, title, format, content } = request.body
+    const { id, title, format, content, encryptedPayload } = request.body
 
     try {
       const restrictions = await this.userManager.getUserRestrictions(userId)
@@ -294,7 +332,7 @@ export default class PostController {
         return response.error('access-denied', 'Access-denied', 403)
       }
 
-      const postInfo = await this.postManager.editPost(userId, id, title, content, format)
+      const postInfo = await this.postManager.editPost(userId, id, title, content, format, encryptedPayload)
       if (!postInfo) {
         return response.error('no-comment', 'Post not found')
       }
@@ -304,10 +342,23 @@ export default class PostController {
         users,
       } = await this.enricher.enrichRawPosts([postInfo])
 
-      this.logger.info(`Post edited by #${userId}`, { user_id: userId, post_id: id, format, content, title })
+      this.logger.info(`Post edited by #${userId}`, {
+        user_id: userId,
+        post_id: id,
+        format,
+        content: encryptedPayload ? '<encrypted>' : content,
+        title,
+      })
       response.success({ post, users })
     } catch (err) {
-      this.logger.error('Post edit error', { error: err, user_id: userId, post_id: id, format, content, title })
+      this.logger.error('Post edit error', {
+        error: err,
+        user_id: userId,
+        post_id: id,
+        format,
+        content: encryptedPayload ? '<encrypted>' : content,
+        title,
+      })
       this.logger.error(err)
 
       if (err instanceof CodeError && err.code === 'access-denied') {
@@ -328,7 +379,7 @@ export default class PostController {
     }
 
     const userId = request.session.data.userId
-    const { site, format, content, title } = request.body
+    const { site, format, content, title, encryptedPayload } = request.body
 
     try {
       const userRestrictions = await this.userManager.getUserRestrictions(userId)
@@ -343,15 +394,28 @@ export default class PostController {
         return response.error('post-creation-restricted', 'You cannot create any more posts due to low karma.', 403)
       }
 
-      const postInfo = await this.postManager.createPost(site, userId, title, content, format)
+      const postInfo = await this.postManager.createPost(site, userId, title, content, format, encryptedPayload)
       const {
         posts: [post],
       } = await this.enricher.enrichRawPosts([postInfo])
 
-      this.logger.info(`Post created by #${userId}`, { user_id: userId, site, format, content, title })
+      this.logger.info(`Post created by #${userId}`, {
+        user_id: userId,
+        site,
+        format,
+        content: encryptedPayload ? '<encrypted>' : content,
+        title,
+      })
       response.success({ post })
     } catch (err) {
-      this.logger.error('Post create failed', { error: err, user_id: userId, site, format, content, title })
+      this.logger.error('Post create failed', {
+        error: err,
+        user_id: userId,
+        site,
+        format,
+        content: encryptedPayload ? '<encrypted>' : content,
+        title,
+      })
       this.logger.error(err)
       return response.error('error', 'Unknown error', 500)
     }
@@ -379,7 +443,7 @@ export default class PostController {
     }
 
     const userId = request.session.data.userId
-    const { post_id: postId, comment_id: parentCommentId, format, content } = request.body
+    const { post_id: postId, comment_id: parentCommentId, format, content, encryptedPayload } = request.body
 
     try {
       const userRestrictions = await this.userManager.getUserRestrictions(userId)
@@ -416,6 +480,7 @@ export default class PostController {
         parentCommentId,
         content,
         format,
+        encryptedPayload,
         {
           bumpFeed,
           sendNotifications,
@@ -424,12 +489,12 @@ export default class PostController {
       const {
         allComments: [comment],
       } = await this.enricher.enrichRawComments([commentInfo], {}, format, () => true)
-      comment.canEdit = overrideUserId === userId
+      comment.canEdit = overrideUserId === userId && !comment.encryptedPayloadId
 
       const users: Record<number, UserEntity> = { [overrideUserId]: await this.userManager.getById(overrideUserId) }
 
       this.logger.info(`Comment created by #${overrideUserId} @${users[overrideUserId].username}`, {
-        comment: content,
+        comment: encryptedPayload ? '<encrypted>' : content,
         username: users[overrideUserId].username,
         user_id: overrideUserId,
       })
@@ -439,7 +504,13 @@ export default class PostController {
         users,
       })
     } catch (err) {
-      this.logger.error('Comment create failed', { error: err, user_id: userId, format, content, post_id: postId })
+      this.logger.error('Comment create failed', {
+        error: err,
+        user_id: userId,
+        format,
+        content: encryptedPayload ? '<encrypted>' : content,
+        post_id: postId,
+      })
       this.logger.error(err)
       return response.error('error', 'Unknown error', 500)
     }
@@ -546,7 +617,7 @@ export default class PostController {
     }
 
     const userId = request.session.data.userId
-    const { id: commentId, content, format } = request.body
+    const { id: commentId, content, format, encryptedPayload } = request.body
 
     try {
       const userRestrictions = await this.userManager.getUserRestrictions(userId)
@@ -554,7 +625,7 @@ export default class PostController {
         return response.error('restricted', 'Editing restricted', 403)
       }
 
-      const commentInfo = await this.postManager.editComment(userId, commentId, content, format)
+      const commentInfo = await this.postManager.editComment(userId, commentId, content, format, encryptedPayload)
       if (!commentInfo) {
         return response.error('no-comment', 'Comment not found')
       }
@@ -569,7 +640,11 @@ export default class PostController {
         users: users,
       })
     } catch (err) {
-      this.logger.error('Comment edit error', { error: err, comment_id: commentId })
+      this.logger.error('Comment edit error', {
+        error: err,
+        comment_id: commentId,
+        content: encryptedPayload ? '<encrypted>' : content,
+      })
       this.logger.error(err)
 
       if (err instanceof CodeError && err.code === 'access-denied') {

--- a/backend/src/api/PostController.ts
+++ b/backend/src/api/PostController.ts
@@ -678,9 +678,12 @@ export default class PostController {
     const targetUser = await this.userManager.getByUsername(username)
 
     if (!targetUser) {
-      return res.success({ publicKey: undefined })
+      return res.success({ publicKey: undefined, publicKeyAlg: undefined })
     }
     const publicKey = await this.userManager.getPublicKey(targetUser.id)
-    return res.success({ publicKey })
+    return res.success({
+      publicKey: publicKey?.publicKey,
+      publicKeyAlg: publicKey?.publicKeyAlg,
+    })
   }
 }

--- a/backend/src/api/PostController.ts
+++ b/backend/src/api/PostController.ts
@@ -725,6 +725,7 @@ export default class PostController {
         title: h.title,
         comment: h.comment,
         content: h.content,
+        encryptedPayloadId: h.encryptedPayloadId,
         date: h.date.toISOString(),
         editor: h.editor,
         changed: h.changed,

--- a/backend/src/api/PostController.ts
+++ b/backend/src/api/PostController.ts
@@ -489,7 +489,7 @@ export default class PostController {
       const {
         allComments: [comment],
       } = await this.enricher.enrichRawComments([commentInfo], {}, format, () => true)
-      comment.canEdit = overrideUserId === userId && !comment.encryptedPayloadId
+      comment.canEdit = overrideUserId === userId
 
       const users: Record<number, UserEntity> = { [overrideUserId]: await this.userManager.getById(overrideUserId) }
 

--- a/backend/src/api/PostController.ts
+++ b/backend/src/api/PostController.ts
@@ -468,8 +468,8 @@ export default class PostController {
 
       const overrideUserId = (await this.postManager.getUserIdOverride(postId)) || userId
 
-      // feed bump when post author is not fully karmadead
-      const bumpFeed = postAuthorRestrictions.restrictedToPostId === false
+      // encrypted replies/comments should not bump public feeds
+      const bumpFeed = postAuthorRestrictions.restrictedToPostId === false && !encryptedPayload
 
       // send notifications when commenter is not fully karmadead
       const sendNotifications = userRestrictions.restrictedToPostId === false

--- a/backend/src/api/StatusController.ts
+++ b/backend/src/api/StatusController.ts
@@ -38,6 +38,7 @@ export default class StatusController {
       const userId = request.session.data.userId
       const user = await this.userManager.getById(userId)
       const stats = await this.userManager.getUserStats(userId)
+      const mailboxPublicKey = await this.userManager.getPublicKey(userId)
 
       if (!user) {
         // Something wrong, user should exist!
@@ -45,7 +46,11 @@ export default class StatusController {
       }
 
       return response.success({
-        user,
+        user: {
+          ...user,
+          publicKey: mailboxPublicKey?.publicKey || '',
+          publicKeyAlg: mailboxPublicKey?.publicKeyAlg || '',
+        },
         ...stats,
       })
     } catch (err) {

--- a/backend/src/api/UserController.ts
+++ b/backend/src/api/UserController.ts
@@ -97,6 +97,7 @@ export default class UserController {
 
     const publicKeySchema = Joi.object<UserSavePublicKeyRequest>({
       publicKey: Joi.string().max(128).allow(''),
+      publicKeyAlg: Joi.string().max(32).allow(''),
     })
 
     const settingsSaveLimiter = rateLimit({
@@ -201,7 +202,7 @@ export default class UserController {
       const invites = await this.userManager.getInvites(profileInfo.id)
       const invitedBy = await this.userManager.getInvitedBy(profileInfo.id)
       const active = await this.userManager.isUserActive(profileInfo.id)
-      const publicKey = await this.userManager.getPublicKey(profileInfo.id)
+      const mailboxPublicKey = await this.userManager.getPublicKey(profileInfo.id)
       const trialApprovers = await this.userManager.getTrialApprovers(profileInfo.id)
       const invitedReason = await this.inviteManager.getInviteReason(profileInfo.id)
       const trialProgress = await this.userManager.tryEndTrial(profileInfo.id, false)
@@ -244,7 +245,8 @@ export default class UserController {
         numberOfComments,
         numberOfInvitesAvailable,
         isBarmalini: this.userManager.isBarmaliniUser(profileInfo.id),
-        publicKey,
+        publicKey: mailboxPublicKey?.publicKey || '',
+        publicKeyAlg: mailboxPublicKey?.publicKeyAlg || '',
         visitedDaysAgo,
         hasOwnApps,
       })
@@ -559,13 +561,13 @@ export default class UserController {
     if (!req.session.data.userId) {
       return res.authRequired()
     }
-    const { publicKey } = req.body
+    const { publicKey, publicKeyAlg } = req.body
     try {
-      this.userManager.savePublicKey(publicKey, req.session.data.userId)
-      return res.success({ publicKey })
+      this.userManager.savePublicKey(publicKey, publicKeyAlg, req.session.data.userId)
+      return res.success({ publicKey, publicKeyAlg })
     } catch (error) {
       this.logger.error('Could not update user public key', { error })
-      return res.error('error', `Could not update public key`, 500)
+      return res.error('error', error instanceof Error ? error.message : `Could not update public key`, 400)
     }
   }
 

--- a/backend/src/api/types/entities/CommentEntity.ts
+++ b/backend/src/api/types/entities/CommentEntity.ts
@@ -8,6 +8,7 @@ export type CommentBaseEntity = {
 
 export type CommentEntity = CommentBaseEntity & {
   created: string
+  encryptedPayloadId?: number
   deleted?: boolean
   rating: number
   parentComment?: number

--- a/backend/src/api/types/entities/EncryptedPayloadEntity.ts
+++ b/backend/src/api/types/entities/EncryptedPayloadEntity.ts
@@ -1,0 +1,38 @@
+export type EncryptedPayloadWrapDraftEntity = {
+  userId: number
+  role: 'sender' | 'recipient'
+  publicKey: string
+  publicKeyAlg: string
+  ephemeralPublicKey: string
+  iv: string
+  encryptedKey: string
+}
+
+export type EncryptedPayloadDraftEntity = {
+  v: number
+  parserProfile: string
+  ciphertext: string
+  iv: string
+  wraps: EncryptedPayloadWrapDraftEntity[]
+}
+
+export type EncryptedPayloadWrapEntity = {
+  role: 'sender' | 'recipient'
+  publicKey: string
+  publicKeyAlg: string
+  ephemeralPublicKey: string
+  iv: string
+  encryptedKey: string
+}
+
+export type EncryptedPayloadEntity = {
+  id: number
+  v: number
+  parserProfile: string
+  canDecrypt: boolean
+  payload?: {
+    ciphertext: string
+    iv: string
+    wrap: EncryptedPayloadWrapEntity
+  }
+}

--- a/backend/src/api/types/entities/HistoryEntity.ts
+++ b/backend/src/api/types/entities/HistoryEntity.ts
@@ -1,6 +1,7 @@
 export type HistoryEntity = {
   id: number
   content: string
+  encryptedPayloadId?: number
   title?: string
   comment?: string
   date: string

--- a/backend/src/api/types/entities/PostEntity.ts
+++ b/backend/src/api/types/entities/PostEntity.ts
@@ -10,6 +10,7 @@ export type PostEntity = PostBaseEntity & {
   author: number
   created: string
   content?: string
+  encryptedPayloadId?: number
   rating: number
   comments: number
   newComments: number

--- a/backend/src/api/types/entities/UserEntity.ts
+++ b/backend/src/api/types/entities/UserEntity.ts
@@ -14,6 +14,8 @@ export type UserEntity = UserBaseEntity & {
   karma: number
   name?: string
   vote?: number
+  publicKey?: string
+  publicKeyAlg?: string
 }
 
 export type UserProfileEntity = UserEntity & {

--- a/backend/src/api/types/requests/AuthSignIn.ts
+++ b/backend/src/api/types/requests/AuthSignIn.ts
@@ -1,4 +1,4 @@
-import { UserBaseEntity } from '../entities/UserEntity'
+import { UserEntity } from '../entities/UserEntity'
 
 export type AuthSignInRequest = {
   username: string
@@ -6,6 +6,6 @@ export type AuthSignInRequest = {
 }
 
 export type AuthSignInResponse = {
-  user: UserBaseEntity
+  user: UserEntity
   session: string
 }

--- a/backend/src/api/types/requests/EncryptedPayload.ts
+++ b/backend/src/api/types/requests/EncryptedPayload.ts
@@ -1,0 +1,13 @@
+import { EncryptedPayloadDraftEntity, EncryptedPayloadEntity } from '../entities/EncryptedPayloadEntity'
+
+export type EncryptedPayloadBatchRequest = {
+  ids: number[]
+}
+
+export type EncryptedPayloadBatchResponse = {
+  payloads: EncryptedPayloadEntity[]
+}
+
+export type EncryptedPayloadRequestMixin = {
+  encryptedPayload?: EncryptedPayloadDraftEntity
+}

--- a/backend/src/api/types/requests/GetPublicKeyByPostOrComment.ts
+++ b/backend/src/api/types/requests/GetPublicKeyByPostOrComment.ts
@@ -4,4 +4,5 @@ export type GetPublicKeyByUsernameRequest = {
 
 export type GetPublicKeyByUsernameResponse = {
   publicKey?: string
+  publicKeyAlg?: string
 }

--- a/backend/src/api/types/requests/PostComment.ts
+++ b/backend/src/api/types/requests/PostComment.ts
@@ -1,8 +1,9 @@
 import { CommentEntity } from '../entities/CommentEntity'
 import { ContentFormat } from '../entities/common'
 import { UserEntity } from '../entities/UserEntity'
+import { EncryptedPayloadRequestMixin } from './EncryptedPayload'
 
-export type PostCommentRequest = {
+export type PostCommentRequest = EncryptedPayloadRequestMixin & {
   comment_id?: number
   post_id: number
   content: string

--- a/backend/src/api/types/requests/PostCreate.ts
+++ b/backend/src/api/types/requests/PostCreate.ts
@@ -1,7 +1,8 @@
 import { ContentFormat } from '../entities/common'
 import { PostEntity } from '../entities/PostEntity'
+import { EncryptedPayloadRequestMixin } from './EncryptedPayload'
 
-export type PostCreateRequest = {
+export type PostCreateRequest = EncryptedPayloadRequestMixin & {
   site: string
   title: string
   content: string

--- a/backend/src/api/types/requests/PostEdit.ts
+++ b/backend/src/api/types/requests/PostEdit.ts
@@ -1,8 +1,9 @@
 import { ContentFormat } from '../entities/common'
 import { PostEntity } from '../entities/PostEntity'
 import { UserEntity } from '../entities/UserEntity'
+import { EncryptedPayloadRequestMixin } from './EncryptedPayload'
 
-export type PostEditRequest = {
+export type PostEditRequest = EncryptedPayloadRequestMixin & {
   id: number
   title?: string
   content: string

--- a/backend/src/api/types/requests/PostEditComment.ts
+++ b/backend/src/api/types/requests/PostEditComment.ts
@@ -1,8 +1,9 @@
 import { CommentEntity } from '../entities/CommentEntity'
 import { ContentFormat } from '../entities/common'
 import { UserEntity } from '../entities/UserEntity'
+import { EncryptedPayloadRequestMixin } from './EncryptedPayload'
 
-export type PostCommentEditRequest = {
+export type PostCommentEditRequest = EncryptedPayloadRequestMixin & {
   id: number
   content: string
   format?: ContentFormat

--- a/backend/src/api/types/requests/UserProfile.ts
+++ b/backend/src/api/types/requests/UserProfile.ts
@@ -19,6 +19,7 @@ export type UserProfileResponse = {
   isBarmalini?: boolean
 
   publicKey: string
+  publicKeyAlg: string
   hasOwnApps: boolean
 
   visitedDaysAgo: number
@@ -86,10 +87,12 @@ export type UserSaveGenderResponse = {
 
 export type UserSavePublicKeyRequest = {
   publicKey: string
+  publicKeyAlg: string
 }
 
 export type UserSavePublicKeyResponse = {
   publicKey: string
+  publicKeyAlg: string
 }
 
 export type BarmaliniPasswordRequest = Record<string, unknown>

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,7 @@ import winston from 'winston'
 
 import { apiMiddleware } from './api/ApiMiddleware'
 import AuthController from './api/AuthController'
+import EncryptedPayloadController from './api/EncryptedPayloadController'
 import FeedController from './api/FeedController'
 import InviteController from './api/InviteController'
 import NotificationsController from './api/NotificationsController'
@@ -29,6 +30,7 @@ import DB from './db/DB'
 import Redis from './db/Redis'
 import BookmarkRepository from './db/repositories/BookmarkRepository'
 import CommentRepository from './db/repositories/CommentRepository'
+import EncryptedPayloadRepository from './db/repositories/EncryptedPayloadRepository'
 import InviteRepository from './db/repositories/InviteRepository'
 import NotificationsRepository from './db/repositories/NotificationsRepository'
 import OAuth2Repository from './db/repositories/OAuth2Repository'
@@ -40,6 +42,7 @@ import UserCredentials from './db/repositories/UserCredentials'
 import UserRepository from './db/repositories/UserRepository'
 import VoteRepository from './db/repositories/VoteRepository'
 import WebPushRepository from './db/repositories/WebPushRepository'
+import EncryptedPayloadManager from './managers/EncryptedPayloadManager'
 import FeedManager from './managers/FeedManager'
 import InviteManager from './managers/InviteManager'
 import NotificationManager from './managers/NotificationManager'
@@ -108,11 +111,12 @@ const theParser = new TheParser({
 })
 
 const bookmarkRepository = new BookmarkRepository(db)
-const commentRepository = new CommentRepository(db)
+const encryptedPayloadRepository = new EncryptedPayloadRepository(db)
+const commentRepository = new CommentRepository(db, encryptedPayloadRepository)
 const credentialsRepository = new UserCredentials(db)
 const inviteRepository = new InviteRepository(db)
 const notificationsRepository = new NotificationsRepository(db)
-const postRepository = new PostRepository(db)
+const postRepository = new PostRepository(db, encryptedPayloadRepository)
 const siteRepository = new SiteRepository(db)
 const voteRepository = new VoteRepository(db)
 const userRepository = new UserRepository(db)
@@ -198,6 +202,7 @@ const voteManager = new VoteManager(voteRepository, postManager, userManager, re
 const searchManager = new SearchManager(userManager, siteManager, logger.child({ service: 'SEARCH' }))
 const oauth2Manager = new OAuth2Manager(oauthRepository, userManager, logger.child({ service: 'OAUTH2' }))
 const pollManager = new PollManager(pollRepository, userManager)
+const encryptedPayloadManager = new EncryptedPayloadManager(encryptedPayloadRepository)
 
 const apiEnricher = new Enricher(siteManager, userManager)
 
@@ -230,6 +235,7 @@ const requests = [
     logger.child({ service: 'STATUS' }),
   ),
   new VoteController(voteManager, userManager, oauthMiddlewareGenerator, logger.child({ service: 'VOTE' })),
+  new EncryptedPayloadController(encryptedPayloadManager, oauthMiddlewareGenerator, logger.child({ service: 'ENC' })),
   new UserController(
     apiEnricher,
     userManager,

--- a/backend/src/db/repositories/CommentRepository.ts
+++ b/backend/src/db/repositories/CommentRepository.ts
@@ -1,15 +1,19 @@
 import { ResultSetHeader } from 'mysql2'
 
+import { EncryptedPayloadDraftEntity } from '../../api/types/entities/EncryptedPayloadEntity'
 import CodeError from '../../CodeError'
 import { escapePercent } from '../../utils/MySqlUtils'
 import DB from '../DB'
 import { CommentRaw, CommentRawWithUserData } from '../types/PostRaw'
+import EncryptedPayloadRepository from './EncryptedPayloadRepository'
 
 export default class CommentRepository {
   private db: DB
+  private encryptedPayloadRepository: EncryptedPayloadRepository
 
-  constructor(db: DB) {
+  constructor(db: DB, encryptedPayloadRepository: EncryptedPayloadRepository) {
     this.db = db
+    this.encryptedPayloadRepository = encryptedPayloadRepository
   }
 
   async getComment(commentId: number): Promise<CommentRaw | undefined> {
@@ -114,6 +118,7 @@ export default class CommentRepository {
     source: string,
     language: string,
     html: string,
+    encryptedPayload?: EncryptedPayloadDraftEntity,
     updateCommentedAt = true,
   ): Promise<CommentRaw> {
     return await this.db.inTransaction(async (conn) => {
@@ -125,6 +130,7 @@ export default class CommentRepository {
         throw new CodeError('no-post', 'Post not found')
       }
 
+      const encryptedPayloadId = await this.encryptedPayloadRepository.createEncryptedPayload(conn, encryptedPayload)
       const commentId = await conn.insert('comments', {
         site_id: siteResult.site_id,
         post_id: postId,
@@ -133,6 +139,7 @@ export default class CommentRepository {
         source: source,
         language: language,
         html: html,
+        encrypted_payload_id: encryptedPayloadId,
       })
 
       const contentSourceId = await conn.insert('content_source', {
@@ -140,12 +147,17 @@ export default class CommentRepository {
         ref_id: commentId,
         author_id: userId,
         source,
+        encrypted_payload_id: encryptedPayloadId,
       })
 
-      await conn.query('update comments set content_source_id=:contentSourceId where comment_id=:commentId', {
-        commentId,
-        contentSourceId,
-      })
+      await conn.query(
+        'update comments set content_source_id=:contentSourceId, encrypted_payload_id=:encryptedPayloadId where comment_id=:commentId',
+        {
+          commentId,
+          contentSourceId,
+          encryptedPayloadId,
+        },
+      )
 
       await conn.query(
         `update posts p set comments=(select count(*) from comments c where c.post_id = p.post_id), 
@@ -176,6 +188,7 @@ export default class CommentRepository {
     source: string,
     language: string,
     html: string,
+    encryptedPayload?: EncryptedPayloadDraftEntity,
     comment?: string,
   ): Promise<boolean> {
     return await this.db.inTransaction(async (conn) => {
@@ -187,11 +200,13 @@ export default class CommentRepository {
         throw new CodeError('unknown', 'Could not select comment')
       }
 
+      const encryptedPayloadId = await this.encryptedPayloadRepository.createEncryptedPayload(conn, encryptedPayload)
       const contentSourceId = await conn.insert('content_source', {
         ref_type: 'comment',
         ref_id: commentId,
         author_id: updateByUserId,
         source,
+        encrypted_payload_id: encryptedPayloadId,
         comment,
       })
 
@@ -202,6 +217,7 @@ export default class CommentRepository {
                  set source=:source,
                      html=:html,
                      content_source_id=:contentSourceId,
+                     encrypted_payload_id=:encryptedPayloadId,
                      edit_flag=:editFlag,
                      language=:language
                  where comment_id = :commentId`,
@@ -210,6 +226,7 @@ export default class CommentRepository {
           source,
           html,
           contentSourceId,
+          encryptedPayloadId,
           editFlag,
           language,
         },

--- a/backend/src/db/repositories/EncryptedPayloadRepository.ts
+++ b/backend/src/db/repositories/EncryptedPayloadRepository.ts
@@ -1,0 +1,71 @@
+import { EncryptedPayloadDraftEntity } from '../../api/types/entities/EncryptedPayloadEntity'
+import DB, { DBConnection } from '../DB'
+import { EncryptedPayloadWithUserKeyRaw } from '../types/EncryptedPayloadRaw'
+
+export default class EncryptedPayloadRepository {
+  private db: DB
+
+  constructor(db: DB) {
+    this.db = db
+  }
+
+  async createEncryptedPayload(
+    conn: DBConnection,
+    payload: EncryptedPayloadDraftEntity | undefined,
+  ): Promise<number | undefined> {
+    if (!payload) {
+      return undefined
+    }
+
+    const encryptedPayloadId = await conn.insert('encrypted_payloads', {
+      v: payload.v,
+      parser_profile: payload.parserProfile,
+      ciphertext: payload.ciphertext,
+      iv: payload.iv,
+    })
+
+    for (const wrap of payload.wraps) {
+      await conn.insert('encrypted_payload_keys', {
+        encrypted_payload_id: encryptedPayloadId,
+        user_id: wrap.userId,
+        role: wrap.role,
+        public_key: wrap.publicKey,
+        public_key_alg: wrap.publicKeyAlg,
+        ephemeral_public_key: wrap.ephemeralPublicKey,
+        iv: wrap.iv,
+        encrypted_key: wrap.encryptedKey,
+      })
+    }
+
+    return encryptedPayloadId
+  }
+
+  async getEncryptedPayloadsByIds(ids: number[], userId: number): Promise<EncryptedPayloadWithUserKeyRaw[]> {
+    if (!ids.length) {
+      return []
+    }
+
+    return await this.db.fetchAll<EncryptedPayloadWithUserKeyRaw>(
+      `
+        SELECT
+          p.*,
+          k.user_id AS key_user_id,
+          k.role AS key_role,
+          k.public_key AS key_public_key,
+          k.public_key_alg AS key_public_key_alg,
+          k.ephemeral_public_key AS key_ephemeral_public_key,
+          k.iv AS key_iv,
+          k.encrypted_key AS key_encrypted_key
+        FROM encrypted_payloads p
+        LEFT JOIN encrypted_payload_keys k
+          ON k.encrypted_payload_id = p.encrypted_payload_id
+         AND k.user_id = :userId
+        WHERE p.encrypted_payload_id IN (:ids)
+      `,
+      {
+        ids,
+        userId,
+      },
+    )
+  }
+}

--- a/backend/src/db/repositories/PostRepository.ts
+++ b/backend/src/db/repositories/PostRepository.ts
@@ -1,17 +1,21 @@
 import { ResultSetHeader } from 'mysql2'
 
 import { FeedSorting } from '../../api/types/entities/common'
+import { EncryptedPayloadDraftEntity } from '../../api/types/entities/EncryptedPayloadEntity'
 import CodeError from '../../CodeError'
 import { escapePercent } from '../../utils/MySqlUtils'
 import DB from '../DB'
 import { ContentSourceRaw } from '../types/ContentSourceRaw'
 import { PostBareBonesRaw, PostRaw, PostRawWithUserData } from '../types/PostRaw'
+import EncryptedPayloadRepository from './EncryptedPayloadRepository'
 
 export default class PostRepository {
   private db: DB
+  private encryptedPayloadRepository: EncryptedPayloadRepository
 
-  constructor(db: DB) {
+  constructor(db: DB, encryptedPayloadRepository: EncryptedPayloadRepository) {
     this.db = db
+    this.encryptedPayloadRepository = encryptedPayloadRepository
   }
 
   /**
@@ -266,8 +270,10 @@ export default class PostRepository {
     source: string,
     language: string,
     html: string,
+    encryptedPayload?: EncryptedPayloadDraftEntity,
   ): Promise<PostRaw> {
     return await this.db.inTransaction(async (db) => {
+      const encryptedPayloadId = await this.encryptedPayloadRepository.createEncryptedPayload(db, encryptedPayload)
       const postId = await db.insert('posts', {
         site_id: siteId,
         author_id: userId,
@@ -275,6 +281,7 @@ export default class PostRepository {
         source,
         language,
         html,
+        encrypted_payload_id: encryptedPayloadId,
       })
 
       const contentSourceId = await db.insert('content_source', {
@@ -283,12 +290,17 @@ export default class PostRepository {
         author_id: userId,
         title,
         source,
+        encrypted_payload_id: encryptedPayloadId,
       })
 
-      await db.query('update posts set content_source_id=:contentSourceId where post_id=:postId', {
-        postId,
-        contentSourceId,
-      })
+      await db.query(
+        'update posts set content_source_id=:contentSourceId, encrypted_payload_id=:encryptedPayloadId where post_id=:postId',
+        {
+          postId,
+          contentSourceId,
+          encryptedPayloadId,
+        },
+      )
 
       const post = await db.fetchOne<PostRaw>('select * from posts where post_id=:postId', {
         postId,
@@ -337,6 +349,7 @@ export default class PostRepository {
     source: string,
     language: string,
     html: string,
+    encryptedPayload?: EncryptedPayloadDraftEntity,
     comment?: string,
   ): Promise<boolean> {
     return await this.db.inTransaction(async (conn) => {
@@ -348,12 +361,14 @@ export default class PostRepository {
         throw new CodeError('unknown', 'Could not select post')
       }
 
+      const encryptedPayloadId = await this.encryptedPayloadRepository.createEncryptedPayload(conn, encryptedPayload)
       const contentSourceId = await conn.insert('content_source', {
         ref_type: 'post',
         ref_id: postId,
         author_id: updateByUserId,
         title,
         source,
+        encrypted_payload_id: encryptedPayloadId,
         comment,
       })
 
@@ -365,6 +380,7 @@ export default class PostRepository {
                      source=:source,
                      html=:html,
                      content_source_id=:contentSourceId,
+                     encrypted_payload_id=:encryptedPayloadId,
                      edit_flag=:editFlag,
                      language=:language
                  where post_id = :postId`,
@@ -374,6 +390,7 @@ export default class PostRepository {
           source,
           html,
           contentSourceId,
+          encryptedPayloadId,
           editFlag,
           language,
         },

--- a/backend/src/db/repositories/UserRepository.ts
+++ b/backend/src/db/repositories/UserRepository.ts
@@ -4,6 +4,7 @@ import { OkPacket } from 'mysql2'
 
 import { FeedSorting } from '../../api/types/entities/common'
 import CodeError from '../../CodeError'
+import { MailboxPublicKey } from '../../managers/types/MailboxPublicKey'
 import { UserGender } from '../../managers/types/UserInfo'
 import DB from '../DB'
 import { InviteRaw } from '../types/InviteRaw'
@@ -375,21 +376,33 @@ export default class UserRepository {
     })
   }
 
-  async savePublicKey(publicKey: string, userId: number) {
+  async savePublicKey(publicKey: string, publicKeyAlg: string, userId: number) {
     return this.db.query(
       `UPDATE users
-                              SET public_key = :publicKey
+                              SET public_key = :publicKey,
+                                  public_key_alg = :publicKeyAlg
                               WHERE user_id = :userId`,
       {
         publicKey,
+        publicKeyAlg,
         userId,
       },
     )
   }
 
-  getPublicKey(userId: number) {
+  getPublicKey(userId: number): Promise<MailboxPublicKey | undefined> {
     return this.db
-      .fetchOne<{ public_key: string }>(`SELECT public_key FROM users WHERE user_id = :userId`, { userId })
-      .then((res) => res?.public_key)
+      .fetchOne<{
+        public_key: string
+        public_key_alg: string
+      }>(`SELECT public_key, public_key_alg FROM users WHERE user_id = :userId`, { userId })
+      .then((res) =>
+        res && res.public_key
+          ? {
+              publicKey: res.public_key,
+              publicKeyAlg: res.public_key_alg || '',
+            }
+          : undefined,
+      )
   }
 }

--- a/backend/src/db/types/ContentSourceRaw.ts
+++ b/backend/src/db/types/ContentSourceRaw.ts
@@ -4,6 +4,7 @@ export type ContentSourceRaw = {
   ref_type: string
   author_id: number
   source: string
+  encrypted_payload_id?: number | null
   title?: string
   comment?: string
   created_at: Date

--- a/backend/src/db/types/EncryptedPayloadRaw.ts
+++ b/backend/src/db/types/EncryptedPayloadRaw.ts
@@ -1,0 +1,31 @@
+export type EncryptedPayloadRaw = {
+  encrypted_payload_id: number
+  v: number
+  parser_profile: string
+  ciphertext: string
+  iv: string
+  created_at: Date
+}
+
+export type EncryptedPayloadKeyRaw = {
+  encrypted_payload_key_id: number
+  encrypted_payload_id: number
+  user_id: number
+  role: string
+  public_key: string
+  public_key_alg: string
+  ephemeral_public_key: string
+  iv: string
+  encrypted_key: string
+  created_at: Date
+}
+
+export type EncryptedPayloadWithUserKeyRaw = EncryptedPayloadRaw & {
+  key_user_id?: number
+  key_role?: string
+  key_public_key?: string
+  key_public_key_alg?: string
+  key_ephemeral_public_key?: string
+  key_iv?: string
+  key_encrypted_key?: string
+}

--- a/backend/src/db/types/PostRaw.ts
+++ b/backend/src/db/types/PostRaw.ts
@@ -16,6 +16,7 @@ export type PostRaw = {
   gold: number
   language: string
   content_source_id: number
+  encrypted_payload_id: number | null
   parser_version: number
 } & PostBareBonesRaw
 
@@ -41,6 +42,7 @@ export type CommentRaw = {
   edit_flag?: number
   language: string
   content_source_id: number
+  encrypted_payload_id: number | null
   parser_version: number
 }
 

--- a/backend/src/managers/EncryptedPayloadManager.ts
+++ b/backend/src/managers/EncryptedPayloadManager.ts
@@ -1,0 +1,40 @@
+import { EncryptedPayloadDraftEntity, EncryptedPayloadEntity } from '../api/types/entities/EncryptedPayloadEntity'
+import { DBConnection } from '../db/DB'
+import EncryptedPayloadRepository from '../db/repositories/EncryptedPayloadRepository'
+
+export default class EncryptedPayloadManager {
+  private encryptedPayloadRepository: EncryptedPayloadRepository
+
+  constructor(encryptedPayloadRepository: EncryptedPayloadRepository) {
+    this.encryptedPayloadRepository = encryptedPayloadRepository
+  }
+
+  createEncryptedPayload(conn: DBConnection, payload: EncryptedPayloadDraftEntity | undefined) {
+    return this.encryptedPayloadRepository.createEncryptedPayload(conn, payload)
+  }
+
+  async getEncryptedPayloadsByIds(ids: number[], userId: number): Promise<EncryptedPayloadEntity[]> {
+    const rows = await this.encryptedPayloadRepository.getEncryptedPayloadsByIds(ids, userId)
+
+    return rows.map((row) => ({
+      id: row.encrypted_payload_id,
+      v: row.v,
+      parserProfile: row.parser_profile,
+      canDecrypt: !!row.key_user_id,
+      payload: row.key_user_id
+        ? {
+            ciphertext: row.ciphertext,
+            iv: row.iv,
+            wrap: {
+              role: (row.key_role || 'recipient') as 'sender' | 'recipient',
+              publicKey: row.key_public_key || '',
+              publicKeyAlg: row.key_public_key_alg || '',
+              ephemeralPublicKey: row.key_ephemeral_public_key || '',
+              iv: row.key_iv || '',
+              encryptedKey: row.key_encrypted_key || '',
+            },
+          }
+        : undefined,
+    }))
+  }
+}

--- a/backend/src/managers/FeedManager.ts
+++ b/backend/src/managers/FeedManager.ts
@@ -313,7 +313,7 @@ export default class FeedManager {
         siteById[rawPost.site_id] = site
       }
 
-      if (rawPost.parser_version !== TheParser.VERSION) {
+      if (!rawPost.encrypted_payload_id && rawPost.parser_version !== TheParser.VERSION) {
         const parseResult = this.parser.parse(rawPost.source)
         commentsToUpdateHtmlAndParserVersion.push({
           id: rawPost.post_id,
@@ -330,6 +330,7 @@ export default class FeedManager {
         created: rawPost.created_at,
         title: rawPost.title,
         content: format === 'html' ? rawPost.html : rawPost.source,
+        encryptedPayloadId: rawPost.encrypted_payload_id || undefined,
         rating: rawPost.rating,
         comments: rawPost.comments,
         newComments: rawPost.read_comments ? Math.max(0, rawPost.comments - rawPost.read_comments) : rawPost.comments,
@@ -339,7 +340,7 @@ export default class FeedManager {
         lastReadCommentId: rawPost.last_read_comment_id,
         language: rawPost.language,
       }
-      if (rawPost.author_id === forUserId) {
+      if (rawPost.author_id === forUserId && !rawPost.encrypted_payload_id) {
         post.canEdit = true
       }
       if (rawPost.edit_flag) {

--- a/backend/src/managers/FeedManager.ts
+++ b/backend/src/managers/FeedManager.ts
@@ -340,7 +340,7 @@ export default class FeedManager {
         lastReadCommentId: rawPost.last_read_comment_id,
         language: rawPost.language,
       }
-      if (rawPost.author_id === forUserId && !rawPost.encrypted_payload_id) {
+      if (rawPost.author_id === forUserId) {
         post.canEdit = true
       }
       if (rawPost.edit_flag) {

--- a/backend/src/managers/NotificationManager.ts
+++ b/backend/src/managers/NotificationManager.ts
@@ -128,7 +128,7 @@ export default class NotificationManager {
                 : await this.commentRepository.getComment(data.source.commentId)
             comment = {
               id: commentRaw.comment_id,
-              content: commentRaw.source,
+              content: commentRaw.encrypted_payload_id ? '🔒 Шифровка' : commentRaw.source,
             }
           }
 
@@ -312,7 +312,7 @@ export default class NotificationManager {
 
     const baseUrl = (this.siteConfig.http ? 'http://' : 'https://') + this.siteConfig.domain
 
-    let commentText = comment.source
+    let commentText = comment.encrypted_payload_id ? '🔒 Шифровка' : comment.source
     if (commentText.length > 30) {
       commentText = commentText.substring(0, 30) + '...'
     }

--- a/backend/src/managers/PostManager.ts
+++ b/backend/src/managers/PostManager.ts
@@ -1,3 +1,4 @@
+import { EncryptedPayloadDraftEntity } from '../api/types/entities/EncryptedPayloadEntity'
 import CodeError from '../CodeError'
 import BookmarkRepository from '../db/repositories/BookmarkRepository'
 import CommentRepository from '../db/repositories/CommentRepository'
@@ -97,15 +98,24 @@ export default class PostManager {
     title: string,
     content: string,
     format: ContentFormat,
+    encryptedPayload?: EncryptedPayloadDraftEntity,
   ): Promise<PostInfo> {
     const site = await this.siteManager.getSiteByName(siteName)
     if (!site) {
       throw new CodeError('no-site', 'Site not found')
     }
 
-    const parseResult = this.parser.parse(content)
-    const language = await this.translationManager.detectLanguage(title, parseResult.text)
-    const postRaw = await this.postRepository.createPost(site.id, userId, title, content, language, parseResult.text)
+    const parseResult = encryptedPayload ? { text: '', mentions: [] } : this.parser.parse(content)
+    const language = encryptedPayload ? '' : await this.translationManager.detectLanguage(title, parseResult.text)
+    const postRaw = await this.postRepository.createPost(
+      site.id,
+      userId,
+      title,
+      encryptedPayload ? '' : content,
+      language,
+      encryptedPayload ? '' : parseResult.text,
+      encryptedPayload,
+    )
     this.userManager.clearUserRestrictionsCache(userId)
 
     await this.bookmarkRepository.setWatch(postRaw.post_id, userId, true)
@@ -126,6 +136,7 @@ export default class PostManager {
       created: postRaw.created_at,
       title: postRaw.title,
       content: format === 'html' ? postRaw.html : postRaw.source,
+      encryptedPayloadId: postRaw.encrypted_payload_id || undefined,
       rating: 0,
       comments: 0,
       newComments: 0,
@@ -141,6 +152,7 @@ export default class PostManager {
     title: string | undefined,
     content: string,
     format: ContentFormat,
+    encryptedPayload?: EncryptedPayloadDraftEntity,
   ): Promise<PostInfo> {
     let [rawPost] = await this.postRepository.getPostsWithUserData([postId], forUserId)
     if (rawPost.author_id !== forUserId) {
@@ -153,16 +165,24 @@ export default class PostManager {
       throw new CodeError('rate-limit', 'Edit rate limit exceeded', 429, { waitSeconds: Math.ceil(waitTimeToEditSec) })
     }
 
-    if (rawPost.source === content && rawPost.title === title) {
+    if (!encryptedPayload && rawPost.source === content && rawPost.title === title) {
       // nothing changed
       const [post] = await this.feedManager.convertRawPosts(forUserId, [rawPost], format)
       return post
     }
 
-    const html = (await this.parser.parse(content)).text
-    const language = await this.translationManager.detectLanguage(title, html)
+    const html = encryptedPayload ? '' : (await this.parser.parse(content)).text
+    const language = encryptedPayload ? '' : await this.translationManager.detectLanguage(title, html)
 
-    const updated = await this.postRepository.updatePostText(forUserId, postId, title, content, language, html)
+    const updated = await this.postRepository.updatePostText(
+      forUserId,
+      postId,
+      title,
+      encryptedPayload ? '' : content,
+      language,
+      html,
+      encryptedPayload,
+    )
     if (!updated) {
       throw new CodeError('unknown', 'Could not edit comment')
     }
@@ -236,7 +256,7 @@ export default class PostManager {
         siteById[raw.site_id] = site
       }
 
-      if (raw.parser_version !== TheParser.VERSION) {
+      if (!raw.encrypted_payload_id && raw.parser_version !== TheParser.VERSION) {
         const html = this.parser.parse(raw.source).text
         raw.parser_version = TheParser.VERSION
         postsToUpdateHtmlAndParserVersion.push({
@@ -251,6 +271,7 @@ export default class PostManager {
         post: raw.post_id,
         site: site ? site.site : '',
         content: format === 'html' ? raw.html : raw.source,
+        encryptedPayloadId: raw.encrypted_payload_id || undefined,
         author: raw.author_id,
         created: raw.created_at,
         rating: raw.rating,
@@ -262,7 +283,7 @@ export default class PostManager {
       if (raw.deleted) {
         comment.deleted = true
       }
-      if (raw.author_id === forUserId) {
+      if (raw.author_id === forUserId && !raw.encrypted_payload_id) {
         comment.canEdit = true
       }
       if (raw.edit_flag) {
@@ -295,27 +316,29 @@ export default class PostManager {
     parentCommentId: number | undefined,
     content: string,
     format: ContentFormat,
+    encryptedPayload: EncryptedPayloadDraftEntity | undefined,
     notificationOptions: {
       bumpFeed: boolean
       sendNotifications: boolean
     },
   ): Promise<CommentInfoWithPostData> {
-    const parseResult = this.parser.parse(content)
-    const language = await this.translationManager.detectLanguage('', parseResult.text)
+    const parseResult = encryptedPayload ? { text: '', mentions: [] } : this.parser.parse(content)
+    const language = encryptedPayload ? '' : await this.translationManager.detectLanguage('', parseResult.text)
     const { bumpFeed, sendNotifications } = notificationOptions
 
     const commentRaw = await this.commentRepository.createComment(
       userId,
       postId,
       parentCommentId,
-      content,
+      encryptedPayload ? '' : content,
       language,
-      parseResult.text,
+      encryptedPayload ? '' : parseResult.text,
+      encryptedPayload,
       bumpFeed,
     )
     this.userManager.clearUserRestrictionsCache(userId)
 
-    if (sendNotifications) {
+    if (sendNotifications && !encryptedPayload) {
       let parentAuthor: UserInfo | undefined
       if (parentCommentId) {
         const parentComment = await this.commentRepository.getComment(parentCommentId)
@@ -370,6 +393,7 @@ export default class PostManager {
     commentId: number,
     content: string,
     format: ContentFormat,
+    encryptedPayload?: EncryptedPayloadDraftEntity,
   ): Promise<CommentInfoWithPostData> {
     let rawComment = await this.commentRepository.getCommentWithUserData(forUserId, commentId)
     if (rawComment.author_id !== forUserId) {
@@ -382,16 +406,23 @@ export default class PostManager {
       throw new CodeError('rate-limit', 'Edit rate limit exceeded', 429, { waitSeconds: Math.ceil(waitTimeToEditSec) })
     }
 
-    if (rawComment.source === content) {
+    if (!encryptedPayload && rawComment.source === content) {
       // nothing changed
       const [comment] = await this.convertRawCommentsWithPostData(forUserId, [rawComment], format)
       return comment
     }
 
-    const html = (await this.parser.parse(content)).text
-    const language = await this.translationManager.detectLanguage('', html)
+    const html = encryptedPayload ? '' : (await this.parser.parse(content)).text
+    const language = encryptedPayload ? '' : await this.translationManager.detectLanguage('', html)
 
-    const updated = await this.commentRepository.updateCommentText(forUserId, commentId, content, language, html)
+    const updated = await this.commentRepository.updateCommentText(
+      forUserId,
+      commentId,
+      encryptedPayload ? '' : content,
+      language,
+      html,
+      encryptedPayload,
+    )
     if (!updated) {
       throw new CodeError('unknown', 'Could not edit comment')
     }

--- a/backend/src/managers/PostManager.ts
+++ b/backend/src/managers/PostManager.ts
@@ -338,12 +338,13 @@ export default class PostManager {
     )
     this.userManager.clearUserRestrictionsCache(userId)
 
+    let parentAuthor: UserInfo | undefined
+    if (sendNotifications && parentCommentId) {
+      const parentComment = await this.commentRepository.getComment(parentCommentId)
+      parentAuthor = await this.userManager.getById(parentComment.author_id)
+    }
+
     if (sendNotifications && !encryptedPayload) {
-      let parentAuthor: UserInfo | undefined
-      if (parentCommentId) {
-        const parentComment = await this.commentRepository.getComment(parentCommentId)
-        parentAuthor = await this.userManager.getById(parentComment.author_id)
-      }
       for (const mention of parseResult.mentions) {
         // if author of parent comment/post was mentioned - do not send notifications:
         // they are already notified about answer to their comment
@@ -352,10 +353,10 @@ export default class PostManager {
         }
         await this.notificationManager.sendMentionNotify(mention, userId, postId, commentRaw.comment_id)
       }
+    }
 
-      if (parentAuthor) {
-        await this.notificationManager.sendAnswerNotify(parentAuthor.id, userId, postId, commentRaw.comment_id)
-      }
+    if (sendNotifications && parentAuthor) {
+      await this.notificationManager.sendAnswerNotify(parentAuthor.id, userId, postId, commentRaw.comment_id)
     }
 
     await this.bookmarkRepository.setWatch(postId, userId, true)

--- a/backend/src/managers/PostManager.ts
+++ b/backend/src/managers/PostManager.ts
@@ -283,7 +283,7 @@ export default class PostManager {
       if (raw.deleted) {
         comment.deleted = true
       }
-      if (raw.author_id === forUserId && !raw.encrypted_payload_id) {
+      if (raw.author_id === forUserId) {
         comment.canEdit = true
       }
       if (raw.edit_flag) {

--- a/backend/src/managers/PostManager.ts
+++ b/backend/src/managers/PostManager.ts
@@ -482,13 +482,14 @@ export default class PostManager {
 
     for (const rawSource of rawSources) {
       let content = rawSource.source
-      if (format === 'html') {
+      if (!rawSource.encrypted_payload_id && format === 'html') {
         content = (await this.parser.parse(content)).text
       }
 
       const source: HistoryInfo = {
         id: rawSource.content_source_id,
         content,
+        encryptedPayloadId: rawSource.encrypted_payload_id || undefined,
         title: rawSource.title,
         comment: rawSource.comment,
         date: rawSource.created_at,

--- a/backend/src/managers/UserCache.ts
+++ b/backend/src/managers/UserCache.ts
@@ -2,6 +2,7 @@ import TrieSearch from 'trie-search'
 
 import UserRepository from '../db/repositories/UserRepository'
 import { UserRaw } from '../db/types/UserRaw'
+import { MailboxPublicKey } from './types/MailboxPublicKey'
 import { UserInfo, UserStats } from './types/UserInfo'
 
 export class UserCache {
@@ -16,7 +17,7 @@ export class UserCache {
   private cacheId: Record<number, UserInfo> = {}
   private cacheUsername: Record<string, UserInfo> = {}
   private cachedUserParents: Record<number, number | undefined | false> = {}
-  private cachedPublicKeys: Record<number, string | undefined> = {}
+  private cachedPublicKeys: Record<number, MailboxPublicKey | undefined> = {}
   private usernamesSuggestionsCache = new TrieSearch('k', { min: 1 })
   private userStatsCache = new Map<number, UserStats>()
 
@@ -161,8 +162,8 @@ export class UserCache {
     delete this.cachedPublicKeys[userId]
   }
 
-  async getPublicKey(userId: number): Promise<string | undefined> {
-    if (this.cachedPublicKeys[userId]) {
+  async getPublicKey(userId: number): Promise<MailboxPublicKey | undefined> {
+    if (userId in this.cachedPublicKeys) {
       return this.cachedPublicKeys[userId]
     }
 

--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -17,6 +17,7 @@ import { aesDecryptFromBase64, aesEncryptToBase64 } from '../parser/CryptoUtils'
 import TheParser from '../parser/TheParser'
 import { sendResetPasswordEmail } from '../utils/Mailer'
 import NotificationManager from './NotificationManager'
+import { isValidMailboxPublicKey, MAILBOX_PUBLIC_KEY_ALG } from './types/MailboxPublicKey'
 import { UserGender, UserInfo, UserRatingBySubsite, UserRestrictions, UserStats } from './types/UserInfo'
 import { UserCache } from './UserCache'
 
@@ -769,13 +770,30 @@ export default class UserManager {
     if (!this.barmaliniUserConfigured()) {
       throw new Error('Barmalini user not configured')
     }
-    await this.userRepository.anonymizeAccount(userId, config.barmalini.userId!)
+    const anonymousUserId = config.barmalini.userId
+    if (!anonymousUserId) {
+      throw new Error('Barmalini user not configured')
+    }
+
+    await this.userRepository.anonymizeAccount(userId, anonymousUserId)
     this.clearCache(userId)
     this.clearUserRestrictionsCache(userId)
   }
 
-  savePublicKey(publicKey: string, userId: number) {
-    const res = this.userRepository.savePublicKey(publicKey, userId)
+  savePublicKey(publicKey: string, publicKeyAlg: string, userId: number) {
+    if (!publicKey && !publicKeyAlg) {
+      const res = this.userRepository.savePublicKey('', '', userId)
+      this.userCache.clearPublicKeysCache(userId)
+      return res
+    }
+
+    if (!isValidMailboxPublicKey(publicKey, publicKeyAlg)) {
+      throw new Error(
+        `Invalid mailbox public key. Expected ${MAILBOX_PUBLIC_KEY_ALG} and a base64url-encoded 32-byte key.`,
+      )
+    }
+
+    const res = this.userRepository.savePublicKey(publicKey, publicKeyAlg, userId)
     this.userCache.clearPublicKeysCache(userId)
     return res
   }

--- a/backend/src/managers/types/CommentInfo.ts
+++ b/backend/src/managers/types/CommentInfo.ts
@@ -8,6 +8,7 @@ export type CommentBaseInfo = {
 export type CommentInfo = CommentBaseInfo & {
   author: number
   created: Date
+  encryptedPayloadId?: number
   deleted?: boolean
   rating: number
   parentComment?: number

--- a/backend/src/managers/types/HistoryInfo.ts
+++ b/backend/src/managers/types/HistoryInfo.ts
@@ -1,6 +1,7 @@
 export type HistoryInfo = {
   id: number
   content: string
+  encryptedPayloadId?: number
   title?: string
   comment?: string
   date: Date

--- a/backend/src/managers/types/MailboxPublicKey.ts
+++ b/backend/src/managers/types/MailboxPublicKey.ts
@@ -1,0 +1,12 @@
+export const MAILBOX_PUBLIC_KEY_ALG = 'x25519-scrypt-v1'
+
+export type MailboxPublicKey = {
+  publicKey: string
+  publicKeyAlg: string
+}
+
+const MAILBOX_PUBLIC_KEY_RE = /^[A-Za-z0-9_-]{43}$/
+
+export function isValidMailboxPublicKey(publicKey: string, publicKeyAlg: string) {
+  return publicKeyAlg === MAILBOX_PUBLIC_KEY_ALG && MAILBOX_PUBLIC_KEY_RE.test(publicKey)
+}

--- a/backend/src/managers/types/PostInfo.ts
+++ b/backend/src/managers/types/PostInfo.ts
@@ -10,6 +10,7 @@ export type PostBaseInfo = {
 export type PostInfo = PostBaseInfo & {
   author: number
   created: Date
+  encryptedPayloadId?: number
   editFlag?: EditFlag
   rating: number
   comments: number

--- a/backend/test/api/EncryptedPayloadController.test.ts
+++ b/backend/test/api/EncryptedPayloadController.test.ts
@@ -1,0 +1,155 @@
+import EncryptedPayloadController from '../../src/api/EncryptedPayloadController'
+
+function createMockEncryptedPayloadManager() {
+  return {
+    getEncryptedPayloadsByIds: jest.fn().mockResolvedValue([
+      {
+        id: 10,
+        v: 1,
+        parserProfile: 'lite-v1',
+        canDecrypt: true,
+        payload: {
+          ciphertext: 'ciphertext',
+          iv: 'payloadIv',
+          wrap: {
+            role: 'recipient',
+            publicKey: 'publicKey',
+            publicKeyAlg: 'x25519-scrypt-v1',
+            ephemeralPublicKey: 'ephemeralKey',
+            iv: 'wrapIv',
+            encryptedKey: 'encryptedKey',
+          },
+        },
+      },
+    ]),
+  }
+}
+
+function createMockOauth() {
+  return jest.fn().mockReturnValue((_req, _res, next) => next())
+}
+
+function createMockLogger() {
+  return {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    verbose: jest.fn(),
+    debug: jest.fn(),
+  }
+}
+
+function createMockRequest(userId: number | undefined, body: Record<string, unknown> = {}) {
+  return {
+    session: {
+      data: { userId },
+    },
+    body,
+  } as any
+}
+
+function createMockResponse() {
+  return {
+    success: jest.fn(),
+    error: jest.fn(),
+    authRequired: jest.fn(),
+  } as any
+}
+
+function createController(overrides: Record<string, any> = {}) {
+  const deps = {
+    encryptedPayloadManager: createMockEncryptedPayloadManager(),
+    oauth: createMockOauth(),
+    logger: createMockLogger(),
+    ...overrides,
+  }
+
+  const controller = new EncryptedPayloadController(
+    deps.encryptedPayloadManager as any,
+    deps.oauth as any,
+    deps.logger as any,
+  )
+
+  return { controller, ...deps }
+}
+
+describe('EncryptedPayloadController', () => {
+  describe('router registration', () => {
+    it('registers the batch fetch route', () => {
+      const { controller } = createController()
+      const routes = controller.router.stack
+        .filter((layer) => layer.route)
+        .map((layer) => ({
+          path: layer.route.path,
+          methods: Object.keys(layer.route.methods),
+        }))
+
+      expect(routes).toEqual(
+        expect.arrayContaining([expect.objectContaining({ path: '/encrypted-payload/get', methods: ['post'] })]),
+      )
+    })
+  })
+
+  describe('getPayloads', () => {
+    it('requires authentication', async () => {
+      const { controller } = createController()
+      const req = createMockRequest(undefined, { ids: [10] })
+      const res = createMockResponse()
+
+      await controller['getPayloads'](req, res)
+
+      expect(res.authRequired).toHaveBeenCalled()
+      expect(res.success).not.toHaveBeenCalled()
+    })
+
+    it('deduplicates ids and returns payloads for the current user', async () => {
+      const { controller, encryptedPayloadManager } = createController()
+      const req = createMockRequest(42, { ids: [10, 11, 10] })
+      const res = createMockResponse()
+
+      await controller['getPayloads'](req, res)
+
+      expect(encryptedPayloadManager.getEncryptedPayloadsByIds).toHaveBeenCalledWith([10, 11], 42)
+      expect(res.success).toHaveBeenCalledWith({
+        payloads: [
+          {
+            id: 10,
+            v: 1,
+            parserProfile: 'lite-v1',
+            canDecrypt: true,
+            payload: {
+              ciphertext: 'ciphertext',
+              iv: 'payloadIv',
+              wrap: {
+                role: 'recipient',
+                publicKey: 'publicKey',
+                publicKeyAlg: 'x25519-scrypt-v1',
+                ephemeralPublicKey: 'ephemeralKey',
+                iv: 'wrapIv',
+                encryptedKey: 'encryptedKey',
+              },
+            },
+          },
+        ],
+      })
+    })
+
+    it('logs and returns 500 when the manager fails', async () => {
+      const encryptedPayloadManager = createMockEncryptedPayloadManager()
+      encryptedPayloadManager.getEncryptedPayloadsByIds.mockRejectedValue(new Error('db failed'))
+
+      const { controller, logger } = createController({ encryptedPayloadManager })
+      const req = createMockRequest(42, { ids: [10] })
+      const res = createMockResponse()
+
+      await controller['getPayloads'](req, res)
+
+      expect(logger.error).toHaveBeenCalledWith('Get encrypted payloads error', {
+        error: expect.any(Error),
+        payloadIds: [10],
+        userId: 42,
+      })
+      expect(res.error).toHaveBeenCalledWith('error', 'Unknown error', 500)
+    })
+  })
+})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -53,6 +53,7 @@
         "react-zoom-pan-pinch": "^3.1.0",
         "scrypt-js": "^3.0.1",
         "textarea-caret": "^3.1.0",
+        "tweetnacl": "^1.0.3",
         "typescript": "^4.6.3",
         "use-debounce": "^8.0.4",
         "use-local-storage": "^3.0.0",
@@ -5074,6 +5075,13 @@
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/bfj": {
       "version": "7.0.2",
@@ -16657,6 +16665,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sshpk/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/ssri": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -17950,11 +17965,9 @@
       }
     },
     "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true,
-      "peer": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -23012,6 +23025,15 @@
       "peer": true,
       "requires": {
         "tweetnacl": "^0.14.3"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+          "optional": true,
+          "peer": true
+        }
       }
     },
     "bfj": {
@@ -31363,6 +31385,15 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+          "optional": true,
+          "peer": true
+        }
       }
     },
     "ssri": {
@@ -32350,11 +32381,9 @@
       }
     },
     "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true,
-      "peer": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,7 @@
     "react-zoom-pan-pinch": "^3.1.0",
     "scrypt-js": "^3.0.1",
     "textarea-caret": "^3.1.0",
+    "tweetnacl": "^1.0.3",
     "typescript": "^4.6.3",
     "use-debounce": "^8.0.4",
     "use-local-storage": "^3.0.0",

--- a/frontend/src/API/APIHelper.ts
+++ b/frontend/src/API/APIHelper.ts
@@ -2,6 +2,8 @@ import { AppLoadingState, AppState } from '../AppState/AppState'
 import APIBase, { APIError } from './APIBase'
 import AuthAPI from './AuthAPI'
 import AuthAPIHelper from './AuthAPIHelper'
+import EncryptedPayloadAPI from './EncryptedPayloadAPI'
+import EncryptedPayloadAPIHelper from './EncryptedPayloadAPIHelper'
 import FeedAPI from './FeedAPI'
 import FeedAPIHelper from './FeedAPIHelper'
 import InviteAPI from './InviteAPI'
@@ -22,6 +24,8 @@ import VoteAPI from './VoteAPI'
 export default class APIHelper {
   auth: AuthAPIHelper
   authAPI: AuthAPI
+  encryptedPayloadAPI: EncryptedPayloadAPI
+  encryptedPayload: EncryptedPayloadAPIHelper
   inviteAPI: InviteAPI
   postAPI: PostAPI
   post: PostAPIHelper
@@ -47,6 +51,7 @@ export default class APIHelper {
     this.baseAPI = api
     this.appState = appState
     this.authAPI = new AuthAPI(api)
+    this.encryptedPayloadAPI = new EncryptedPayloadAPI(api)
     this.inviteAPI = new InviteAPI(api)
     this.postAPI = new PostAPI(api)
     this.voteAPI = new VoteAPI(api)
@@ -55,6 +60,7 @@ export default class APIHelper {
     this.post = new PostAPIHelper(this.postAPI, appState)
     this.userAPI = new UserAPI(api, this.post)
     this.auth = new AuthAPIHelper(this.authAPI, appState)
+    this.encryptedPayload = new EncryptedPayloadAPIHelper(this.encryptedPayloadAPI)
     this.user = new UserAPIHelper(this.userAPI, appState)
     this.site = new SiteAPIHelper(this.siteAPI, appState)
     this.notifications = new NotificationsAPIHelper(this.notificationsAPI, appState)

--- a/frontend/src/API/EncryptedPayloadAPI.ts
+++ b/frontend/src/API/EncryptedPayloadAPI.ts
@@ -1,0 +1,23 @@
+import { EncryptedPayloadEntity } from '@utils/mailCrypto'
+
+import APIBase from './APIBase'
+
+type EncryptedPayloadBatchRequest = {
+  ids: number[]
+}
+
+type EncryptedPayloadBatchResponse = {
+  payloads: EncryptedPayloadEntity[]
+}
+
+export default class EncryptedPayloadAPI {
+  api: APIBase
+
+  constructor(api: APIBase) {
+    this.api = api
+  }
+
+  getPayloadsBatch(data: EncryptedPayloadBatchRequest) {
+    return this.api.request<EncryptedPayloadBatchRequest, EncryptedPayloadBatchResponse>('/encrypted-payload/get', data)
+  }
+}

--- a/frontend/src/API/EncryptedPayloadAPIHelper.ts
+++ b/frontend/src/API/EncryptedPayloadAPIHelper.ts
@@ -1,0 +1,34 @@
+import { BatchedCache } from '@utils/BatchedCache'
+import { EncryptedPayloadEntity } from '@utils/mailCrypto'
+
+import EncryptedPayloadAPI from './EncryptedPayloadAPI'
+
+export default class EncryptedPayloadAPIHelper {
+  private api: EncryptedPayloadAPI
+  private batchedCache: BatchedCache<number, EncryptedPayloadEntity>
+
+  constructor(api: EncryptedPayloadAPI) {
+    this.api = api
+    this.batchedCache = new BatchedCache({
+      debounceTime: 200,
+      batchSize: 128,
+      cacheTTL: 5 * 60 * 1000,
+      fetchFunction: async (ids) => {
+        const response = await this.api.getPayloadsBatch({ ids })
+        const result = new Map<number, EncryptedPayloadEntity>()
+        for (const payload of response.payloads) {
+          result.set(payload.id, payload)
+        }
+        return result
+      },
+    })
+  }
+
+  getEncryptedPayloadCached(encryptedPayloadId: number) {
+    return this.batchedCache.get(encryptedPayloadId)
+  }
+
+  invalidateEncryptedPayload(encryptedPayloadId: number) {
+    this.batchedCache.delete(encryptedPayloadId)
+  }
+}

--- a/frontend/src/API/PostAPI.ts
+++ b/frontend/src/API/PostAPI.ts
@@ -1,6 +1,7 @@
 import { FeedSorting } from '../Types/FeedSortingSettings'
 import { SiteInfo, SiteWithUserInfo } from '../Types/SiteInfo'
 import { UserInfo } from '../Types/UserInfo'
+import { EncryptedPayloadDraft } from '../Utils/mailCrypto'
 import APIBase from './APIBase'
 
 export type ContentFormat = 'html' | 'source'
@@ -17,6 +18,7 @@ export type PostEntity = {
   created: string
   title?: string
   content: string
+  encryptedPayloadId?: number
   rating: number
   comments: number
   newComments: number
@@ -31,6 +33,7 @@ export type CommentEntity = {
   author: number
   deleted?: boolean
   content: string
+  encryptedPayloadId?: number
   rating: number
   vote?: number
   isNew?: boolean
@@ -47,6 +50,7 @@ type PostCreateRequest = {
   site: string
   title?: string
   content: string
+  encryptedPayload?: EncryptedPayloadDraft
   format?: ContentFormat
 }
 type PostCreateResponse = {
@@ -117,6 +121,7 @@ type CommentCreateRequest = {
   comment_id?: number
   post_id: number
   content: string
+  encryptedPayload?: EncryptedPayloadDraft
   format?: ContentFormat
 }
 type CommentCreateResponse = {
@@ -127,6 +132,7 @@ type CommentCreateResponse = {
 type CommentEditRequest = {
   id: number
   content: string
+  encryptedPayload?: EncryptedPayloadDraft
   format?: ContentFormat
 }
 type CommentEditResponse = {
@@ -138,6 +144,7 @@ type PostEditRequest = {
   id: number
   title: string
   content: string
+  encryptedPayload?: EncryptedPayloadDraft
   format?: ContentFormat
 }
 type PostEditResponse = {
@@ -228,11 +235,17 @@ export default class PostAPI {
     this.api = api
   }
 
-  create(site: string, title: string | undefined, content: string): Promise<PostCreateResponse> {
+  create(
+    site: string,
+    title: string | undefined,
+    content: string,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ): Promise<PostCreateResponse> {
     return this.api.request<PostCreateRequest, PostCreateResponse>('/post/create', {
       site,
       title,
       content,
+      encryptedPayload,
     })
   }
 
@@ -278,11 +291,17 @@ export default class PostAPI {
     })
   }
 
-  comment(content: string, postId: number, commentId?: number): Promise<CommentCreateResponse> {
+  comment(
+    content: string,
+    postId: number,
+    commentId?: number,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ): Promise<CommentCreateResponse> {
     return this.api.request<CommentCreateRequest, CommentCreateResponse>('/post/comment', {
       post_id: postId,
       comment_id: commentId,
       content,
+      encryptedPayload,
     })
   }
 
@@ -293,18 +312,29 @@ export default class PostAPI {
     })
   }
 
-  editComment(content: string, commentId: number): Promise<CommentEditResponse> {
+  editComment(
+    content: string,
+    commentId: number,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ): Promise<CommentEditResponse> {
     return this.api.request<CommentEditRequest, CommentEditResponse>('/post/edit-comment', {
       id: commentId,
       content,
+      encryptedPayload,
     })
   }
 
-  editPost(postId: number, title: string, content: string): Promise<PostEditResponse> {
+  editPost(
+    postId: number,
+    title: string,
+    content: string,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ): Promise<PostEditResponse> {
     return this.api.request<PostEditRequest, PostEditResponse>('/post/edit', {
       id: postId,
       title,
       content,
+      encryptedPayload,
     })
   }
 

--- a/frontend/src/API/PostAPI.ts
+++ b/frontend/src/API/PostAPI.ts
@@ -203,6 +203,7 @@ type GetPostPublicKeyRequest = {
 
 export type GetPostPublicKeyResponse = {
   publicKey?: string
+  publicKeyAlg?: string
 }
 
 export type TranslateModes = 'altTranslate' | 'annotate' | 'translate'

--- a/frontend/src/API/PostAPIHelper.ts
+++ b/frontend/src/API/PostAPIHelper.ts
@@ -4,6 +4,7 @@ import { HistoryInfo } from '../Types/HistoryInfo'
 import { CommentInfo, PostInfo } from '../Types/PostInfo'
 import { SiteInfo } from '../Types/SiteInfo'
 import { UserInfo } from '../Types/UserInfo'
+import { EncryptedPayloadDraft } from '../Utils/mailCrypto'
 import PostAPI, { CommentEntity, PostEntity } from './PostAPI'
 
 type FeedPostsResult = {
@@ -170,8 +171,13 @@ export default class PostAPIHelper {
     )
   }
 
-  async comment(content: string, postId: number, commentId?: number): Promise<PostCommentResult> {
-    const response = await this.postAPI.comment(content, postId, commentId)
+  async comment(
+    content: string,
+    postId: number,
+    commentId?: number,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ): Promise<PostCommentResult> {
+    const response = await this.postAPI.comment(content, postId, commentId, encryptedPayload)
 
     const [comment] = this.fixComments([response.comment], response.users)
 
@@ -180,8 +186,12 @@ export default class PostAPIHelper {
     }
   }
 
-  async editComment(content: string, commentId: number): Promise<PostCommentEditResult> {
-    const response = await this.postAPI.editComment(content, commentId)
+  async editComment(
+    content: string,
+    commentId: number,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ): Promise<PostCommentEditResult> {
+    const response = await this.postAPI.editComment(content, commentId, encryptedPayload)
 
     const [comment] = this.fixComments([response.comment], response.users)
 
@@ -190,8 +200,13 @@ export default class PostAPIHelper {
     }
   }
 
-  async editPost(postId: number, title: string, content: string): Promise<PostEditResult> {
-    const response = await this.postAPI.editPost(postId, title, content)
+  async editPost(
+    postId: number,
+    title: string,
+    content: string,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ): Promise<PostEditResult> {
+    const response = await this.postAPI.editPost(postId, title, content, encryptedPayload)
 
     const [post] = this.fixPosts([response.post], response.users)
 

--- a/frontend/src/API/UserAPI.ts
+++ b/frontend/src/API/UserAPI.ts
@@ -27,6 +27,7 @@ type UserProfileResponse = {
   numberOfInvitesAvailable?: number
   isBarmalini?: boolean
   publicKey: string
+  publicKeyAlg: string
   hasOwnApps: boolean
   visitedDaysAgo: number
 }
@@ -179,8 +180,11 @@ export default class UserAPI {
     return this.api.request<{ gender: UserGender }, { gender: UserGender }>('/user/savegender', { gender })
   }
 
-  async savePublicKey(publicKey: string): Promise<{ publicKey: string }> {
-    return this.api.request<{ publicKey: string }, { publicKey: string }>('/user/save-public-key', { publicKey })
+  async savePublicKey(publicKey: string, publicKeyAlg: string): Promise<{ publicKey: string; publicKeyAlg: string }> {
+    return this.api.request<{ publicKey: string; publicKeyAlg: string }, { publicKey: string; publicKeyAlg: string }>(
+      '/user/save-public-key',
+      { publicKey, publicKeyAlg },
+    )
   }
 
   async getBarmaliniAccess(): Promise<BarmaliniAccessResult> {

--- a/frontend/src/API/UserAPIHelper.ts
+++ b/frontend/src/API/UserAPIHelper.ts
@@ -15,6 +15,7 @@ export type UserProfileResult = {
   numberOfInvitesAvailable?: number
   isBarmalini?: boolean
   publicKey: string
+  publicKeyAlg: string
   visitedDaysAgo: number
   hasOwnApps: boolean
 }

--- a/frontend/src/API/use/usePost.ts
+++ b/frontend/src/API/use/usePost.ts
@@ -4,6 +4,7 @@ import { useAppState } from '../../AppState/AppState'
 import { CommentInfo, PostInfo } from '../../Types/PostInfo'
 import { SiteInfo } from '../../Types/SiteInfo'
 import { UserInfo } from '../../Types/UserInfo'
+import { EncryptedPayloadDraft } from '../../Utils/mailCrypto'
 import { useCache } from './useCache'
 
 type UsePost = {
@@ -13,9 +14,13 @@ type UsePost = {
   error?: string
   anonymousUser?: UserInfo
 
-  postComment(comment: string, answerToCommentId?: number): Promise<CommentInfo>
-  editComment(comment: string, commentId: number): Promise<CommentInfo>
-  editPost(title: string, content: string): Promise<PostInfo>
+  postComment(
+    comment: string,
+    answerToCommentId?: number,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ): Promise<CommentInfo>
+  editComment(comment: string, commentId: number, encryptedPayload?: EncryptedPayloadDraft): Promise<CommentInfo>
+  editPost(title: string, content: string, encryptedPayload?: EncryptedPayloadDraft): Promise<PostInfo>
   setVote(value: number): void
   setCommentVote(commentId: number, vote: number): void
   reload(showUnreadOnly?: boolean): void
@@ -58,8 +63,8 @@ export function usePost(siteName: string, postId: number, showUnreadOnly?: boole
   }, [post])
 
   const { postComment, editComment, editPost, setVote, setCommentVote, reload } = useMemo(() => {
-    const postComment = async (text: string, answerToCommentId?: number) => {
-      const { comment } = await api.post.comment(text, postId, answerToCommentId)
+    const postComment = async (text: string, answerToCommentId?: number, encryptedPayload?: EncryptedPayloadDraft) => {
+      const { comment } = await api.post.comment(text, postId, answerToCommentId, encryptedPayload)
 
       if (rawComments) {
         const totalComments = countComments(rawComments) + 1
@@ -107,8 +112,8 @@ export function usePost(siteName: string, postId: number, showUnreadOnly?: boole
       return comment
     }
 
-    const editComment = async (text: string, commentId: number) => {
-      const { comment } = await api.post.editComment(text, commentId)
+    const editComment = async (text: string, commentId: number, encryptedPayload?: EncryptedPayloadDraft) => {
+      const { comment } = await api.post.editComment(text, commentId, encryptedPayload)
 
       if (!comments) {
         // no comments loaded!
@@ -134,8 +139,8 @@ export function usePost(siteName: string, postId: number, showUnreadOnly?: boole
       return comment
     }
 
-    const editPost = async (title: string, text: string) => {
-      const { post } = await api.post.editPost(postId, title, text)
+    const editPost = async (title: string, text: string, encryptedPayload?: EncryptedPayloadDraft) => {
+      const { post } = await api.post.editPost(postId, title, text, encryptedPayload)
       setPost(post)
       return post
     }

--- a/frontend/src/AppState/AppState.tsx
+++ b/frontend/src/AppState/AppState.tsx
@@ -6,6 +6,7 @@ import { createContext, ReactElement, ReactNode, useContext, useEffect, useMemo 
 import APIBase from '../API/APIBase';
 import APICache from '../API/APICache';
 import APIHelper from '../API/APIHelper';
+import { CryptoSessionStore } from './CryptoSessionStore';
 import ConfirmDialog, { ConfirmDialogProps } from '../Components/ConfirmDialog';
 import MediaUploader, { MediaUploaderProps } from '../Components/MediaUploader';
 import { themes } from '../theme';
@@ -97,6 +98,7 @@ export class AppState {
 
     readonly api: APIHelper;
     readonly cache: APICache;
+    readonly cryptoSession: CryptoSessionStore;
 
     constructor() {
         makeObservable(this);
@@ -107,6 +109,7 @@ export class AppState {
 
         const apiBase = new APIBase();
         this.cache = makeAutoObservable(new APICache());
+        this.cryptoSession = new CryptoSessionStore();
         this.api = new APIHelper(apiBase, this);
         this.api.init().then().catch();
 
@@ -155,11 +158,13 @@ export class AppState {
 
     @action
     setUserInfo(value: UserInfo | undefined) {
+        this.cryptoSession.syncCurrentUser(value?.id);
         this.userInfo = value;
     }
 
     clearCachesOnLogout() {
         this.api.oauth2Api.clearClientCache()
+        this.cryptoSession.clear()
     }
 
     @action

--- a/frontend/src/AppState/CryptoSessionStore.ts
+++ b/frontend/src/AppState/CryptoSessionStore.ts
@@ -68,6 +68,14 @@ export class CryptoSessionStore {
 
       return keyPair
     } catch (error) {
+      if (this.mailboxUserId === userId && this.hasMailboxKey(publicKey, publicKeyAlg) && this.mailboxKeyPair) {
+        runInAction(() => {
+          this.mailboxUnlocking = false
+          this.mailboxError = undefined
+        })
+        return this.mailboxKeyPair
+      }
+
       runInAction(() => {
         this.mailboxUnlocking = false
         this.mailboxError = error instanceof Error ? error.message : 'Не удалось разблокировать почтовый ящик.'

--- a/frontend/src/AppState/CryptoSessionStore.ts
+++ b/frontend/src/AppState/CryptoSessionStore.ts
@@ -1,0 +1,78 @@
+import { makeAutoObservable, runInAction } from 'mobx'
+
+import { deriveMailboxKeyPair, mailboxKeyMatches, MailboxKeyPair } from '../Utils/mailCrypto'
+
+export class CryptoSessionStore {
+  mailboxKeyPair: MailboxKeyPair | undefined = undefined
+  mailboxUserId: number | undefined = undefined
+  mailboxUnlocking = false
+  mailboxError: string | undefined = undefined
+
+  constructor() {
+    makeAutoObservable(this, {}, { autoBind: true })
+  }
+
+  get isMailboxUnlocked() {
+    return !!this.mailboxKeyPair
+  }
+
+  hasMailboxKey(publicKey: string, publicKeyAlg: string) {
+    return !!this.mailboxKeyPair && mailboxKeyMatches(this.mailboxKeyPair, publicKey, publicKeyAlg)
+  }
+
+  cacheMailboxKeyPair(userId: number, keyPair: MailboxKeyPair) {
+    this.mailboxUserId = userId
+    this.mailboxKeyPair = keyPair
+    this.mailboxError = undefined
+  }
+
+  clear() {
+    this.mailboxUserId = undefined
+    this.mailboxKeyPair = undefined
+    this.mailboxUnlocking = false
+    this.mailboxError = undefined
+  }
+
+  syncCurrentUser(userId?: number) {
+    if (!userId) {
+      this.clear()
+      return
+    }
+
+    if (this.mailboxUserId && this.mailboxUserId !== userId) {
+      this.clear()
+    }
+  }
+
+  async unlockMailbox(userId: number, password: string, publicKey: string, publicKeyAlg: string) {
+    if (this.mailboxUserId === userId && this.hasMailboxKey(publicKey, publicKeyAlg)) {
+      if (this.mailboxKeyPair) {
+        return this.mailboxKeyPair
+      }
+    }
+
+    this.mailboxUnlocking = true
+    this.mailboxError = undefined
+
+    try {
+      const keyPair = await deriveMailboxKeyPair(password)
+
+      if (!mailboxKeyMatches(keyPair, publicKey, publicKeyAlg)) {
+        throw new Error('Пароль не подходит.')
+      }
+
+      runInAction(() => {
+        this.cacheMailboxKeyPair(userId, keyPair)
+        this.mailboxUnlocking = false
+      })
+
+      return keyPair
+    } catch (error) {
+      runInAction(() => {
+        this.mailboxUnlocking = false
+        this.mailboxError = error instanceof Error ? error.message : 'Не удалось разблокировать почтовый ящик.'
+      })
+      throw error
+    }
+  }
+}

--- a/frontend/src/Components/CommentComponent.module.scss
+++ b/frontend/src/Components/CommentComponent.module.scss
@@ -48,6 +48,24 @@
   }
 }
 
+.encryptedContent {
+  position: relative;
+  padding: 12px 14px;
+  border-radius: 4px;
+  background: var(--dim1);
+  border: 1px solid var(--dim2);
+
+  &::after {
+    content: '🔒';
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    opacity: 0.2;
+    font-size: 20px;
+    pointer-events: none;
+  }
+}
+
 :global(.internalLinkExpand) .comment {
   margin-bottom: 12px;
 }

--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -3,6 +3,7 @@ import React, { useMemo, useState } from 'react'
 import { TranslateType } from '@api/PostAPI'
 import { useInterpreter } from '@api/use/useInterpreter'
 import { useAPI } from '@state/AppState'
+import classNames from 'classnames'
 import OutsideClickHandler from 'react-outside-click-handler'
 import { toast } from 'react-toastify'
 
@@ -167,7 +168,7 @@ export default function CommentComponent(props: CommentProps) {
             <div className={styles.content}>
               {props.comment.encryptedPayloadId ? (
                 <EncryptedContentComponent
-                  className={styles.commentContent}
+                  className={classNames(styles.commentContent, styles.encryptedContent)}
                   encryptedPayloadId={props.comment.encryptedPayloadId}
                   kind='comment'
                   lowRating={props.comment.rating <= Conf.COMMENT_LOW_RATING_THRESHOLD || props.comment.vote === -1}

--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -2,13 +2,14 @@ import React, { useMemo, useState } from 'react'
 
 import { TranslateType } from '@api/PostAPI'
 import { useInterpreter } from '@api/use/useInterpreter'
-import { useAPI } from '@state/AppState'
+import { useAPI, useAppState } from '@state/AppState'
 import classNames from 'classnames'
 import OutsideClickHandler from 'react-outside-click-handler'
 import { toast } from 'react-toastify'
 
 import Conf from '../Conf'
 import { CommentInfo, PostLinkInfo } from '../Types/PostInfo'
+import { getEncryptedPayloadSource } from '../Utils/encryptedPayloadSource'
 import { EncryptedPayloadDraft } from '../Utils/mailCrypto'
 import { AltTranslateButton, AnnotateButton, TranslateButton } from './ContentButtons'
 import ContentComponent, { LARGE_AUTO_CUT } from './ContentComponent'
@@ -44,6 +45,8 @@ interface CommentProps {
   unreadOnly?: boolean
   hideRating?: boolean
   currentUsername?: string
+  parentAuthorUserName?: string
+  parentAuthorUserId?: number
 }
 
 export default function CommentComponent(props: CommentProps) {
@@ -53,6 +56,7 @@ export default function CommentComponent(props: CommentProps) {
   const [showOptions, setShowOptions] = useState(false)
 
   const api = useAPI()
+  const appState = useAppState()
   const {
     currentMode,
     inProgress,
@@ -115,6 +119,19 @@ export default function CommentComponent(props: CommentProps) {
   const handleEdit = async () => {
     try {
       const comment = await api.postAPI.getComment(props.comment.id, 'source')
+
+      if (comment.comment.encryptedPayloadId) {
+        const payload = await api.encryptedPayload.getEncryptedPayloadCached(comment.comment.encryptedPayloadId)
+        const source = await getEncryptedPayloadSource(appState, payload)
+
+        if (source === undefined) {
+          return
+        }
+
+        setEditingText(source)
+        return
+      }
+
       setEditingText(comment.comment.content)
     } catch (e) {
       console.log('Get comment error:', e)
@@ -160,7 +177,7 @@ export default function CommentComponent(props: CommentProps) {
         {editingText === false ? (
           showHistory ? (
             <HistoryComponent
-              initial={{ content, date: created }}
+              initial={{ content, date: created, encryptedPayloadId: props.comment.encryptedPayloadId }}
               history={{ id: props.comment.id, type: 'comment' }}
               onClose={toggleHistory}
             />
@@ -198,8 +215,11 @@ export default function CommentComponent(props: CommentProps) {
           <CreateCommentComponentRestricted
             post={props.comment.postLink}
             comment={props.comment}
+            parentAuthorUserName={props.parent?.author.username || props.parentAuthorUserName}
+            parentAuthorUserId={props.parent?.author.id || props.parentAuthorUserId}
             open={true}
             text={editingText}
+            initialEncrypted={!!props.comment.encryptedPayloadId}
             onAnswer={handleEditComplete}
           />
         )}
@@ -300,6 +320,8 @@ export default function CommentComponent(props: CommentProps) {
               open={answerOpen}
               post={props.comment.postLink}
               comment={props.comment}
+              parentAuthorUserName={props.parent?.author.username || props.parentAuthorUserName}
+              parentAuthorUserId={props.parent?.author.id || props.parentAuthorUserId}
               onAnswer={handleAnswer}
               storageKey={`cp:${props.comment.id}`}
             />
@@ -317,6 +339,8 @@ export default function CommentComponent(props: CommentProps) {
                 unreadOnly={props.unreadOnly}
                 idx={idx}
                 currentUsername={props.currentUsername}
+                parentAuthorUserName={props.comment.author.username}
+                parentAuthorUserId={props.comment.author.id}
               />
             ))
           ) : (

--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -8,9 +8,11 @@ import { toast } from 'react-toastify'
 
 import Conf from '../Conf'
 import { CommentInfo, PostLinkInfo } from '../Types/PostInfo'
+import { EncryptedPayloadDraft } from '../Utils/mailCrypto'
 import { AltTranslateButton, AnnotateButton, TranslateButton } from './ContentButtons'
 import ContentComponent, { LARGE_AUTO_CUT } from './ContentComponent'
 import { CreateCommentComponentRestricted } from './CreateCommentComponent'
+import EncryptedContentComponent from './EncryptedContentComponent'
 import { HistoryComponent } from './HistoryComponent'
 import RatingSwitch from './RatingSwitch'
 import { SignatureComponent } from './SignatureComponent'
@@ -24,8 +26,17 @@ interface CommentProps {
   comment: CommentInfo
   showSite?: boolean
   parent?: CommentInfo
-  onAnswer?: (text: string, post?: PostLinkInfo, comment?: CommentInfo) => Promise<CommentInfo | undefined>
-  onEdit?: (text: string, comment: CommentInfo) => Promise<CommentInfo | undefined>
+  onAnswer?: (
+    text: string,
+    post?: PostLinkInfo,
+    comment?: CommentInfo,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ) => Promise<CommentInfo | undefined>
+  onEdit?: (
+    text: string,
+    comment: CommentInfo,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ) => Promise<CommentInfo | undefined>
   depth?: number
   maxTreeDepth?: number
   idx?: number
@@ -62,23 +73,33 @@ export default function CommentComponent(props: CommentProps) {
     setShowOptions(!showOptions)
   }
 
-  const handleAnswer = async (text: string, post?: PostLinkInfo, comment?: CommentInfo) => {
+  const handleAnswer = async (
+    text: string,
+    post?: PostLinkInfo,
+    comment?: CommentInfo,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ) => {
     if (!post) {
       return undefined
     }
-    const res = await props.onAnswer?.(text, post, comment)
+    const res = await props.onAnswer?.(text, post, comment, encryptedPayload)
     setAnswerOpen(false)
     return res
   }
 
-  const handleEditComplete = async (text: string) => {
+  const handleEditComplete = async (
+    text: string,
+    _post?: PostLinkInfo,
+    _comment?: CommentInfo,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ) => {
     try {
-      const res = await props.onEdit?.(text, props.comment)
+      const res = await props.onEdit?.(text, props.comment, encryptedPayload)
       setEditingText(false)
       return res
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.log('Could not edit comment', err)
-      toast.error(err.message || 'Не удалось отредактировать комментарий')
+      toast.error(err instanceof Error ? err.message : 'Не удалось отредактировать комментарий')
       throw err
     }
   }
@@ -106,6 +127,7 @@ export default function CommentComponent(props: CommentProps) {
 
   const { author, created, site, postLink, editFlag } = props.comment
   const content = altContent || props.comment.content
+  const isEncrypted = !!props.comment.encryptedPayloadId
 
   const depth = props.depth || 0
   const maxDepth = props.maxTreeDepth || 0
@@ -143,18 +165,32 @@ export default function CommentComponent(props: CommentProps) {
             />
           ) : (
             <div className={styles.content}>
-              <ContentComponent
-                className={styles.commentContent}
-                content={content}
-                currentUsername={props.currentUsername}
-                lowRating={props.comment.rating <= Conf.COMMENT_LOW_RATING_THRESHOLD || props.comment.vote === -1}
-                autoCut={
-                  !altContent &&
-                  (props.comment.rating <= Conf.COMMENT_LOW_RATING_THRESHOLD || props.comment.vote === -1)
-                    ? LARGE_AUTO_CUT
-                    : undefined
-                }
-              />
+              {props.comment.encryptedPayloadId ? (
+                <EncryptedContentComponent
+                  className={styles.commentContent}
+                  encryptedPayloadId={props.comment.encryptedPayloadId}
+                  kind='comment'
+                  lowRating={props.comment.rating <= Conf.COMMENT_LOW_RATING_THRESHOLD || props.comment.vote === -1}
+                  autoCut={
+                    props.comment.rating <= Conf.COMMENT_LOW_RATING_THRESHOLD || props.comment.vote === -1
+                      ? LARGE_AUTO_CUT
+                      : undefined
+                  }
+                />
+              ) : (
+                <ContentComponent
+                  className={styles.commentContent}
+                  content={content}
+                  currentUsername={props.currentUsername}
+                  lowRating={props.comment.rating <= Conf.COMMENT_LOW_RATING_THRESHOLD || props.comment.vote === -1}
+                  autoCut={
+                    !altContent &&
+                    (props.comment.rating <= Conf.COMMENT_LOW_RATING_THRESHOLD || props.comment.vote === -1)
+                      ? LARGE_AUTO_CUT
+                      : undefined
+                  }
+                />
+              )}
             </div>
           )
         ) : (
@@ -187,7 +223,7 @@ export default function CommentComponent(props: CommentProps) {
           )}
 
           <div className={styles.control + ' ' + postStyles.options}>
-            {(showTranslateButtonInline || currentMode === 'translate') && (
+            {!isEncrypted && (showTranslateButtonInline || currentMode === 'translate') && (
               <div className={styles.control}>
                 <TranslateButton
                   iconOnly={true}
@@ -197,12 +233,12 @@ export default function CommentComponent(props: CommentProps) {
                 />
               </div>
             )}
-            {currentMode === 'altTranslate' && (
+            {!isEncrypted && currentMode === 'altTranslate' && (
               <div className={styles.control}>
                 <AltTranslateButton iconOnly={true} isActive={true} inProgress={inProgress} onClick={altTranslate} />
               </div>
             )}
-            {currentMode === 'annotate' && (
+            {!isEncrypted && currentMode === 'annotate' && (
               <div className={styles.control}>
                 <AnnotateButton iconOnly={true} isActive={true} inProgress={inProgress} onClick={annotate} />
               </div>

--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -11,11 +11,9 @@ import { AppState, useAppState, ZoomedImg } from '../AppState/AppState'
 import { FakeRoot } from '../index'
 import { observeOnHidden } from '../Services/ObserverService'
 import { useTheme } from '../Theme/ThemeProvider'
-import { b64DecodeUnicode } from '../Utils/utils'
 import GalleryComponent, { GalleryElement } from './GalleryComponent'
 import InternalLinkExpandComponent from './InternalLinkExpandComponent'
 import { OAuthEmbeddedAppComponent } from './OAuth2AppCardModalComponent'
-import { SecretMailDecoderForm, SecretMailEncoderForm } from './SecretMailbox'
 import TelegramEmbed from './TelegramEmbed'
 import TwitterEmbed from './TwitterEmbed'
 import { getAutoMuteVideos, getVideoAutopause, getVideoVolume, setVideoVolume } from './UserProfileSettings'
@@ -70,26 +68,11 @@ export const SMALL_AUTO_CUT = 100
 
 const iframeToOriginalEl = new WeakMap<HTMLIFrameElement, HTMLElement>()
 
-type MailboxKey = {
-  type: 'mailbox'
-  mailboxTitle?: string
-  openKey: string
-  forUsername?: string
-}
-
-type MailKey = {
-  type: 'mail'
-  secret: string
-  title: string
-}
-
 function updateContent(
   appState: AppState,
   div: HTMLDivElement,
-  setMailboxKey: (key: MailboxKey | MailKey | null) => void,
   setCut: (cut: boolean) => void,
   cleanupRegistry: CleanupRegistry,
-  currentUsername?: string,
 ): void {
   div.querySelectorAll('div.gallery').forEach((gallery) => {
     updateGallery(gallery as HTMLDivElement, appState, cleanupRegistry, setCut)
@@ -118,14 +101,6 @@ function updateContent(
     updateExpand(expand as HTMLDetailsElement, setCut)
   })
 
-  div.querySelectorAll('span.secret-mailbox').forEach((mailbox) => {
-    updateMailbox(mailbox as HTMLSpanElement, setMailboxKey)
-  })
-
-  div.querySelectorAll('span.secret-mail').forEach((mail) => {
-    updateMail(mail as HTMLSpanElement, setMailboxKey, currentUsername, appState, cleanupRegistry)
-  })
-
   div.querySelectorAll('span.expand-button').forEach((expandButton) => {
     updateInternalExpandButton(expandButton as HTMLElement, appState, cleanupRegistry)
   })
@@ -136,27 +111,6 @@ function updateContent(
 
   div.querySelectorAll('div.poll').forEach((pollEl) => {
     updatePoll(pollEl as HTMLDivElement, appState, cleanupRegistry)
-  })
-}
-
-function updateMailbox(mailbox: HTMLSpanElement, setMailboxKey: (key: MailboxKey | null) => void) {
-  const secret = mailbox.dataset.secret
-  if (!secret) {
-    return
-  }
-  let mailboxTitle = mailbox.dataset.rawText
-  try {
-    mailboxTitle = mailboxTitle && b64DecodeUnicode(mailboxTitle)
-  } catch (e) {
-    mailboxTitle = undefined
-  }
-
-  mailbox.addEventListener('click', () => {
-    setMailboxKey({
-      type: 'mailbox',
-      openKey: secret,
-      mailboxTitle,
-    })
   })
 }
 
@@ -189,102 +143,6 @@ function renderWithTheme(container: HTMLElement, content: React.ReactNode, appSt
       containerToRootMap.delete(container)
     })
   }
-}
-
-function updateMail(
-  mail: HTMLSpanElement,
-  setMailboxKey: (key: MailKey | null) => void,
-  currentUsername: string | undefined,
-  appState: AppState,
-  cleanupRegistry: CleanupRegistry,
-) {
-  // check processed
-  if (mail.dataset.processed) {
-    return
-  }
-  mail.dataset.processed = '1'
-
-  const secret = mail.dataset.secret
-  if (!secret) {
-    mail.classList.add('secret-mail-error')
-    return
-  }
-  let cipher: string | undefined
-  let encodedKey: string
-
-  // try decode secret as json
-  try {
-    const j = JSON.parse(b64DecodeUnicode(secret))
-    // add mention "для @username"
-    if (j.to && !mail.querySelector('span.mention')) {
-      const mention = document.createElement('span')
-      mention.classList.add('mention')
-      mention.innerText = j.to
-      mail.appendChild(document.createTextNode(' для '))
-      mail.appendChild(mention)
-    }
-
-    // check v, to, c
-    if (!j.v || !j.c || !Number.isInteger(j.v) || !j.toKey) {
-      throw new Error('Invalid secret')
-    } else if (j.to && j.to === currentUsername && j.toKey) {
-      encodedKey = j.toKey
-      cipher = j.c
-    } else if (j.from && j.from === currentUsername && j.fromKey) {
-      encodedKey = j.fromKey
-      cipher = j.c
-    } else if (!j.to) {
-      encodedKey = j.toKey
-      cipher = j.c
-    }
-
-    if (!cipher) {
-      mail.classList.add('secret-mail-disabled')
-      return
-    }
-  } catch (e) {
-    // add error class
-    mail.classList.add('secret-mail-error')
-    return
-  }
-
-  // just the text
-  const title = mail.innerText.trim()
-
-  const mailInnerHtml = mail.innerHTML
-  let decoded = false
-  let cleanup: CleanupHandler | undefined
-
-  mail.addEventListener('click', () => {
-    if (decoded || !cipher || !appState) {
-      return
-    }
-    mail.classList.remove('i', 'i-mail-secure')
-    mail.classList.add('secret-mail-decoding')
-
-    const mailContent = (
-      <SecretMailDecoderForm
-        cipher={cipher}
-        title={title}
-        encodedKey={encodedKey}
-        onClose={(result) => {
-          if (result) {
-            decoded = true
-            mail.classList.add('i-mail-open', 'secret-mail-decoded', 'i')
-            mail.classList.remove('secret-mail-decoding')
-          } else {
-            mail.classList.add('i', 'i-mail-secure')
-            mail.classList.remove('secret-mail-decoding')
-            cleanup?.cleanup()
-            cleanup = undefined
-            mail.innerHTML = mailInnerHtml
-          }
-        }}
-      />
-    )
-
-    cleanup = cleanupRegistry.register(renderWithTheme(mail, mailContent, appState))
-  })
 }
 
 function processExpandLink(
@@ -748,7 +606,6 @@ function updateGallery(
 export default function ContentComponent(props: ContentComponentProps) {
   const contentDiv = useRef<HTMLDivElement>(null)
   const [cut, setCut] = useState(false)
-  const [mailboxKey, setMailboxKey] = useState<MailboxKey | MailKey | null>(null)
   const cleanupRegistryRef = useRef<CleanupRegistry>(new CleanupRegistry())
   const appState = useAppState()
 
@@ -776,7 +633,7 @@ export default function ContentComponent(props: ContentComponentProps) {
     cleanupRegistry.cleanup()
 
     // Update content using the registry
-    updateContent(appState, content, setMailboxKey, setCut, cleanupRegistry, props.currentUsername)
+    updateContent(appState, content, setCut, cleanupRegistry)
 
     let resizeObserver: ResizeObserver | null = null
 
@@ -850,9 +707,6 @@ export default function ContentComponent(props: ContentComponentProps) {
             Читать дальше
           </Button>
         </div>
-      )}
-      {mailboxKey && mailboxKey.type === 'mailbox' && (
-        <SecretMailEncoderForm {...mailboxKey} onClose={() => setMailboxKey(null)} />
       )}
     </>
   )

--- a/frontend/src/Components/CreateCommentComponent.module.scss
+++ b/frontend/src/Components/CreateCommentComponent.module.scss
@@ -89,6 +89,7 @@ button.editorButton {
 
 .editor {
   display: flex;
+  position: relative;
 
   :global(.rta) {
     width: 100%;
@@ -126,6 +127,40 @@ button.editorButton {
   }
 }
 
+.editorEncrypted {
+  &::after {
+    content: '🔒';
+    position: absolute;
+    top: 14px;
+    right: 16px;
+    font-size: 20px;
+    opacity: 0.18;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  :global(textarea) {
+    padding-right: 48px;
+  }
+}
+
+.previewEncrypted {
+  position: relative;
+  background: var(--dim1);
+  border: 1px solid var(--dim2);
+  border-radius: 4px;
+
+  &::after {
+    content: '🔒';
+    position: absolute;
+    top: 14px;
+    right: 16px;
+    font-size: 20px;
+    opacity: 0.18;
+    pointer-events: none;
+  }
+}
+
 .final {
   margin: 4px 0;
   display: flex;
@@ -160,7 +195,23 @@ button.editorButton {
   }
 }
 
+.buttonEncrypt {
+  margin-right: auto;
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  padding: 0;
+  justify-content: center;
+
+  :global(.i):before {
+    font-size: 20px;
+  }
+}
+
 .commentButtonGroup {
+  width: 100%;
+  align-items: center;
+
   @media (max-width: 420px) {
     justify-content: flex-end;
     button {

--- a/frontend/src/Components/CreateCommentComponent.module.scss
+++ b/frontend/src/Components/CreateCommentComponent.module.scss
@@ -211,6 +211,7 @@ button.editorButton {
 .commentButtonGroup {
   width: 100%;
   align-items: center;
+  justify-content: flex-end;
 
   @media (max-width: 420px) {
     justify-content: flex-end;

--- a/frontend/src/Components/CreateCommentComponent.tsx
+++ b/frontend/src/Components/CreateCommentComponent.tsx
@@ -238,10 +238,14 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
       throw new Error('Не удалось определить адресата шифрования.')
     }
 
-    const [senderKey, recipientKey] = await Promise.all([
-      api.postAPI.getPublicKeyByUsername(currentUsername),
-      api.postAPI.getPublicKeyByUsername(encryptionTarget.username),
-    ])
+    const recipientKey = await api.postAPI.getPublicKeyByUsername(encryptionTarget.username)
+    const senderKey =
+      currentUser.publicKey && currentUser.publicKeyAlg
+        ? {
+            publicKey: currentUser.publicKey,
+            publicKeyAlg: currentUser.publicKeyAlg,
+          }
+        : await api.postAPI.getPublicKeyByUsername(currentUsername)
 
     if (!senderKey.publicKey || senderKey.publicKeyAlg !== MAILBOX_PUBLIC_KEY_ALG) {
       throw new Error('Сначала создайте собственный шифрованный почтовый ящик в настройках профиля.')
@@ -775,7 +779,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
         </SpilloverWrapper>
       </div>
       {previewing === null ? (
-        <div className={styles.editor} ref={containerRef}>
+        <div className={classNames(styles.editor, { [styles.editorEncrypted]: isEncrypted })} ref={containerRef}>
           <ReactTextareaAutocomplete<string>
             tabIndex={textareaTabIndex}
             placeholder={placeholderText}
@@ -799,7 +803,9 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
         </div>
       ) : (
         <div
-          className={classNames(commentStyles.content, styles.preview, postStyles.preview)}
+          className={classNames(commentStyles.content, styles.preview, postStyles.preview, {
+            [styles.previewEncrypted]: isEncrypted,
+          })}
           onClick={handleClosePreview}
         >
           <ContentComponent content={previewing} />
@@ -807,19 +813,22 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
       )}
       <div className={styles.final}>
         <ButtonGroup spacing={ButtonGroupSpacing.MEDIUM} className={styles.commentButtonGroup}>
-          <div className={styles.buttonThemeToggle}>
-            {previewing && <ThemeToggleComponent buttonLabel='Превью с другой темой' resetOnOnmount={true} />}
-          </div>
           {encryptionTarget && (
             <Button
-              variant='minimal'
+              variant={isEncrypted ? 'primaryAccent' : 'ghostAccent'}
+              size='normal'
               active={isEncrypted}
-              disabled={isPosting}
+              disabled={disabledButtons}
               onClick={() => toggleEncrypted().catch()}
+              className={styles.buttonEncrypt}
+              title='Шифровка'
             >
               <span className='i i-mail-secure' />
             </Button>
           )}
+          <div className={styles.buttonThemeToggle}>
+            {previewing && <ThemeToggleComponent buttonLabel='Превью темы' resetOnOnmount={true} />}
+          </div>
           <Button
             variant='minimal'
             disabled={isPosting || !answerText}

--- a/frontend/src/Components/CreateCommentComponent.tsx
+++ b/frontend/src/Components/CreateCommentComponent.tsx
@@ -44,6 +44,7 @@ interface CreateCommentProps {
   comment?: CommentInfo
   post?: PostLinkInfo
   text?: string
+  initialEncrypted?: boolean
   storageKey?: string
   parentAuthorUserName?: string
   parentAuthorUserId?: number
@@ -186,7 +187,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
 
   const api = useAPI()
   const appState = useAppState()
-  const [isEncrypted, setIsEncrypted] = useState(false)
+  const [isEncrypted, setIsEncrypted] = useState(!!props.initialEncrypted)
   const [encryptionKeys, setEncryptionKeys] = useState<
     | {
         sender: { userId: number; username: string; publicKey: string; publicKeyAlg: string }
@@ -217,6 +218,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
             username: props.parentAuthorUserName,
           }
         : undefined
+  const showEncryptionToggle = !!encryptionTarget || isEncrypted
 
   const setStorageValueDebounced = useDebouncedCallback((value) => {
     if (props.storageKey) {
@@ -395,11 +397,11 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
   }, [props.open, props.comment])
 
   useEffect(() => {
-    if (!encryptionTarget) {
+    if (!encryptionTarget && !props.initialEncrypted) {
       setIsEncrypted(false)
       setEncryptionKeys(undefined)
     }
-  }, [encryptionTarget?.userId])
+  }, [encryptionTarget?.userId, props.initialEncrypted])
 
   useEffect(() => {
     if (!answerRef.current || !containerRef.current) {
@@ -813,7 +815,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
       )}
       <div className={styles.final}>
         <ButtonGroup spacing={ButtonGroupSpacing.MEDIUM} className={styles.commentButtonGroup}>
-          {encryptionTarget && (
+          {showEncryptionToggle && (
             <Button
               variant={isEncrypted ? 'primaryAccent' : 'ghostAccent'}
               size='normal'

--- a/frontend/src/Components/CreateCommentComponent.tsx
+++ b/frontend/src/Components/CreateCommentComponent.tsx
@@ -19,7 +19,6 @@ import { UserGender } from '../Types/UserInfo'
 import ContentComponent from './ContentComponent'
 import MediaUploader, { CreateGalleryOption, MediaResult } from './MediaUploader'
 import { PollCreationWizard, PollCreationWizardSubmitData } from './PollCreationWizard'
-import { SecretMailEncoderForm } from './SecretMailbox'
 import SlowMode from './SlowMode'
 import ThemeToggleComponent from './ThemeToggleComponent'
 
@@ -173,15 +172,6 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
   })
   const controlsRef = useRef<HTMLDivElement>(null)
 
-  const [parentPublicKey, setParentPublicKey] = useState<
-    | {
-        publicKey: string
-        username: string
-      }
-    | undefined
-  >(undefined)
-  const [mailForm, setFormOpen] = useState(false)
-
   const api = useAPI()
 
   const pronoun =
@@ -191,27 +181,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
         ? 'ей'
         : ''
   const placeholderText = props.comment ? `Ваш ответ ${pronoun}` : ''
-  const disabledButtons = isPosting || previewing !== null || mailForm
-
-  const state = useAppState()
-  const username = state.userInfo?.username
-
-  // retrieve parent public key
-  useEffect(() => {
-    const parentUserName = props.parentAuthorUserName || props.comment?.author?.username
-
-    if (!parentUserName || parentUserName === username) {
-      return
-    }
-    api.postAPI.getPublicKeyByUsername(parentUserName).then((res) => {
-      if (res.publicKey) {
-        setParentPublicKey({
-          publicKey: res.publicKey,
-          username: parentUserName,
-        })
-      }
-    })
-  }, [props.parentAuthorUserName, props.comment])
+  const disabledButtons = isPosting || previewing !== null
 
   const setStorageValueDebounced = useDebouncedCallback((value) => {
     if (props.storageKey) {
@@ -503,13 +473,6 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
     }
   }
 
-  const handleMailClose = (result?: string) => {
-    setFormOpen(false)
-    if (result) {
-      replaceText(result, result.length)
-    }
-  }
-
   const handlePollCreate = async (pollData: PollCreationWizardSubmitData) => {
     try {
       const result = await api.pollAPI.createPoll({
@@ -695,10 +658,6 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
               <PollIcon />
             </Button>
           </div>
-          {/*{parentPublicKey &&*/}
-          {/*<div className={styles.control}>*/}
-          {/*    <Button variant='minimal' disabled={disabledButtons} onClick={() => setFormOpen(true)} title="Шифрованное послание"><MailIcon /></Button></div>*/}
-          {/*}*/}
         </SpilloverWrapper>
       </div>
       {previewing === null ? (
@@ -762,14 +721,6 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
             onCancel={handleMediaUploadCancel}
             mediaData={mediaUploaderData}
             initialGalleryCreate={mediaUploaderInGallery}
-          />
-        )}
-        {mailForm && parentPublicKey && (
-          <SecretMailEncoderForm
-            openKey={parentPublicKey.publicKey}
-            forUsername={parentPublicKey.username}
-            mailboxTitle={`Шифровка`}
-            onClose={handleMailClose}
           />
         )}
         {pollWizardOpen &&

--- a/frontend/src/Components/CreateCommentComponent.tsx
+++ b/frontend/src/Components/CreateCommentComponent.tsx
@@ -3,6 +3,7 @@ import React, { ReactNode, useEffect, useRef, useState } from 'react'
 import { useAPI, useAppState } from '@state/AppState'
 import Button from '@ui/Button'
 import ButtonGroup, { ButtonGroupSpacing } from '@ui/ButtonGroup'
+import { encryptContentForUsers, EncryptedPayloadDraft, MAILBOX_PUBLIC_KEY_ALG } from '@utils/mailCrypto'
 import ReactTextareaAutocomplete from '@webscopeio/react-textarea-autocomplete'
 import classNames from 'classnames'
 import debouncePromise from 'debounce-promise'
@@ -16,6 +17,7 @@ import { useDebouncedCallback } from 'use-debounce'
 
 import { CommentInfo, PostLinkInfo } from '../Types/PostInfo'
 import { UserGender } from '../Types/UserInfo'
+import { renderEncryptedContentHtml } from '../Utils/encryptedContentParser'
 import ContentComponent from './ContentComponent'
 import MediaUploader, { CreateGalleryOption, MediaResult } from './MediaUploader'
 import { PollCreationWizard, PollCreationWizardSubmitData } from './PollCreationWizard'
@@ -44,6 +46,7 @@ interface CreateCommentProps {
   text?: string
   storageKey?: string
   parentAuthorUserName?: string
+  parentAuthorUserId?: number
 
   /**
    * Optional tab index for the textarea. When provided, formatting buttons
@@ -51,7 +54,12 @@ interface CreateCommentProps {
    */
   textareaTabIndex?: number
 
-  onAnswer: (text: string, post?: PostLinkInfo, comment?: CommentInfo) => Promise<CommentInfo | string | undefined>
+  onAnswer: (
+    text: string,
+    post?: PostLinkInfo,
+    comment?: CommentInfo,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ) => Promise<CommentInfo | string | undefined>
 }
 
 // same as CreateCommentComponent, but with slow mode and other restrictions
@@ -91,8 +99,8 @@ export const CreateCommentComponentRestricted = observer((props: CreateCommentPr
   return (
     <CreateCommentComponent
       {...props}
-      onAnswer={(text, post, comment) => {
-        return props.onAnswer(text, post, comment).finally(() => {
+      onAnswer={(text, post, comment, encryptedPayload) => {
+        return props.onAnswer(text, post, comment, encryptedPayload).finally(() => {
           api.user.refreshUserRestrictions()
         })
       }}
@@ -160,7 +168,11 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
 
   const openMediaUploader = (file?: File) => {
     const answer = answerRef.current
-    const inGallery = answer ? getGalleryInsertPosition(answer.value, answer.selectionStart) !== null : false
+    const inGallery = isEncrypted
+      ? false
+      : answer
+        ? getGalleryInsertPosition(answer.value, answer.selectionStart) !== null
+        : false
     setMediaUploaderInGallery(inGallery)
     setMediaUploaderData(file)
     setMediaUploaderOpen(true)
@@ -173,6 +185,15 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
   const controlsRef = useRef<HTMLDivElement>(null)
 
   const api = useAPI()
+  const appState = useAppState()
+  const [isEncrypted, setIsEncrypted] = useState(false)
+  const [encryptionKeys, setEncryptionKeys] = useState<
+    | {
+        sender: { userId: number; username: string; publicKey: string; publicKeyAlg: string }
+        recipient: { userId: number; username: string; publicKey: string; publicKeyAlg: string }
+      }
+    | undefined
+  >(undefined)
 
   const pronoun =
     props?.comment?.author?.gender === UserGender.he
@@ -180,8 +201,22 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
       : props?.comment?.author?.gender === UserGender.she
         ? 'ей'
         : ''
-  const placeholderText = props.comment ? `Ваш ответ ${pronoun}` : ''
+  const placeholderText = `${props.comment ? `Ваш ответ ${pronoun}` : ''}${isEncrypted ? ' (будет зашифрован)' : ''}`
   const disabledButtons = isPosting || previewing !== null
+  const currentUser = appState.userInfo
+  const currentUsername = currentUser?.username
+  const encryptionTarget =
+    props.comment && props.comment.author.id !== currentUser?.id
+      ? {
+          userId: props.comment.author.id,
+          username: props.comment.author.username,
+        }
+      : props.parentAuthorUserId && props.parentAuthorUserName && props.parentAuthorUserId !== currentUser?.id
+        ? {
+            userId: props.parentAuthorUserId,
+            username: props.parentAuthorUserName,
+          }
+        : undefined
 
   const setStorageValueDebounced = useDebouncedCallback((value) => {
     if (props.storageKey) {
@@ -196,6 +231,58 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
   const handleAnswerChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setStorageValueDebounced(e.target.value)
     setAnswerText(e.target.value)
+  }
+
+  const resolveEncryptionKeys = async () => {
+    if (!currentUser || !currentUsername || !encryptionTarget) {
+      throw new Error('Не удалось определить адресата шифрования.')
+    }
+
+    const [senderKey, recipientKey] = await Promise.all([
+      api.postAPI.getPublicKeyByUsername(currentUsername),
+      api.postAPI.getPublicKeyByUsername(encryptionTarget.username),
+    ])
+
+    if (!senderKey.publicKey || senderKey.publicKeyAlg !== MAILBOX_PUBLIC_KEY_ALG) {
+      throw new Error('Сначала создайте собственный шифрованный почтовый ящик в настройках профиля.')
+    }
+
+    if (!recipientKey.publicKey || recipientKey.publicKeyAlg !== MAILBOX_PUBLIC_KEY_ALG) {
+      throw new Error(`У @${encryptionTarget.username} нет совместимого почтового ящика.`)
+    }
+
+    return {
+      sender: {
+        userId: currentUser.id,
+        username: currentUsername,
+        publicKey: senderKey.publicKey,
+        publicKeyAlg: senderKey.publicKeyAlg,
+      },
+      recipient: {
+        userId: encryptionTarget.userId,
+        username: encryptionTarget.username,
+        publicKey: recipientKey.publicKey,
+        publicKeyAlg: recipientKey.publicKeyAlg,
+      },
+    }
+  }
+
+  const toggleEncrypted = async () => {
+    if (isEncrypted) {
+      setIsEncrypted(false)
+      setEncryptionKeys(undefined)
+      return
+    }
+
+    try {
+      setPosting(true)
+      setEncryptionKeys(await resolveEncryptionKeys())
+      setIsEncrypted(true)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Не удалось включить шифрование.')
+    } finally {
+      setPosting(false)
+    }
   }
 
   const handleHotKey = (e: KeyboardEvent) => {
@@ -304,6 +391,13 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
   }, [props.open, props.comment])
 
   useEffect(() => {
+    if (!encryptionTarget) {
+      setIsEncrypted(false)
+      setEncryptionKeys(undefined)
+    }
+  }, [encryptionTarget?.userId])
+
+  useEffect(() => {
     if (!answerRef.current || !containerRef.current) {
       return
     }
@@ -338,8 +432,12 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
     }
     setPosting(true)
     try {
-      const response = await api.postAPI.preview(answerText)
-      setPreviewing(response.content)
+      if (isEncrypted) {
+        setPreviewing(renderEncryptedContentHtml(answerText))
+      } else {
+        const response = await api.postAPI.preview(answerText)
+        setPreviewing(response.content)
+      }
     } catch (e) {
       console.error(e)
       setPreviewing(null)
@@ -363,22 +461,38 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
     setPreviewing(null)
   }
 
-  const handleAnswer = () => {
+  const handleAnswer = async () => {
     setPosting(true)
-    props
-      .onAnswer(answerText, props.post, props.comment)
-      .then(() => {
-        setStorageValueDebounced('')
-        setStorageValueDebounced.flush()
-        setAnswerText('')
-      })
-      .catch((error) => {
-        console.log('onAnswer ERR', error)
-      })
-      .finally(() => {
-        setPreviewing(null)
-        setPosting(false)
-      })
+    try {
+      const resolvedEncryptionKeys = isEncrypted ? encryptionKeys || (await resolveEncryptionKeys()) : undefined
+      const encryptedPayload =
+        isEncrypted &&
+        resolvedEncryptionKeys &&
+        (await encryptContentForUsers(answerText, [
+          {
+            ...resolvedEncryptionKeys.sender,
+            role: 'sender',
+          },
+          {
+            ...resolvedEncryptionKeys.recipient,
+            role: 'recipient',
+          },
+        ]))
+
+      await props.onAnswer(isEncrypted ? '' : answerText, props.post, props.comment, encryptedPayload || undefined)
+
+      setStorageValueDebounced('')
+      setStorageValueDebounced.flush()
+      setAnswerText('')
+      setIsEncrypted(false)
+      setEncryptionKeys(undefined)
+    } catch (error) {
+      console.log('onAnswer ERR', error)
+      toast.error(error instanceof Error ? error.message : 'Не удалось отправить сообщение.')
+    } finally {
+      setPreviewing(null)
+      setPosting(false)
+    }
   }
 
   const handleMediaUpload = (result: MediaResult[], gallery?: CreateGalleryOption | undefined) => {
@@ -431,7 +545,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
       })
     } else {
       // Not inside gallery - wrap if checkbox is checked
-      if (gallery?.create) {
+      if (gallery?.create && !isEncrypted) {
         mediaText = `<gallery>\n${mediaText}\n</gallery>`
       }
       replaceText(mediaText, mediaText.length)
@@ -468,7 +582,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
       const result = await api.userAPI.getUsernameSuggestions(startsWith)
       return result.usernames
     } catch (e) {
-      debounceSuggestError((e as any).message)
+      debounceSuggestError(e instanceof Error ? e.message : 'Не удалось загрузить подсказки.')
       return []
     }
   }
@@ -477,7 +591,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
     try {
       const result = await api.pollAPI.createPoll({
         question: pollData.question,
-        options: pollData.options.map((opt: any) => opt.text),
+        options: pollData.options.map((opt) => opt.text),
         settings: {
           allowMultipleChoice: pollData.settings.isMultipleChoice,
           resultVisibility: pollData.settings.resultVisibility,
@@ -571,7 +685,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
         <div className={styles.control}>
           <Button
             variant='minimal'
-            disabled={disabledButtons}
+            disabled={disabledButtons || isEncrypted}
             onClick={() => applyTag('irony')}
             title='Ирония'
             tabIndex={toolbarTabIndex}
@@ -616,7 +730,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
           <div className={styles.control}>
             <Button
               variant='minimal'
-              disabled={disabledButtons}
+              disabled={disabledButtons || isEncrypted}
               onClick={() => applyTag('expand', { title: '' })}
               title='Свернуть/Развернуть'
               tabIndex={toolbarTabIndex}
@@ -639,7 +753,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
           <div className={styles.control}>
             <Button
               variant='minimal'
-              disabled={disabledButtons}
+              disabled={disabledButtons || isEncrypted}
               onClick={() => applyTag('spoiler')}
               title='Спойлер'
               tabIndex={toolbarTabIndex}
@@ -650,7 +764,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
           <div className={styles.control}>
             <Button
               variant='minimal'
-              disabled={disabledButtons}
+              disabled={disabledButtons || isEncrypted}
               onClick={() => setPollWizardOpen(true)}
               title='Создать опрос'
               tabIndex={toolbarTabIndex}
@@ -696,6 +810,16 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
           <div className={styles.buttonThemeToggle}>
             {previewing && <ThemeToggleComponent buttonLabel='Превью с другой темой' resetOnOnmount={true} />}
           </div>
+          {encryptionTarget && (
+            <Button
+              variant='minimal'
+              active={isEncrypted}
+              disabled={isPosting}
+              onClick={() => toggleEncrypted().catch()}
+            >
+              <span className='i i-mail-secure' />
+            </Button>
+          )}
           <Button
             variant='minimal'
             disabled={isPosting || !answerText}

--- a/frontend/src/Components/EncryptedContentComponent.module.scss
+++ b/frontend/src/Components/EncryptedContentComponent.module.scss
@@ -1,16 +1,26 @@
 .locked {
   border: 1px solid var(--dim3);
-  border-radius: 8px;
+  border-radius: 4px;
   padding: 12px;
   background: var(--dim1);
   color: var(--fgSoft);
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease;
 
   &.canDecrypt {
     cursor: pointer;
+
+    &:hover {
+      border-color: var(--primary);
+      background: var(--dim2);
+    }
   }
 
   &.disabled {
-    opacity: 0.85;
+    background: var(--dim1);
+    border-color: var(--dim2);
+    color: var(--fgGhost);
   }
 
   &.error {
@@ -28,4 +38,9 @@
 .body {
   margin-top: 8px;
   font-size: 14px;
+}
+
+.disabled .header,
+.disabled .body {
+  opacity: 0.5;
 }

--- a/frontend/src/Components/EncryptedContentComponent.module.scss
+++ b/frontend/src/Components/EncryptedContentComponent.module.scss
@@ -1,0 +1,31 @@
+.locked {
+  border: 1px solid var(--dim3);
+  border-radius: 8px;
+  padding: 12px;
+  background: var(--dim1);
+  color: var(--fgSoft);
+
+  &.canDecrypt {
+    cursor: pointer;
+  }
+
+  &.disabled {
+    opacity: 0.85;
+  }
+
+  &.error {
+    border-color: var(--danger);
+  }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.body {
+  margin-top: 8px;
+  font-size: 14px;
+}

--- a/frontend/src/Components/EncryptedContentComponent.tsx
+++ b/frontend/src/Components/EncryptedContentComponent.tsx
@@ -26,7 +26,8 @@ const EncryptedContentComponent = observer((props: EncryptedContentComponentProp
   const [decryptedHtml, setDecryptedHtml] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  const title = props.kind === 'post' ? 'Зашифрованный пост' : 'Зашифрованный комментарий'
+  const titleText = payload !== null && !payload.canDecrypt ? 'Шифровка (не для вас)' : 'Шифровка'
+  const bodyText = payload === null ? error || 'Загрузка...' : payload.canDecrypt ? error || '' : ''
 
   useEffect(() => {
     setDecryptedHtml(null)
@@ -113,16 +114,9 @@ const EncryptedContentComponent = observer((props: EncryptedContentComponentProp
     >
       <div className={styles.header}>
         <span className='i i-mail-secure' />
-        <span>{title}</span>
+        <span>{titleText}</span>
       </div>
-      <div className={styles.body}>
-        {error ||
-          (payload === null
-            ? 'Загрузка...'
-            : payload.canDecrypt
-              ? 'Нажмите, чтобы разблокировать содержимое.'
-              : 'Это сообщение зашифровано для другого пользователя.')}
-      </div>
+      {bodyText && <div className={styles.body}>{bodyText}</div>}
     </div>
   )
 })

--- a/frontend/src/Components/EncryptedContentComponent.tsx
+++ b/frontend/src/Components/EncryptedContentComponent.tsx
@@ -5,9 +5,9 @@ import classNames from 'classnames'
 import { observer } from 'mobx-react-lite'
 
 import { renderEncryptedContentHtml } from '../Utils/encryptedContentParser'
-import { decryptEncryptedPayload, EncryptedPayloadEntity } from '../Utils/mailCrypto'
+import { getEncryptedPayloadSource } from '../Utils/encryptedPayloadSource'
+import { EncryptedPayloadEntity } from '../Utils/mailCrypto'
 import ContentComponent from './ContentComponent'
-import { MailboxUnlockForm } from './SecretMailbox'
 
 import styles from './EncryptedContentComponent.module.scss'
 
@@ -25,9 +25,21 @@ const EncryptedContentComponent = observer((props: EncryptedContentComponentProp
   const [payload, setPayload] = useState<EncryptedPayloadEntity | null>(null)
   const [decryptedHtml, setDecryptedHtml] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const mailboxKeyPair = appState.cryptoSession.mailboxKeyPair
+  const mailboxMatchesPayload =
+    !!payload?.payload &&
+    !!mailboxKeyPair &&
+    appState.cryptoSession.hasMailboxKey(payload.payload.wrap.publicKey, payload.payload.wrap.publicKeyAlg)
 
-  const titleText = payload !== null && !payload.canDecrypt ? 'Шифровка (не для вас)' : 'Шифровка'
-  const bodyText = payload === null ? error || 'Загрузка...' : payload.canDecrypt ? error || '' : ''
+  const titleText =
+    payload === null
+      ? error
+        ? 'Шифровка'
+        : 'Шифровка (загрузка)'
+      : !payload.canDecrypt
+        ? 'Шифровка (не для вас)'
+        : 'Шифровка'
+  const bodyText = payload === null ? error || '' : payload.canDecrypt ? error || '' : ''
 
   useEffect(() => {
     setDecryptedHtml(null)
@@ -44,52 +56,36 @@ const EncryptedContentComponent = observer((props: EncryptedContentComponentProp
   }, [api.encryptedPayload, props.encryptedPayloadId])
 
   const tryDecrypt = useCallback(async () => {
-    if (!payload?.payload || !appState.cryptoSession.mailboxKeyPair) {
+    if (!payload?.payload) {
       return
     }
 
-    const source = await decryptEncryptedPayload(payload, appState.cryptoSession.mailboxKeyPair)
+    const source = await getEncryptedPayloadSource(appState, payload)
+
+    if (source === undefined) {
+      return
+    }
+
     setDecryptedHtml(renderEncryptedContentHtml(source))
     setError(null)
-  }, [appState.cryptoSession.mailboxKeyPair, payload])
+  }, [appState, payload])
 
   useEffect(() => {
-    if (
-      payload?.payload &&
-      appState.cryptoSession.mailboxKeyPair &&
-      appState.cryptoSession.hasMailboxKey(payload.payload.wrap.publicKey, payload.payload.wrap.publicKeyAlg)
-    ) {
+    if (decryptedHtml === null && mailboxMatchesPayload) {
       tryDecrypt().catch((decryptError) => {
         setError(decryptError instanceof Error ? decryptError.message : 'Не удалось расшифровать содержимое.')
       })
     }
-  }, [appState.cryptoSession, payload, tryDecrypt])
+  }, [decryptedHtml, mailboxMatchesPayload, tryDecrypt])
 
   const handleUnlock = () => {
     if (!payload?.canDecrypt || !payload.payload) {
       return
     }
 
-    if (appState.cryptoSession.hasMailboxKey(payload.payload.wrap.publicKey, payload.payload.wrap.publicKeyAlg)) {
-      tryDecrypt().catch((decryptError) => {
-        setError(decryptError instanceof Error ? decryptError.message : 'Не удалось расшифровать содержимое.')
-      })
-      return
-    }
-
-    appState.setModal(
-      <MailboxUnlockForm
-        publicKey={payload.payload.wrap.publicKey}
-        publicKeyAlg={payload.payload.wrap.publicKeyAlg}
-        onSuccess={() => {
-          appState.setModal(undefined)
-          tryDecrypt().catch((decryptError) => {
-            setError(decryptError instanceof Error ? decryptError.message : 'Не удалось расшифровать содержимое.')
-          })
-        }}
-        onCancel={() => appState.setModal(undefined)}
-      />,
-    )
+    tryDecrypt().catch((decryptError) => {
+      setError(decryptError instanceof Error ? decryptError.message : 'Не удалось расшифровать содержимое.')
+    })
   }
 
   if (decryptedHtml !== null) {
@@ -107,7 +103,7 @@ const EncryptedContentComponent = observer((props: EncryptedContentComponentProp
     <div
       className={classNames(styles.locked, props.className, {
         [styles.canDecrypt]: !!payload?.canDecrypt,
-        [styles.disabled]: payload !== null && !payload.canDecrypt,
+        [styles.disabled]: payload === null || (payload !== null && !payload.canDecrypt),
         [styles.error]: !!error,
       })}
       onClick={payload?.canDecrypt ? handleUnlock : undefined}

--- a/frontend/src/Components/EncryptedContentComponent.tsx
+++ b/frontend/src/Components/EncryptedContentComponent.tsx
@@ -1,0 +1,130 @@
+import React, { useCallback, useEffect, useState } from 'react'
+
+import { useAPI, useAppState } from '@state/AppState'
+import classNames from 'classnames'
+import { observer } from 'mobx-react-lite'
+
+import { renderEncryptedContentHtml } from '../Utils/encryptedContentParser'
+import { decryptEncryptedPayload, EncryptedPayloadEntity } from '../Utils/mailCrypto'
+import ContentComponent from './ContentComponent'
+import { MailboxUnlockForm } from './SecretMailbox'
+
+import styles from './EncryptedContentComponent.module.scss'
+
+type EncryptedContentComponentProps = {
+  encryptedPayloadId: number
+  kind: 'post' | 'comment'
+  className?: string
+  autoCut?: number
+  lowRating?: boolean
+}
+
+const EncryptedContentComponent = observer((props: EncryptedContentComponentProps) => {
+  const api = useAPI()
+  const appState = useAppState()
+  const [payload, setPayload] = useState<EncryptedPayloadEntity | null>(null)
+  const [decryptedHtml, setDecryptedHtml] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const title = props.kind === 'post' ? 'Зашифрованный пост' : 'Зашифрованный комментарий'
+
+  useEffect(() => {
+    setDecryptedHtml(null)
+    setError(null)
+
+    api.encryptedPayload
+      .getEncryptedPayloadCached(props.encryptedPayloadId)
+      .then((result) => {
+        setPayload(result)
+      })
+      .catch(() => {
+        setError('Не удалось загрузить зашифрованное содержимое.')
+      })
+  }, [api.encryptedPayload, props.encryptedPayloadId])
+
+  const tryDecrypt = useCallback(async () => {
+    if (!payload?.payload || !appState.cryptoSession.mailboxKeyPair) {
+      return
+    }
+
+    const source = await decryptEncryptedPayload(payload, appState.cryptoSession.mailboxKeyPair)
+    setDecryptedHtml(renderEncryptedContentHtml(source))
+    setError(null)
+  }, [appState.cryptoSession.mailboxKeyPair, payload])
+
+  useEffect(() => {
+    if (
+      payload?.payload &&
+      appState.cryptoSession.mailboxKeyPair &&
+      appState.cryptoSession.hasMailboxKey(payload.payload.wrap.publicKey, payload.payload.wrap.publicKeyAlg)
+    ) {
+      tryDecrypt().catch((decryptError) => {
+        setError(decryptError instanceof Error ? decryptError.message : 'Не удалось расшифровать содержимое.')
+      })
+    }
+  }, [appState.cryptoSession, payload, tryDecrypt])
+
+  const handleUnlock = () => {
+    if (!payload?.canDecrypt || !payload.payload) {
+      return
+    }
+
+    if (appState.cryptoSession.hasMailboxKey(payload.payload.wrap.publicKey, payload.payload.wrap.publicKeyAlg)) {
+      tryDecrypt().catch((decryptError) => {
+        setError(decryptError instanceof Error ? decryptError.message : 'Не удалось расшифровать содержимое.')
+      })
+      return
+    }
+
+    appState.setModal(
+      <MailboxUnlockForm
+        publicKey={payload.payload.wrap.publicKey}
+        publicKeyAlg={payload.payload.wrap.publicKeyAlg}
+        onSuccess={() => {
+          appState.setModal(undefined)
+          tryDecrypt().catch((decryptError) => {
+            setError(decryptError instanceof Error ? decryptError.message : 'Не удалось расшифровать содержимое.')
+          })
+        }}
+        onCancel={() => appState.setModal(undefined)}
+      />,
+    )
+  }
+
+  if (decryptedHtml !== null) {
+    return (
+      <ContentComponent
+        className={props.className}
+        content={decryptedHtml}
+        autoCut={props.autoCut}
+        lowRating={props.lowRating}
+      />
+    )
+  }
+
+  return (
+    <div
+      className={classNames(styles.locked, props.className, {
+        [styles.canDecrypt]: !!payload?.canDecrypt,
+        [styles.disabled]: payload !== null && !payload.canDecrypt,
+        [styles.error]: !!error,
+      })}
+      onClick={payload?.canDecrypt ? handleUnlock : undefined}
+    >
+      <div className={styles.header}>
+        <span className='i i-mail-secure' />
+        <span>{title}</span>
+      </div>
+      <div className={styles.body}>
+        {error ||
+          (payload === null
+            ? 'Загрузка...'
+            : payload.canDecrypt
+              ? 'Нажмите, чтобы разблокировать содержимое.'
+              : 'Это сообщение зашифровано для другого пользователя.')}
+      </div>
+    </div>
+  )
+})
+
+export default EncryptedContentComponent

--- a/frontend/src/Components/HistoryComponent.tsx
+++ b/frontend/src/Components/HistoryComponent.tsx
@@ -9,6 +9,7 @@ import { useTheme } from '../Theme/ThemeProvider'
 import { HistoryInfo } from '../Types/HistoryInfo'
 import ContentComponent from './ContentComponent'
 import DateComponent from './DateComponent'
+import EncryptedContentComponent from './EncryptedContentComponent'
 
 import { ReactComponent as CloseIcon } from '../Assets/close.svg'
 import styles from './HistoryComponent.module.scss'
@@ -16,12 +17,13 @@ import styles from './HistoryComponent.module.scss'
 interface HistoryComponentProps {
   history: {
     id: number
-    type: string
+    type: 'post' | 'comment'
   }
   onClose?: () => void
   initial?: {
     title?: string
     content: string
+    encryptedPayloadId?: number
     date: Date
   }
 }
@@ -29,8 +31,6 @@ interface HistoryComponentProps {
 export const HistoryComponent = (props: HistoryComponentProps) => {
   const api = useAPI()
   const currentUsername = useAppState().userInfo?.username
-  const [title, setTitle] = useState(props.initial?.title)
-  const [content, setContent] = useState(props.initial?.content || '')
   const [selectedId, setSelectedId] = useState(0)
   const [showDiff, setShowDiff] = useState(false)
   const [historyEntries, setHistoryEntries] = useState<HistoryInfo[]>(
@@ -39,6 +39,7 @@ export const HistoryComponent = (props: HistoryComponentProps) => {
           {
             id: 0,
             content: props.initial.content,
+            encryptedPayloadId: props.initial.encryptedPayloadId,
             title: props.initial.title,
             date: props.initial.date,
             changed: 0,
@@ -57,8 +58,6 @@ export const HistoryComponent = (props: HistoryComponentProps) => {
     }
 
     setSelectedId(id)
-    setContent(entry.content)
-    setTitle(entry.title)
   }
 
   useEffect(() => {
@@ -69,8 +68,6 @@ export const HistoryComponent = (props: HistoryComponentProps) => {
         if (result.length > 0) {
           const last = result[0]
           setSelectedId(last.id)
-          setTitle(last.title)
-          setContent(last.content)
         }
       })
       .catch((err) => {
@@ -81,33 +78,43 @@ export const HistoryComponent = (props: HistoryComponentProps) => {
   }, [api, history, onClose])
 
   const selectedIndex = historyEntries.findIndex((h) => h.id === selectedId)
+  const selectedEntry = selectedIndex >= 0 ? historyEntries[selectedIndex] : undefined
   const prevEntry =
     selectedIndex >= 0 && selectedIndex < historyEntries.length - 1 ? historyEntries[selectedIndex + 1] : undefined
+  const canShowDiff = !!prevEntry && !selectedEntry?.encryptedPayloadId && !prevEntry.encryptedPayloadId
 
   const { theme } = useTheme()
+
+  useEffect(() => {
+    if (showDiff && !canShowDiff) {
+      setShowDiff(false)
+    }
+  }, [canShowDiff, showDiff])
 
   return (
     <div className={styles.history}>
       <div className='content'>
-        {title && <div className='title'>{title}</div>}
-        {showDiff && prevEntry ? (
+        {selectedEntry?.title && <div className='title'>{selectedEntry.title}</div>}
+        {showDiff && prevEntry && selectedEntry ? (
           <DiffViewer
             oldValue={prevEntry.content}
-            newValue={content}
+            newValue={selectedEntry.content}
             splitView={false}
             hideLineNumbers={true}
             useDarkTheme={theme === 'dark'}
             compareMethod={DiffMethod.WORDS}
             codeFoldMessageRenderer={(n) => <pre>{`Развернуть ${n} строк ...`}</pre>}
           />
+        ) : selectedEntry?.encryptedPayloadId ? (
+          <EncryptedContentComponent encryptedPayloadId={selectedEntry.encryptedPayloadId} kind={props.history.type} />
         ) : (
-          <ContentComponent {...{ currentUsername, content }} />
+          <ContentComponent currentUsername={currentUsername} content={selectedEntry?.content || ''} />
         )}
       </div>
       <div className='sideNav'>
         <div className='top'>
           <span>История</span>
-          {prevEntry && (
+          {canShowDiff && (
             <div className={classNames('diffToggle', showDiff ? 'active' : '')} onClick={() => setShowDiff(!showDiff)}>
               &plusmn;
             </div>

--- a/frontend/src/Components/PostComponent.module.scss
+++ b/frontend/src/Components/PostComponent.module.scss
@@ -52,6 +52,24 @@ input.title {
   // TODO video sizing
 }
 
+.encryptedContent {
+  position: relative;
+  padding: 16px 18px;
+  border-radius: 4px;
+  background: var(--dim1);
+  border: 1px solid var(--dim2);
+
+  &::after {
+    content: '🔒';
+    position: absolute;
+    top: 12px;
+    right: 14px;
+    opacity: 0.2;
+    font-size: 20px;
+    pointer-events: none;
+  }
+}
+
 .controls {
   display: flex;
   margin-top: 8px;

--- a/frontend/src/Components/PostComponent.tsx
+++ b/frontend/src/Components/PostComponent.tsx
@@ -10,6 +10,7 @@ import { toast } from 'react-toastify'
 
 import Conf from '../Conf'
 import { CommentInfo, PostInfo, PostLinkInfo } from '../Types/PostInfo'
+import { getEncryptedPayloadSource } from '../Utils/encryptedPayloadSource'
 import { EncryptedPayloadDraft } from '../Utils/mailCrypto'
 import { AltTranslateButton, AnnotateButton, TranslateButton, UnwatchButton, WatchButton } from './ContentButtons'
 import ContentComponent from './ContentComponent'
@@ -44,7 +45,8 @@ interface PostComponentProps {
 
 export default function PostComponent(props: PostComponentProps) {
   const api = useAPI()
-  const currentUsername = useAppState().userInfo?.username
+  const appState = useAppState()
+  const currentUsername = appState.userInfo?.username
   const [showOptions, setShowOptions] = useState(false)
   const [editingText, setEditingText] = useState<false | string>(false)
   const [editingTitle, setEditingTitle] = useState<string>(props.post.title || '')
@@ -144,6 +146,19 @@ export default function PostComponent(props: PostComponentProps) {
   const handleEdit = async () => {
     try {
       const post = await api.postAPI.get(props.post.id, 'source', true)
+
+      if (post.post.encryptedPayloadId) {
+        const payload = await api.encryptedPayload.getEncryptedPayloadCached(post.post.encryptedPayloadId)
+        const source = await getEncryptedPayloadSource(appState, payload)
+
+        if (source === undefined) {
+          return
+        }
+
+        setEditingText(source)
+        return
+      }
+
       setEditingText(post.post.content)
     } catch (e) {
       console.log('Get comment error:', e)
@@ -181,7 +196,7 @@ export default function PostComponent(props: PostComponentProps) {
           {editingText === false ? (
             showHistory ? (
               <HistoryComponent
-                initial={{ title, content, date: created }}
+                initial={{ title, content, date: created, encryptedPayloadId: props.post.encryptedPayloadId }}
                 history={{ id: props.post.id, type: 'post' }}
                 onClose={toggleHistory}
               />
@@ -223,7 +238,12 @@ export default function PostComponent(props: PostComponentProps) {
                 value={editingTitle}
                 onChange={handleEditingTitle}
               />
-              <CreateCommentComponent open={true} text={editingText} onAnswer={handleEditComplete} />
+              <CreateCommentComponent
+                open={true}
+                text={editingText}
+                initialEncrypted={!!props.post.encryptedPayloadId}
+                onAnswer={handleEditComplete}
+              />
             </>
           )}
         </div>

--- a/frontend/src/Components/PostComponent.tsx
+++ b/frontend/src/Components/PostComponent.tsx
@@ -8,10 +8,12 @@ import OutsideClickHandler from 'react-outside-click-handler'
 import { toast } from 'react-toastify'
 
 import Conf from '../Conf'
-import { PostInfo } from '../Types/PostInfo'
+import { CommentInfo, PostInfo, PostLinkInfo } from '../Types/PostInfo'
+import { EncryptedPayloadDraft } from '../Utils/mailCrypto'
 import { AltTranslateButton, AnnotateButton, TranslateButton, UnwatchButton, WatchButton } from './ContentButtons'
 import ContentComponent from './ContentComponent'
 import CreateCommentComponent from './CreateCommentComponent'
+import EncryptedContentComponent from './EncryptedContentComponent'
 import { HistoryComponent } from './HistoryComponent'
 import PostLink from './PostLink'
 import RatingSwitch from './RatingSwitch'
@@ -29,7 +31,12 @@ interface PostComponentProps {
   buttons?: React.ReactNode
   onChange?: (id: number, post: Partial<PostInfo>) => void
   autoCut?: number
-  onEdit?: (post: PostInfo, text: string, title?: string) => Promise<PostInfo | undefined>
+  onEdit?: (
+    post: PostInfo,
+    text: string,
+    title?: string,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ) => Promise<PostInfo | undefined>
   dangerousHtmlTitle?: boolean
   hideRating?: boolean
 }
@@ -71,6 +78,7 @@ export default function PostComponent(props: PostComponentProps) {
   const { id, created, site, author, vote, rating, watch } = props.post
   const title = altTitle || props.post.title
   const content = altContent || props.post.content
+  const isEncrypted = !!props.post.encryptedPayloadId
 
   const toggleOptions = () => {
     setShowOptions(!showOptions)
@@ -114,15 +122,20 @@ export default function PostComponent(props: PostComponentProps) {
       })
   }
 
-  const handleEditComplete = async (text: string) => {
+  const handleEditComplete = async (
+    text: string,
+    _post?: PostLinkInfo,
+    _comment?: CommentInfo,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ) => {
     try {
-      await props.onEdit?.(props.post, text, editingTitle)
+      await props.onEdit?.(props.post, text, editingTitle, encryptedPayload)
       setEditingText(false)
       // return res;
       return undefined
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.log('Could not edit post', err)
-      toast.error(err.message || 'Не удалось отредактировать пост')
+      toast.error(err instanceof Error ? err.message : 'Не удалось отредактировать пост')
       throw err
     }
   }
@@ -181,11 +194,21 @@ export default function PostComponent(props: PostComponentProps) {
                   </div>
                 )}
                 <div className={styles.content}>
-                  <ContentComponent
-                    className={styles.content}
-                    {...{ autoCut, content, currentUsername }}
-                    lowRating={rating <= Conf.POST_LOW_RATING_THRESHOLD || props.post.vote === -1}
-                  />
+                  {props.post.encryptedPayloadId ? (
+                    <EncryptedContentComponent
+                      className={styles.content}
+                      encryptedPayloadId={props.post.encryptedPayloadId}
+                      kind='post'
+                      autoCut={autoCut}
+                      lowRating={rating <= Conf.POST_LOW_RATING_THRESHOLD || props.post.vote === -1}
+                    />
+                  ) : (
+                    <ContentComponent
+                      className={styles.content}
+                      {...{ autoCut, content, currentUsername }}
+                      lowRating={rating <= Conf.POST_LOW_RATING_THRESHOLD || props.post.vote === -1}
+                    />
+                  )}
                 </div>
               </>
             )
@@ -222,7 +245,7 @@ export default function PostComponent(props: PostComponentProps) {
           </div>
         )}
         <div className={styles.control + ' ' + styles.options}>
-          {(showTranslateButtonInline || currentMode === 'translate') && (
+          {!isEncrypted && (showTranslateButtonInline || currentMode === 'translate') && (
             <div className={styles.control}>
               <TranslateButton
                 iconOnly={true}
@@ -232,12 +255,12 @@ export default function PostComponent(props: PostComponentProps) {
               />
             </div>
           )}
-          {currentMode === 'altTranslate' && (
+          {!isEncrypted && currentMode === 'altTranslate' && (
             <div className={styles.control}>
               <AltTranslateButton iconOnly={true} isActive={true} inProgress={inProgress} onClick={altTranslate} />
             </div>
           )}
-          {currentMode === 'annotate' && (
+          {!isEncrypted && currentMode === 'annotate' && (
             <div className={styles.control}>
               <AnnotateButton iconOnly={true} isActive={true} inProgress={inProgress} onClick={annotate} />
             </div>

--- a/frontend/src/Components/PostComponent.tsx
+++ b/frontend/src/Components/PostComponent.tsx
@@ -4,6 +4,7 @@ import { TranslateType } from '@api/PostAPI'
 import { useInterpreter } from '@api/use/useInterpreter'
 import { useAPI, useAppState } from '@state/AppState'
 import Button from '@ui/Button'
+import classNames from 'classnames'
 import OutsideClickHandler from 'react-outside-click-handler'
 import { toast } from 'react-toastify'
 
@@ -196,7 +197,7 @@ export default function PostComponent(props: PostComponentProps) {
                 <div className={styles.content}>
                   {props.post.encryptedPayloadId ? (
                     <EncryptedContentComponent
-                      className={styles.content}
+                      className={classNames(styles.content, styles.encryptedContent)}
                       encryptedPayloadId={props.post.encryptedPayloadId}
                       kind='post'
                       autoCut={autoCut}

--- a/frontend/src/Components/SecretMailbox.module.scss
+++ b/frontend/src/Components/SecretMailbox.module.scss
@@ -46,7 +46,7 @@
 
   .decodeInput {
     margin-top: 8px;
-    width: 260px;
+    width: 100%;
   }
 
   label {
@@ -118,10 +118,24 @@
     margin: 8px;
 
     :global(.i):before {
-      vertical-align: middle;
+      vertical-align: text-bottom;
       font-size: 16px;
       padding-right: 4px;
     }
+  }
+
+  .hintMessage {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .hintWarning {
+    color: var(--fgSofter);
+  }
+
+  .hintError {
+    color: var(--danger);
   }
   .info {
     p {

--- a/frontend/src/Components/SecretMailbox.tsx
+++ b/frontend/src/Components/SecretMailbox.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useDebouncedCallback } from 'use-debounce'
 
-import { useAppState } from '../AppState/AppState'
+import { AppState, useAppState } from '../AppState/AppState'
 import { deriveMailboxKeyPair, MailboxKeyPair } from '../Utils/mailCrypto'
 import Overlay from './Overlay'
 
@@ -300,4 +300,25 @@ export function MailboxUnlockForm(props: MailboxUnlockFormProps) {
       </div>
     </>
   )
+}
+
+export function requestMailboxUnlock(appState: AppState, publicKey: string, publicKeyAlg: string) {
+  return new Promise<boolean>((resolve) => {
+    const close = () => appState.setModal(undefined)
+
+    appState.setModal(
+      <MailboxUnlockForm
+        publicKey={publicKey}
+        publicKeyAlg={publicKeyAlg}
+        onSuccess={() => {
+          close()
+          resolve(true)
+        }}
+        onCancel={() => {
+          close()
+          resolve(false)
+        }}
+      />,
+    )
+  })
 }

--- a/frontend/src/Components/SecretMailbox.tsx
+++ b/frontend/src/Components/SecretMailbox.tsx
@@ -3,6 +3,7 @@ import React, { useRef, useState } from 'react'
 import Button from '@ui/Button'
 import classNames from 'classnames'
 import { useHotkeys } from 'react-hotkeys-hook'
+import { useDebouncedCallback } from 'use-debounce'
 
 import { useAppState } from '../AppState/AppState'
 import { deriveMailboxKeyPair, MailboxKeyPair } from '../Utils/mailCrypto'
@@ -165,38 +166,124 @@ type MailboxUnlockFormProps = {
   onCancel: () => void
 }
 
-export function MailboxUnlockForm(props: MailboxUnlockFormProps) {
+type MailboxUnlockFieldsProps = {
+  publicKey: string
+  publicKeyAlg: string
+  onSuccess?: () => void
+}
+
+function MailboxUnlockFields(props: MailboxUnlockFieldsProps) {
   const appState = useAppState()
   const passwordRef = useRef<HTMLInputElement>(null)
+  const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [checking, setChecking] = useState(false)
+  const unlockAttemptRef = useRef(0)
+  const completedRef = useRef(false)
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (value: string, attemptId: number) => {
     const userId = appState.userInfo?.id
-    const password = passwordRef.current?.value || ''
 
-    if (!userId || !password) {
+    if (!userId || !value || completedRef.current) {
       return
     }
 
     try {
       setError(null)
-      await appState.cryptoSession.unlockMailbox(userId, password, props.publicKey, props.publicKeyAlg)
+      await appState.cryptoSession.unlockMailbox(userId, value, props.publicKey, props.publicKeyAlg)
+
+      if (completedRef.current) {
+        return
+      }
+
+      completedRef.current = true
+      setChecking(false)
+      handleSubmitDebounced.cancel()
       props.onSuccess?.()
     } catch (unlockError) {
+      if (
+        completedRef.current ||
+        appState.cryptoSession.hasMailboxKey(props.publicKey, props.publicKeyAlg) ||
+        unlockAttemptRef.current !== attemptId
+      ) {
+        return
+      }
+
+      setChecking(false)
       setError(unlockError instanceof Error ? unlockError.message : 'Не удалось разблокировать почтовый ящик.')
     }
   }
 
-  useHotkeys(
-    ['ctrl+enter', 'meta+enter'],
-    () => {
-      handleSubmit().catch()
-    },
-    {
-      enableOnFormTags: true,
-    },
-  )
+  const handleSubmitDebounced = useDebouncedCallback((value: string, attemptId: number) => {
+    handleSubmit(value, attemptId).catch()
+  }, 300)
 
+  useHotkeys(['ctrl+enter', 'meta+enter'], () => {
+    const value = passwordRef.current?.value || ''
+    if (!value) {
+      return
+    }
+
+    handleSubmitDebounced.cancel()
+    setChecking(true)
+    const attemptId = unlockAttemptRef.current + 1
+    unlockAttemptRef.current = attemptId
+    handleSubmit(value, attemptId).catch()
+  })
+
+  React.useEffect(() => {
+    if (!password || completedRef.current) {
+      handleSubmitDebounced.cancel()
+      setChecking(false)
+      setError(null)
+      return
+    }
+
+    setChecking(true)
+    const attemptId = unlockAttemptRef.current + 1
+    unlockAttemptRef.current = attemptId
+    handleSubmitDebounced(password, attemptId)
+
+    return () => {
+      handleSubmitDebounced.cancel()
+    }
+  }, [handleSubmitDebounced, password])
+
+  return (
+    <>
+      <input
+        autoFocus={true}
+        ref={passwordRef}
+        className={styles.decodeInput}
+        type='password'
+        placeholder='Пароль от вашего почтового ящика'
+        value={password}
+        onChange={(e) => {
+          setPassword(e.target.value)
+          setError(null)
+        }}
+      />
+      {(checking || appState.cryptoSession.mailboxUnlocking || error) && (
+        <div className={styles.hint}>
+          {(checking || appState.cryptoSession.mailboxUnlocking) && (
+            <span className={classNames(styles.hintMessage, styles.hintWarning)}>
+              <span className='i i-slow' />
+              <span>Проверяем...</span>
+            </span>
+          )}
+          {!checking && !appState.cryptoSession.mailboxUnlocking && error && (
+            <span className={classNames(styles.hintMessage, styles.hintError)}>
+              <span className='i i-close' />
+              <span>{error}</span>
+            </span>
+          )}
+        </div>
+      )}
+    </>
+  )
+}
+
+export function MailboxUnlockForm(props: MailboxUnlockFormProps) {
   return (
     <>
       <Overlay onClick={props.onCancel} />
@@ -205,28 +292,11 @@ export function MailboxUnlockForm(props: MailboxUnlockFormProps) {
           <span className='i i-mailbox-secure'></span>
           Разблокировать почтовый ящик
         </h3>
-        <div className={styles.info}>
-          <p>Введите пароль от вашего почтового ящика. После успешной разблокировки ключ останется в памяти сессии.</p>
-        </div>
-        <label>Пароль</label>
-        <input
-          autoFocus={true}
-          ref={passwordRef}
-          className={styles.decodeInput}
-          type='password'
-          placeholder='Пароль от почтового ящика'
-          onChange={() => setError(null)}
+        <MailboxUnlockFields
+          publicKey={props.publicKey}
+          publicKeyAlg={props.publicKeyAlg}
+          onSuccess={props.onSuccess}
         />
-        {error && (
-          <div className={styles.hint}>
-            <span className={classNames(mediaFormStyles.error, 'i i-close')}>{error}</span>
-          </div>
-        )}
-        <div className={styles.submit}>
-          <Button onClick={() => handleSubmit().catch()} disabled={appState.cryptoSession.mailboxUnlocking}>
-            {appState.cryptoSession.mailboxUnlocking ? 'Разблокируем...' : 'Разблокировать'}
-          </Button>
-        </div>
       </div>
     </>
   )

--- a/frontend/src/Components/SecretMailbox.tsx
+++ b/frontend/src/Components/SecretMailbox.tsx
@@ -1,258 +1,18 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useRef, useState } from 'react'
 
-import { cryptico, RSAKey } from '@daotl/cryptico'
+import Button from '@ui/Button'
 import classNames from 'classnames'
 import { useHotkeys } from 'react-hotkeys-hook'
-import OutsideClickHandler from 'react-outside-click-handler'
-import TextareaAutosize from 'react-textarea-autosize'
-import { scrypt } from 'scrypt-js'
-import { useDebouncedCallback } from 'use-debounce'
 
-import useFocus from '../API/use/useFocus'
-import { useAPI, useAppState } from '../AppState/AppState'
-import { b64EncodeUnicode } from '../Utils/utils'
+import { useAppState } from '../AppState/AppState'
+import { deriveMailboxKeyPair, MailboxKeyPair } from '../Utils/mailCrypto'
 import Overlay from './Overlay'
 
-import createCommentStyles from './CreateCommentComponent.module.scss'
 import mediaFormStyles from './MediaUploader.module.scss'
 import styles from './SecretMailbox.module.scss'
 
-let rsaKeyCache: RSAKey | null = null
-
-async function getRSAKey(password: string): Promise<RSAKey> {
-  const salt = 'f8psK3rQ58K#J#j95@UXFt94RTyH!q9R'
-
-  const N = 16384,
-    r = 8,
-    p = 1
-  const dkLen = 32
-
-  const encoder = new TextEncoder()
-  const derivedKey = await scrypt(encoder.encode(password), encoder.encode(salt), N, r, p, dkLen)
-
-  return cryptico.generateRSAKey(new TextDecoder('utf-8').decode(derivedKey), 512)
-}
-
-export function SecretMailEncoderForm(props: {
-  openKey: string
-  forUsername?: string
-  mailboxTitle?: string
-  onClose: (result?: string) => void
-}) {
-  const [encoded, setEncoded] = useState<string>('')
-  const testAreaRef = useFocus<HTMLTextAreaElement>()
-  const resultRef = useRef<HTMLDivElement>(null)
-  const currentUsername = useAppState().userInfo?.username
-  const [ownPublicKey, setOwnPublicKey] = useState<false | string | undefined>(false)
-
-  const api = useAPI()
-
-  // fetch own public key
-  useEffect(() => {
-    if (currentUsername) {
-      api.postAPI.getPublicKeyByUsername(currentUsername).then((key) => {
-        setOwnPublicKey(key?.publicKey)
-      })
-    }
-  }, [currentUsername, api])
-
-  const encode = () => {
-    const sourceText = (testAreaRef.current?.value || '').trim()
-    if (!sourceText) {
-      return ''
-    }
-
-    const randomAESKey = cryptico.generateAESKey()
-    const aesKeyString = cryptico.bytes2string(randomAESKey)
-    const msgCypher = cryptico.encryptAESCBC(sourceText, randomAESKey)
-
-    const cipherTo: string = (cryptico.encrypt(aesKeyString, props.openKey, undefined as any) as any).cipher
-
-    const cipherFrom: string | undefined =
-      ownPublicKey && (cryptico.encrypt(aesKeyString, ownPublicKey, undefined as any) as any).cipher
-
-    const json = {
-      to: props.forUsername,
-      from: currentUsername,
-      toKey: cipherTo,
-      fromKey: cipherFrom,
-      c: msgCypher,
-      v: 1,
-    }
-    return b64EncodeUnicode(JSON.stringify(json))
-  }
-
-  const handleTextChange = useDebouncedCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setEncoded(encode())
-  }, 300)
-
-  const getResult = (encoded: string) =>
-    encoded && `<mail secret="${encoded}">${props.mailboxTitle || 'Шифровка'}</mail>`
-
-  // select all text in result div
-  const handleResultClick = () => {
-    if (resultRef.current) {
-      const range = document.createRange()
-      range.selectNodeContents(resultRef.current)
-      const selection = window.getSelection()
-      if (selection) {
-        selection.removeAllRanges()
-        selection.addRange(range)
-      }
-    }
-  }
-
-  const handleSubmit = () => {
-    props.onClose(getResult(encode()))
-  }
-
-  useHotkeys(
-    ['ctrl+enter', 'meta+enter'],
-    () => {
-      handleSubmit()
-    },
-    {
-      enableOnFormTags: true,
-    },
-  )
-
-  return (
-    <>
-      <Overlay
-        onClick={() => {
-          props.onClose()
-        }}
-      />
-      <div className={classNames(mediaFormStyles.container, styles.container, styles.modal)}>
-        <h3 className={classNames(styles.shortTitle)}>
-          <span className='i i-mail-secure' />
-          <span>{`${(props.mailboxTitle && props.mailboxTitle) || 'Написать шифровку'}`}</span>
-        </h3>
-        {!ownPublicKey && ownPublicKey !== false && (
-          <div className={styles.info}>
-            <p>
-              ⚠️ Вы не сможете прочитать это свое сообщение после отправки, так как не создали свой шифрованный почтовый
-              ящик.
-            </p>
-          </div>
-        )}
-        <div className={classNames(createCommentStyles.editor, createCommentStyles.answer)}>
-          <TextareaAutosize
-            placeholder={'Текст шифровки'}
-            ref={testAreaRef}
-            minRows={3}
-            maxRows={25}
-            maxLength={20000}
-            onChange={handleTextChange}
-          />
-        </div>
-        {encoded && (
-          <>
-            <span>Результат шифрования:</span>
-            <div className={styles.encodingResult} ref={resultRef} onClick={handleResultClick}>
-              {getResult(encoded)}
-            </div>
-          </>
-        )}
-        <div className={createCommentStyles.final}>
-          {/* FIXME replace with <Button */}
-          {/* eslint-disable-next-line react/forbid-elements */}
-          <button className={classNames(styles.copyButton, mediaFormStyles.choose)} onClick={handleSubmit}>
-            Готово
-          </button>
-        </div>
-      </div>
-    </>
-  )
-}
-
-export function SecretMailDecoderForm(props: {
-  encodedKey: string
-  cipher: string
-  title: string
-  onClose: (result: boolean) => void
-}) {
-  const tryDecode = (rsaKey: RSAKey | null) => {
-    if (!rsaKey) {
-      return null
-    }
-
-    const decoded = cryptico.decrypt(props.encodedKey, rsaKey)
-    if (decoded.status === 'success') {
-      rsaKeyCache = rsaKey
-
-      const aesKey = cryptico.string2bytes(decoded.plaintext)
-      const decrypted = cryptico.decryptAESCBC(props.cipher, aesKey)
-
-      props.onClose(true)
-      return decrypted
-    }
-    return null
-  }
-
-  const [decoded, setDecoded] = useState<string>((rsaKeyCache && tryDecode(rsaKeyCache)) || '')
-
-  const passwordRef = useFocus()
-  const [wrongPassword, setWrongPassword] = useState(false)
-  const [loading, setLoading] = useState(false)
-
-  const handleDecode = useDebouncedCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLoading(true)
-    try {
-      const password = e.target.value
-      const res = tryDecode(await getRSAKey(password))
-      if (res) {
-        setDecoded(res)
-      }
-      setWrongPassword(!!password.length && !res)
-    } finally {
-      setLoading(false)
-    }
-  }, 300)
-
-  return decoded ? (
-    <>{decoded}</>
-  ) : (
-    <>
-      <OutsideClickHandler
-        onOutsideClick={() => {
-          if (!decoded) {
-            props.onClose(false)
-          }
-        }}
-      >
-        <div className={classNames(styles.container)}>
-          <h3>
-            <span className={classNames('i', decoded ? 'i-mail-open' : 'i-mail-secure')} />
-            <span>{props.title}</span>
-          </h3>
-          <div className={styles.decoded}>{decoded}</div>
-          <>
-            <input
-              autoFocus={true}
-              ref={passwordRef}
-              className={styles.decodeInput}
-              type='password'
-              placeholder='Пароль от почтового ящика'
-              onChange={handleDecode}
-            />
-            {(loading || wrongPassword) && (
-              <div className={styles.hint}>
-                {loading && <span className={classNames(mediaFormStyles.warning, 'i i-slow')}>Проверяем...</span>}
-                {!loading && (
-                  <span className={classNames(mediaFormStyles.error, 'i i-close')}>Пароль не подходит.</span>
-                )}
-              </div>
-            )}
-          </>
-        </div>
-      </OutsideClickHandler>
-    </>
-  )
-}
-
 type SecretMailKeyGeneratorFormProps = {
-  onSuccess: (key: string) => void
+  onSuccess: (keyPair: MailboxKeyPair) => void
   onCancel: () => void
 }
 
@@ -265,32 +25,32 @@ export function SecretMailKeyGeneratorForm(props: SecretMailKeyGeneratorFormProp
   const [loading, setLoading] = useState(false)
 
   const handlePasswordChange = () => {
-    if (!password1Ref?.current?.value || !password2Ref?.current?.value) {
+    if (!password1Ref.current?.value || !password2Ref.current?.value) {
       setPasswordsMatch(null)
       return
     }
+
     setPasswordsMatch(password1Ref.current.value === password2Ref.current.value)
   }
 
   const handleSubmit = async () => {
-    if (passwordsMatch === true) {
-      try {
-        setLoading(true)
-        const passwd = password1Ref?.current?.value || ''
-        const privateKey = await getRSAKey(passwd)
-        const publicKey = cryptico.publicKeyString(privateKey)
-        props.onSuccess(publicKey)
-      } finally {
-        setLoading(false)
-      }
+    if (passwordsMatch !== true) {
+      return
+    }
+
+    try {
+      setLoading(true)
+      const keyPair = await deriveMailboxKeyPair(password1Ref.current?.value || '')
+      props.onSuccess(keyPair)
+    } finally {
+      setLoading(false)
     }
   }
 
-  // handle keypresses
   useHotkeys(
     ['ctrl+enter', 'meta+enter'],
     () => {
-      handleSubmit()
+      handleSubmit().catch()
     },
     {
       enableOnFormTags: true,
@@ -314,13 +74,13 @@ export function SecretMailKeyGeneratorForm(props: SecretMailKeyGeneratorFormProp
         <form
           onSubmit={(e) => {
             e.preventDefault()
-            handleSubmit()
+            handleSubmit().catch()
           }}
         >
           <div className={styles.info}>
             <p>
-              Создайте ваш новый пароль для расшифровки адресованных вам секретных соообщений (также для чтения вами
-              ваших исходящих). Этот пароль не обязан совпадать с паролем от аккаунта.
+              Создайте пароль почтового ящика. Из него на этом устройстве детерминированно выводится ваш приватный ключ
+              для расшифровки адресованных вам зашифрованных сообщений и будущего закрытого контента.
             </p>
           </div>
           <label>Пароль</label>
@@ -328,7 +88,7 @@ export function SecretMailKeyGeneratorForm(props: SecretMailKeyGeneratorFormProp
             autoFocus={true}
             type={inputType}
             placeholder='Пароль'
-            id={'pwd1'}
+            id='pwd1'
             ref={password1Ref}
             onChange={handlePasswordChange}
           />
@@ -341,7 +101,7 @@ export function SecretMailKeyGeneratorForm(props: SecretMailKeyGeneratorFormProp
           <input
             type={inputType}
             placeholder='Пароль еще раз'
-            id={'pwd2'}
+            id='pwd2'
             ref={password2Ref}
             onChange={handlePasswordChange}
           />
@@ -362,18 +122,15 @@ export function SecretMailKeyGeneratorForm(props: SecretMailKeyGeneratorFormProp
 
           <div className={classNames(styles.columns, styles.submit)}>
             <div className={styles.cutCover}>
-              {/* FIXME replace with <Button */}
-              {/* eslint-disable-next-line react/forbid-elements */}
-              <button
-                className={classNames('button', styles.cutButton)}
-                type='button'
+              <Button
+                className={styles.cutButton}
                 onClick={(e) => {
                   e.preventDefault()
                   setCut(!cut)
                 }}
               >
                 <span className={classNames('i', 'i-info')}></span>Инфо
-              </button>
+              </Button>
             </div>
             <div>
               <input
@@ -387,20 +144,89 @@ export function SecretMailKeyGeneratorForm(props: SecretMailKeyGeneratorFormProp
 
           <div className={classNames(styles.hint, { [styles.collapsed]: cut })}>
             <p>
-              Когда вы вводите пароль, на его основе генерируются пара ключей (публичный и приватный) для шифрования
-              секретных сообщений, <b>адресованных вам</b>. Публичный ключ не является секретом, он хранится на сервере
-              и виден другим пользователям, а приватный ключ нигде не сохраняется, и используется только на вашем
-              компьютере для расшифровки сообщений, зашифрованных с помощью публичного ключа.
+              На сервер отправляется только публичный ключ. Приватный ключ не сохраняется и каждый раз выводится из
+              вашего пароля локально в браузере.
             </p>
             <p>
-              Обратите внимание, что если вы решите сменить пароль "почтового ящика", то вместе с ним изменятся и ключи
-              шифрования. Новые сообщения <b>адресованные вам</b> (а также ваши копии исходящих сообщений) будут
-              шифроваться с помощью нового ключа, а старые сообщения, зашифрованные с помощью старого ключа, можно будет
-              прочитать только с помощью старого пароля. Поэтому очень важно хорошо запоминать свои пароли или сохранять
-              их в надежном месте.
+              Если вы смените пароль почтового ящика, изменится и пара ключей. Новый закрытый контент для вас будет
+              шифроваться уже под новый ключ, а старый останется привязан к старому паролю.
             </p>
           </div>
         </form>
+      </div>
+    </>
+  )
+}
+
+type MailboxUnlockFormProps = {
+  publicKey: string
+  publicKeyAlg: string
+  onSuccess?: () => void
+  onCancel: () => void
+}
+
+export function MailboxUnlockForm(props: MailboxUnlockFormProps) {
+  const appState = useAppState()
+  const passwordRef = useRef<HTMLInputElement>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async () => {
+    const userId = appState.userInfo?.id
+    const password = passwordRef.current?.value || ''
+
+    if (!userId || !password) {
+      return
+    }
+
+    try {
+      setError(null)
+      await appState.cryptoSession.unlockMailbox(userId, password, props.publicKey, props.publicKeyAlg)
+      props.onSuccess?.()
+    } catch (unlockError) {
+      setError(unlockError instanceof Error ? unlockError.message : 'Не удалось разблокировать почтовый ящик.')
+    }
+  }
+
+  useHotkeys(
+    ['ctrl+enter', 'meta+enter'],
+    () => {
+      handleSubmit().catch()
+    },
+    {
+      enableOnFormTags: true,
+    },
+  )
+
+  return (
+    <>
+      <Overlay onClick={props.onCancel} />
+      <div className={classNames(mediaFormStyles.container, styles.container, styles.modal)}>
+        <h3>
+          <span className='i i-mailbox-secure'></span>
+          Разблокировать почтовый ящик
+        </h3>
+        <div className={styles.info}>
+          <p>Введите пароль от вашего почтового ящика. После успешной разблокировки ключ останется в памяти сессии.</p>
+        </div>
+        <label>Пароль</label>
+        <input
+          autoFocus={true}
+          ref={passwordRef}
+          className={styles.decodeInput}
+          type='password'
+          placeholder='Пароль от почтового ящика'
+          onChange={() => setError(null)}
+        />
+        {error && (
+          <div className={styles.hint}>
+            <span className={classNames(mediaFormStyles.error, 'i i-close')}>{error}</span>
+          </div>
+        )}
+        <div className={styles.submit}>
+          <Button onClick={() => handleSubmit().catch()} disabled={appState.cryptoSession.mailboxUnlocking}>
+            {appState.cryptoSession.mailboxUnlocking ? 'Разблокируем...' : 'Разблокировать'}
+          </Button>
+        </div>
       </div>
     </>
   )

--- a/frontend/src/Components/UserProfileSettings.tsx
+++ b/frontend/src/Components/UserProfileSettings.tsx
@@ -4,6 +4,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useUserProfile } from '@api/use/useUserProfile'
 import { useAPI, useAppState } from '@state/AppState'
 import Button from '@ui/Button'
+import { MAILBOX_PUBLIC_KEY_ALG, MailboxKeyPair } from '@utils/mailCrypto'
 import { selectElementText } from '@utils/utils'
 import classNames from 'classnames'
 import { observer } from 'mobx-react-lite'
@@ -11,7 +12,7 @@ import { toast } from 'react-toastify'
 
 import { BarmaliniAccessResult, UserGender } from '../Types/UserInfo'
 import AnonymizeAccountDialog from './AnonymizeAccountDialog'
-import { SecretMailKeyGeneratorForm } from './SecretMailbox'
+import { MailboxUnlockForm, SecretMailKeyGeneratorForm } from './SecretMailbox'
 import ThemeToggleComponent from './ThemeToggleComponent'
 
 import styles from './UserProfileSettings.module.scss'
@@ -222,7 +223,7 @@ export default function UserProfileSettings(props: UserProfileSettingsProps) {
         </Button>
       </div>
 
-      {/* <MailboxSettings /> */}
+      <MailboxSettings />
       {props.barmaliniAccess && <BarmaliniAccess />}
 
       {!props.hasApps && (
@@ -358,22 +359,28 @@ const BarmaliniAccess = observer(() => {
  */
 export const MailboxSettings = observer(() => {
   const api = useAPI()
-  const { userInfo, confirmAlert } = useAppState()
+  const appState = useAppState()
+  const { userInfo, confirmAlert } = appState
   const [state, refreshProfile] = useUserProfile(userInfo?.username || '')
   const publicKey = state.status === 'ready' && state.profile.publicKey
+  const publicKeyAlg = state.status === 'ready' ? state.profile.publicKeyAlg : ''
   const [creatingMailbox, setCreatingMailbox] = React.useState(false)
+  const [unlockingMailbox, setUnlockingMailbox] = React.useState(false)
   const [revealPublicKey, setRevealPublicKey] = React.useState(false)
+  const mailboxCreated = !!publicKey && !!publicKeyAlg
+  const mailboxUnlocked = !!publicKey && !!publicKeyAlg && appState.cryptoSession.hasMailboxKey(publicKey, publicKeyAlg)
 
   const handleDelete = async (e: React.MouseEvent) => {
     e.preventDefault()
     await confirmAlert({
       message:
-        'Вы действительно хотите удалить почтовый ящик? Вы больше не сможете получать новые шифровки, ' +
-        'но вы сможете читать старые шифровки, адресованные вам.',
+        'Вы действительно хотите удалить почтовый ящик? Вы больше не сможете получать новый закрытый контент, ' +
+        'зашифрованный для вас.',
       onConfirm: () => {
         api.userAPI
-          .savePublicKey('')
+          .savePublicKey('', '')
           .then(() => {
+            appState.cryptoSession.clear()
             refreshProfile()
           })
           .catch((error) => {
@@ -394,10 +401,15 @@ export const MailboxSettings = observer(() => {
     }
   }
 
-  const handleCreatePublicKey = (key: string) => {
+  const handleCreatePublicKey = (keyPair: MailboxKeyPair) => {
+    if (!userInfo) {
+      return
+    }
+
     api.userAPI
-      .savePublicKey(key)
+      .savePublicKey(keyPair.publicKey, keyPair.publicKeyAlg)
       .then(() => {
+        appState.cryptoSession.cacheMailboxKeyPair(userInfo.id, keyPair)
         refreshProfile()
       })
       .catch((error) => {
@@ -412,14 +424,17 @@ export const MailboxSettings = observer(() => {
     <>
       {(state.status === 'ready' && (
         <div className={styles.mailbox}>
-          {(publicKey && (
+          {(mailboxCreated && (
             <>
-              {/*mailbox exists*/}
               <div className={styles.mailboxHeader}>
-                <span className={classNames('i i-mailbox-secure', { [styles.mailboxCreated]: !!publicKey })} />
-                Почтовый ящик готов!
+                <span className={classNames('i i-mailbox-secure', { [styles.mailboxCreated]: mailboxCreated })} />
+                {mailboxUnlocked ? 'Почтовый ящик разблокирован' : 'Почтовый ящик готов'}
               </div>
               <div className={styles.mailboxActions}>
+                {!mailboxUnlocked && publicKey && publicKeyAlg && (
+                  <Button onClick={() => setUnlockingMailbox(true)}>Разблокировать</Button>
+                )}
+                {mailboxUnlocked && <Button onClick={() => appState.cryptoSession.clear()}>Заблокировать</Button>}
                 <Button variant='danger' onClick={handleDelete}>
                   Удалить
                 </Button>
@@ -435,13 +450,14 @@ export const MailboxSettings = observer(() => {
                     <span className={styles.publicKey} onClick={handleShowPublicKey}>
                       {publicKey}
                     </span>
+                    <br />
+                    <span className={styles.label}>Алгоритм: {publicKeyAlg || MAILBOX_PUBLIC_KEY_ALG}</span>
                   </div>
                 )}
               </div>
             </>
           )) || (
             <div>
-              {/*Mailbox doesn't exist*/}
               <Button
                 onClick={() => {
                   setCreatingMailbox(true)
@@ -457,6 +473,16 @@ export const MailboxSettings = observer(() => {
       {creatingMailbox && (
         <div className={styles.modalWrapper}>
           <SecretMailKeyGeneratorForm onSuccess={handleCreatePublicKey} onCancel={() => setCreatingMailbox(false)} />
+        </div>
+      )}
+      {unlockingMailbox && publicKey && publicKeyAlg && (
+        <div className={styles.modalWrapper}>
+          <MailboxUnlockForm
+            publicKey={publicKey}
+            publicKeyAlg={publicKeyAlg}
+            onSuccess={() => setUnlockingMailbox(false)}
+            onCancel={() => setUnlockingMailbox(false)}
+          />
         </div>
       )}
     </>

--- a/frontend/src/Components/UserProfileSettings.tsx
+++ b/frontend/src/Components/UserProfileSettings.tsx
@@ -372,6 +372,11 @@ export const MailboxSettings = observer(() => {
 
   const handleDelete = async (e: React.MouseEvent) => {
     e.preventDefault()
+    if (!userInfo) {
+      return
+    }
+
+    const currentUserInfo = userInfo
     await confirmAlert({
       message:
         'Вы действительно хотите удалить почтовый ящик? Вы больше не сможете получать новый закрытый контент, ' +
@@ -381,6 +386,11 @@ export const MailboxSettings = observer(() => {
           .savePublicKey('', '')
           .then(() => {
             appState.cryptoSession.clear()
+            appState.setUserInfo({
+              ...currentUserInfo,
+              publicKey: '',
+              publicKeyAlg: '',
+            })
             refreshProfile()
           })
           .catch((error) => {
@@ -406,10 +416,17 @@ export const MailboxSettings = observer(() => {
       return
     }
 
+    const currentUserInfo = userInfo
+
     api.userAPI
       .savePublicKey(keyPair.publicKey, keyPair.publicKeyAlg)
       .then(() => {
-        appState.cryptoSession.cacheMailboxKeyPair(userInfo.id, keyPair)
+        appState.cryptoSession.cacheMailboxKeyPair(currentUserInfo.id, keyPair)
+        appState.setUserInfo({
+          ...currentUserInfo,
+          publicKey: keyPair.publicKey,
+          publicKeyAlg: keyPair.publicKeyAlg,
+        })
         refreshProfile()
       })
       .catch((error) => {

--- a/frontend/src/Pages/CreatePostPage.tsx
+++ b/frontend/src/Pages/CreatePostPage.tsx
@@ -8,7 +8,8 @@ import { toast } from 'react-toastify'
 import { useAPI, useAppState } from '../AppState/AppState'
 import CreateCommentComponent from '../Components/CreateCommentComponent'
 import SlowMode from '../Components/SlowMode'
-import { CommentInfo } from '../Types/PostInfo'
+import { CommentInfo, PostLinkInfo } from '../Types/PostInfo'
+import { EncryptedPayloadDraft } from '../Utils/mailCrypto'
 
 import createCommentStyles from '../Components/CommentComponent.module.scss'
 import styles from './CreatePostPage.module.css'
@@ -19,11 +20,16 @@ export const CreatePostPage = observer(() => {
   const [title, setTitle] = useState('')
   const navigate = useNavigate()
 
-  const handleAnswer = async (text: string): Promise<CommentInfo | undefined> => {
+  const handleAnswer = async (
+    text: string,
+    _post?: PostLinkInfo,
+    _comment?: CommentInfo,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ): Promise<CommentInfo | undefined> => {
     console.log('post', title, text)
 
     try {
-      const result = await api.postAPI.create(site, title, text)
+      const result = await api.postAPI.create(site, title, text, encryptedPayload)
       console.log('CREATE', result)
       navigate((site !== 'main' ? `/s/${site}` : '') + `/p${result.post.id}`)
     } catch (error) {
@@ -39,8 +45,11 @@ export const CreatePostPage = observer(() => {
     api.user.refreshUserRestrictions()
   }, [api])
 
-  if (Number.isInteger(userRestrictions?.restrictedToPostId)) {
-    return <RestrictedToPostIdMessage postId={userRestrictions!.restrictedToPostId as number} />
+  const restrictedPostId =
+    typeof userRestrictions?.restrictedToPostId === 'number' ? userRestrictions.restrictedToPostId : undefined
+
+  if (restrictedPostId !== undefined) {
+    return <RestrictedToPostIdMessage postId={restrictedPostId} />
   }
 
   if (userRestrictions?.postSlowModeWaitSecRemain) {

--- a/frontend/src/Pages/PostPage.tsx
+++ b/frontend/src/Pages/PostPage.tsx
@@ -10,6 +10,7 @@ import { CreateCommentComponentRestricted } from '../Components/CreateCommentCom
 import PostComponent from '../Components/PostComponent'
 import Username from '../Components/Username'
 import { CommentInfo, PostInfo, PostLinkInfo } from '../Types/PostInfo'
+import { EncryptedPayloadDraft } from '../Utils/mailCrypto'
 import { scrollUnderTopbar } from '../Utils/utils'
 
 import styles from './PostPage.module.css'
@@ -40,16 +41,21 @@ export default function PostPage() {
     document.title = docTitle
   }, [post, postId])
 
-  const handleCommentEdit = async (text: string, comment: CommentInfo) => {
-    return await editComment(text, comment.id)
+  const handleCommentEdit = async (text: string, comment: CommentInfo, encryptedPayload?: EncryptedPayloadDraft) => {
+    return await editComment(text, comment.id, encryptedPayload)
   }
 
-  const handleAnswer = async (text: string, post?: PostLinkInfo, comment?: CommentInfo) => {
+  const handleAnswer = async (
+    text: string,
+    post?: PostLinkInfo,
+    comment?: CommentInfo,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ) => {
     if (!post) {
       return
     }
 
-    const newComment = await postComment(text, comment?.id)
+    const newComment = await postComment(text, comment?.id, encryptedPayload)
     setTimeout(() => {
       const el = document.querySelector(`div[data-comment-id="${newComment.id}"]`)
       el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
@@ -102,8 +108,13 @@ export default function PostPage() {
     }
   }, [location.hash, comments, unreadOnly, postId])
 
-  const handlePostEdit = async (post: PostInfo, text: string, title?: string): Promise<PostInfo | undefined> => {
-    return await editPost(title || '', text)
+  const handlePostEdit = async (
+    post: PostInfo,
+    text: string,
+    title?: string,
+    encryptedPayload?: EncryptedPayloadDraft,
+  ): Promise<PostInfo | undefined> => {
+    return await editPost(title || '', text, encryptedPayload)
   }
 
   const baseRoute = site === 'main' ? '/' : `/s/${site}/`
@@ -161,6 +172,7 @@ export default function PostPage() {
             </div>
             <CreateCommentComponentRestricted
               parentAuthorUserName={post.author.username}
+              parentAuthorUserId={post.author.id}
               open={true}
               post={post}
               onAnswer={handleAnswer}

--- a/frontend/src/Pages/PostPage.tsx
+++ b/frontend/src/Pages/PostPage.tsx
@@ -157,6 +157,8 @@ export default function PostPage() {
                     unreadOnly={unreadOnly}
                     onEdit={handleCommentEdit}
                     currentUsername={userInfo?.username}
+                    parentAuthorUserName={post.author.username}
+                    parentAuthorUserId={post.author.id}
                   />
                 ))
               ) : error ? (

--- a/frontend/src/Types/HistoryInfo.ts
+++ b/frontend/src/Types/HistoryInfo.ts
@@ -1,6 +1,7 @@
 export type HistoryInfo = {
   id: number
   content: string
+  encryptedPayloadId?: number
   title?: string
   comment?: string
   date: Date

--- a/frontend/src/Types/PostInfo.ts
+++ b/frontend/src/Types/PostInfo.ts
@@ -13,6 +13,7 @@ export interface PostInfo extends PostLinkInfo {
   created: Date
   title?: string
   content: string
+  encryptedPayloadId?: number
   rating: number
   comments: number
   newComments: number
@@ -30,6 +31,7 @@ export interface CommentInfo {
   author: UserBaseInfo
   deleted?: boolean
   content: string
+  encryptedPayloadId?: number
   rating: number
   vote?: number
   isNew?: boolean

--- a/frontend/src/Types/UserInfo.ts
+++ b/frontend/src/Types/UserInfo.ts
@@ -14,6 +14,8 @@ export type UserInfo = UserBaseInfo & {
   name: string
   karma: number
   vote?: number
+  publicKey?: string
+  publicKeyAlg?: string
 }
 
 export type UserProfileInfo = UserInfo & {

--- a/frontend/src/Utils/encryptedContentParser.ts
+++ b/frontend/src/Utils/encryptedContentParser.ts
@@ -1,0 +1,111 @@
+const INLINE_TAGS = new Set(['b', 'i', 'u', 'strike'])
+
+export function renderEncryptedContentHtml(source: string) {
+  const doc = new DOMParser().parseFromString(`<body>${source}</body>`, 'text/html')
+  return renderNodes(Array.from(doc.body.childNodes), false)
+}
+
+function renderNodes(nodes: ChildNode[], preserveWhitespace: boolean): string {
+  return nodes
+    .map((node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        return renderText(node.textContent || '', preserveWhitespace)
+      }
+
+      if (!(node instanceof HTMLElement)) {
+        return ''
+      }
+
+      const tagName = node.tagName.toLowerCase()
+      if (INLINE_TAGS.has(tagName)) {
+        return `<${tagName}>${renderNodes(Array.from(node.childNodes), preserveWhitespace)}</${tagName}>`
+      }
+
+      if (tagName === 'br') {
+        return '<br/>'
+      }
+
+      if (tagName === 'a') {
+        const href = sanitizeLink(node.getAttribute('href'))
+        const body = renderNodes(Array.from(node.childNodes), false)
+        return href ? `<a href='${escapeAttribute(href)}' target='_blank' rel='noreferrer noopener'>${body}</a>` : body
+      }
+
+      if (tagName === 'img') {
+        const src = sanitizeMediaUrl(node.getAttribute('src'))
+        if (!src) {
+          return ''
+        }
+
+        return `<img src='${escapeAttribute(src)}' alt='${escapeAttribute(node.getAttribute('alt') || '')}' />`
+      }
+
+      if (tagName === 'video') {
+        const src = sanitizeMediaUrl(node.getAttribute('src'))
+        if (!src) {
+          return ''
+        }
+
+        return `<video src='${escapeAttribute(src)}' controls></video>`
+      }
+
+      if (tagName === 'blockquote') {
+        return `<blockquote>${renderNodes(Array.from(node.childNodes), false)}</blockquote>`
+      }
+
+      if (tagName === 'pre') {
+        return `<pre>${escapeHtml(node.textContent || '')}</pre>`
+      }
+
+      return escapeHtml(node.outerHTML)
+    })
+    .join('')
+}
+
+function renderText(text: string, preserveWhitespace: boolean): string {
+  const escaped = escapeHtml(text)
+  return preserveWhitespace ? escaped : escaped.replace(/\n/g, '<br/>')
+}
+
+function sanitizeLink(href: string | null): string | null {
+  if (!href) {
+    return null
+  }
+
+  try {
+    const url = new URL(href, window.location.origin)
+    if (['http:', 'https:', 'mailto:'].includes(url.protocol)) {
+      return url.toString()
+    }
+  } catch (error) {}
+
+  return null
+}
+
+function sanitizeMediaUrl(src: string | null): string | null {
+  if (!src) {
+    return null
+  }
+
+  try {
+    const url = new URL(src, window.location.origin)
+    if (['http:', 'https:'].includes(url.protocol)) {
+      return url.toString()
+    }
+  } catch (error) {}
+
+  return null
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function escapeAttribute(value: string): string {
+  return escapeHtml(value)
+}

--- a/frontend/src/Utils/encryptedPayloadSource.ts
+++ b/frontend/src/Utils/encryptedPayloadSource.ts
@@ -1,0 +1,30 @@
+import type { AppState } from '../AppState/AppState'
+import { requestMailboxUnlock } from '../Components/SecretMailbox'
+import { decryptEncryptedPayload, EncryptedPayloadEntity } from './mailCrypto'
+
+export async function getEncryptedPayloadSource(
+  appState: AppState,
+  payload: EncryptedPayloadEntity,
+): Promise<string | undefined> {
+  if (!payload.canDecrypt || !payload.payload) {
+    throw new Error('Недостаточно данных для расшифровки.')
+  }
+
+  if (!appState.cryptoSession.hasMailboxKey(payload.payload.wrap.publicKey, payload.payload.wrap.publicKeyAlg)) {
+    const unlocked = await requestMailboxUnlock(
+      appState,
+      payload.payload.wrap.publicKey,
+      payload.payload.wrap.publicKeyAlg,
+    )
+
+    if (!unlocked) {
+      return undefined
+    }
+  }
+
+  if (!appState.cryptoSession.mailboxKeyPair) {
+    return undefined
+  }
+
+  return decryptEncryptedPayload(payload, appState.cryptoSession.mailboxKeyPair)
+}

--- a/frontend/src/Utils/mailCrypto.ts
+++ b/frontend/src/Utils/mailCrypto.ts
@@ -1,0 +1,59 @@
+import { scrypt } from 'scrypt-js'
+import nacl from 'tweetnacl'
+
+export const MAILBOX_PUBLIC_KEY_ALG = 'x25519-scrypt-v1'
+
+const MAILBOX_SALT = 'f8psK3rQ58K#J#j95@UXFt94RTyH!q9R'
+const SCRYPT_N = 32768
+const SCRYPT_R = 8
+const SCRYPT_P = 1
+const SCRYPT_DK_LEN = 32
+
+export type MailboxKeyPair = {
+  publicKey: string
+  publicKeyAlg: string
+  publicKeyBytes: Uint8Array
+  secretKey: Uint8Array
+}
+
+const encoder = new TextEncoder()
+
+export async function deriveMailboxKeyPair(password: string): Promise<MailboxKeyPair> {
+  const derivedKey = await scrypt(
+    encoder.encode(password),
+    encoder.encode(MAILBOX_SALT),
+    SCRYPT_N,
+    SCRYPT_R,
+    SCRYPT_P,
+    SCRYPT_DK_LEN,
+  )
+
+  const secretKey = Uint8Array.from(derivedKey)
+  const keyPair = nacl.box.keyPair.fromSecretKey(secretKey)
+
+  return {
+    publicKey: bytesToBase64Url(keyPair.publicKey),
+    publicKeyAlg: MAILBOX_PUBLIC_KEY_ALG,
+    publicKeyBytes: keyPair.publicKey,
+    secretKey: keyPair.secretKey,
+  }
+}
+
+export function isValidMailboxPublicKey(publicKey: string, publicKeyAlg: string) {
+  return publicKeyAlg === MAILBOX_PUBLIC_KEY_ALG && /^[A-Za-z0-9_-]{43}$/.test(publicKey)
+}
+
+export function mailboxKeyMatches(keyPair: MailboxKeyPair, publicKey: string, publicKeyAlg: string) {
+  return keyPair.publicKeyAlg === publicKeyAlg && keyPair.publicKey === publicKey
+}
+
+export function bytesToBase64Url(bytes: Uint8Array) {
+  const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('')
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+export function base64UrlToBytes(value: string) {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized + '==='.slice((normalized.length + 3) % 4)
+  return Uint8Array.from(atob(padded), (char) => char.charCodeAt(0))
+}

--- a/frontend/src/Utils/mailCrypto.ts
+++ b/frontend/src/Utils/mailCrypto.ts
@@ -2,12 +2,19 @@ import { scrypt } from 'scrypt-js'
 import nacl from 'tweetnacl'
 
 export const MAILBOX_PUBLIC_KEY_ALG = 'x25519-scrypt-v1'
+export const ENCRYPTED_PAYLOAD_VERSION = 1
+export const ENCRYPTED_PAYLOAD_PARSER_PROFILE = 'lite-v1'
 
 const MAILBOX_SALT = 'f8psK3rQ58K#J#j95@UXFt94RTyH!q9R'
 const SCRYPT_N = 32768
 const SCRYPT_R = 8
 const SCRYPT_P = 1
 const SCRYPT_DK_LEN = 32
+const HKDF_INFO = new TextEncoder().encode('orbitar-encrypted-content-v1')
+const EMPTY_SALT = new Uint8Array([])
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
 
 export type MailboxKeyPair = {
   publicKey: string
@@ -16,7 +23,37 @@ export type MailboxKeyPair = {
   secretKey: Uint8Array
 }
 
-const encoder = new TextEncoder()
+export type EncryptedPayloadWrapDraft = {
+  userId: number
+  role: 'sender' | 'recipient'
+  publicKey: string
+  publicKeyAlg: string
+  ephemeralPublicKey: string
+  iv: string
+  encryptedKey: string
+}
+
+export type EncryptedPayloadDraft = {
+  v: number
+  parserProfile: string
+  ciphertext: string
+  iv: string
+  wraps: EncryptedPayloadWrapDraft[]
+}
+
+export type EncryptedPayloadWrap = Omit<EncryptedPayloadWrapDraft, 'userId'>
+
+export type EncryptedPayloadEntity = {
+  id: number
+  v: number
+  parserProfile: string
+  canDecrypt: boolean
+  payload?: {
+    ciphertext: string
+    iv: string
+    wrap: EncryptedPayloadWrap
+  }
+}
 
 export async function deriveMailboxKeyPair(password: string): Promise<MailboxKeyPair> {
   const derivedKey = await scrypt(
@@ -39,6 +76,81 @@ export async function deriveMailboxKeyPair(password: string): Promise<MailboxKey
   }
 }
 
+export async function encryptContentForUsers(
+  source: string,
+  recipients: Array<Pick<EncryptedPayloadWrapDraft, 'userId' | 'role' | 'publicKey' | 'publicKeyAlg'>>,
+): Promise<EncryptedPayloadDraft> {
+  const contentKey = crypto.getRandomValues(new Uint8Array(32))
+  const contentIv = crypto.getRandomValues(new Uint8Array(12))
+  const ciphertext = await encryptWithAesGcm(contentKey, contentIv, encoder.encode(source))
+
+  const wraps = await Promise.all(
+    recipients.map(async (recipient) => {
+      if (!isValidMailboxPublicKey(recipient.publicKey, recipient.publicKeyAlg)) {
+        throw new Error('Некорректный публичный ключ получателя.')
+      }
+
+      const ephemeralKeyPair = nacl.box.keyPair()
+      const wrapIv = crypto.getRandomValues(new Uint8Array(12))
+      const sharedSecret = nacl.scalarMult(ephemeralKeyPair.secretKey, base64UrlToBytes(recipient.publicKey))
+      const wrapKey = await deriveSharedAesKey(sharedSecret)
+      const encryptedKey = await crypto.subtle.encrypt({ name: 'AES-GCM', iv: wrapIv }, wrapKey, contentKey)
+
+      return {
+        userId: recipient.userId,
+        role: recipient.role,
+        publicKey: recipient.publicKey,
+        publicKeyAlg: recipient.publicKeyAlg,
+        ephemeralPublicKey: bytesToBase64Url(ephemeralKeyPair.publicKey),
+        iv: bytesToBase64Url(wrapIv),
+        encryptedKey: bytesToBase64Url(new Uint8Array(encryptedKey)),
+      }
+    }),
+  )
+
+  return {
+    v: ENCRYPTED_PAYLOAD_VERSION,
+    parserProfile: ENCRYPTED_PAYLOAD_PARSER_PROFILE,
+    ciphertext: bytesToBase64Url(ciphertext),
+    iv: bytesToBase64Url(contentIv),
+    wraps,
+  }
+}
+
+export async function decryptEncryptedPayload(
+  payload: EncryptedPayloadEntity,
+  keyPair: MailboxKeyPair,
+): Promise<string> {
+  if (!payload.payload) {
+    throw new Error('Недостаточно данных для расшифровки.')
+  }
+
+  const { wrap } = payload.payload
+  if (!mailboxKeyMatches(keyPair, wrap.publicKey, wrap.publicKeyAlg)) {
+    throw new Error('Пароль не подходит.')
+  }
+
+  try {
+    const sharedSecret = nacl.scalarMult(keyPair.secretKey, base64UrlToBytes(wrap.ephemeralPublicKey))
+    const wrapKey = await deriveSharedAesKey(sharedSecret)
+    const contentKey = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: base64UrlToBytes(wrap.iv) },
+      wrapKey,
+      base64UrlToBytes(wrap.encryptedKey),
+    )
+
+    const decrypted = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: base64UrlToBytes(payload.payload.iv) },
+      await importAesKey(new Uint8Array(contentKey), ['decrypt']),
+      base64UrlToBytes(payload.payload.ciphertext),
+    )
+
+    return decoder.decode(decrypted)
+  } catch (error) {
+    throw new Error('Не удалось расшифровать содержимое.')
+  }
+}
+
 export function isValidMailboxPublicKey(publicKey: string, publicKeyAlg: string) {
   return publicKeyAlg === MAILBOX_PUBLIC_KEY_ALG && /^[A-Za-z0-9_-]{43}$/.test(publicKey)
 }
@@ -56,4 +168,36 @@ export function base64UrlToBytes(value: string) {
   const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
   const padded = normalized + '==='.slice((normalized.length + 3) % 4)
   return Uint8Array.from(atob(padded), (char) => char.charCodeAt(0))
+}
+
+async function deriveSharedAesKey(sharedSecret: Uint8Array) {
+  const hkdfKey = await crypto.subtle.importKey('raw', sharedSecret, 'HKDF', false, ['deriveKey'])
+  return crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: EMPTY_SALT,
+      info: HKDF_INFO,
+    },
+    hkdfKey,
+    {
+      name: 'AES-GCM',
+      length: 256,
+    },
+    false,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+async function importAesKey(keyBytes: Uint8Array, usages: KeyUsage[]) {
+  return crypto.subtle.importKey('raw', keyBytes, { name: 'AES-GCM' }, false, usages)
+}
+
+async function encryptWithAesGcm(keyBytes: Uint8Array, iv: Uint8Array, data: Uint8Array) {
+  const encrypted = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    await importAesKey(keyBytes, ['encrypt']),
+    data,
+  )
+  return new Uint8Array(encrypted)
 }


### PR DESCRIPTION
## Summary
- adds mailbox v2 foundation: `public_key_alg`, deterministic mailbox keypair derivation, global `CryptoSessionStore`, shared unlock UX
- adds generic encrypted payload storage (`encrypted_payloads`, `encrypted_payload_keys`) bound to `content_source` and cached on `posts` / `comments`
- makes whole-body encrypted comments first-class; encrypted post plumbing is included in the same model
- adds client-side preview, decrypt, edit, and history support for encrypted content
- encrypted replies still notify the parent author with a generic `🔒 Шифровка` preview and do not bump public feeds

## Different From The Original Implementation
- replaces the old RSA-512 / inline-mail approach with first-class whole-body encrypted content
- stores one ciphertext plus per-user key wraps instead of duplicating ciphertext per addressee
- content rows now keep `encryptedPayloadId`; ciphertext is stored separately and fetched through a dedicated batch API
- mailbox unlock is session-wide and reused across page render, history, and edit flows instead of being a one-off per content item
- encrypted content is now attached to `content_source`, so edit history and future private-thread work can build on the same model

## Inboxes Follow-Up
This PR is intentionally the direct encrypted-content foundation, not the full private-inbox implementation.

Reusable pieces already in place:
- global `CryptoSessionStore`
- generic `encrypted_payloads` / `encrypted_payload_keys`
- payload ids on `content_source`, `posts`, and `comments`
- batched payload fetch and locked renderer

Planned direction for private/group inboxes:
- introduce a thread key per inbox
- wrap that thread key once per participant
- encrypt each post/comment with the thread key instead of creating per-message wraps for every participant
- reuse the same unlock/session/rendering path from this PR

## Crypto Approach (For Audit)
High level:
- password deterministically derives the user's long-term mailbox keypair
- each encrypted body gets one random content key and one ciphertext
- that content key is wrapped separately for sender and recipient
- backend stores only ciphertext + wraps; plaintext never leaves the client

Details:
- password -> mailbox keypair: `scrypt-js` with `N=32768`, `r=8`, `p=1`, `dkLen=32`; output is used as the Curve25519 secret via `tweetnacl.box.keyPair.fromSecretKey`
- only `public_key` + `public_key_alg = x25519-scrypt-v1` are stored server-side
- plaintext is encrypted once with Web Crypto `AES-256-GCM` using a random 32-byte content key and random 12-byte IV
- for each allowed decryptor, the client generates an ephemeral Curve25519 keypair, computes ECDH with `tweetnacl.scalarMult`, derives a wrapping key via Web Crypto `HKDF-SHA-256`, and wraps the content key with `AES-GCM`
- `/encrypted-payload/get` returns the payload body only when the current user has a matching wrap
- decryption is client-side only: derive mailbox key from password, unwrap content key, decrypt ciphertext, render with the restricted `lite-v1` client parser
- encrypted content does not support implicit parser-based mentions; encrypted replies use generic notification/push previews (`🔒 Шифровка`)
- encrypted comments do not bump public feeds

Key code paths:
- mailbox KDF + per-content encrypt/decrypt: [frontend/src/Utils/mailCrypto.ts](https://github.com/spaceshelter/orbitar/blob/9da38b354dba856618d5878862d5e34b56349dfa/frontend/src/Utils/mailCrypto.ts#L58)
- session unlock cache: [frontend/src/AppState/CryptoSessionStore.ts](https://github.com/spaceshelter/orbitar/blob/9da38b354dba856618d5878862d5e34b56349dfa/frontend/src/AppState/CryptoSessionStore.ts#L5)
- editor encryption flow: [frontend/src/Components/CreateCommentComponent.tsx](https://github.com/spaceshelter/orbitar/blob/9da38b354dba856618d5878862d5e34b56349dfa/frontend/src/Components/CreateCommentComponent.tsx#L188)
- encrypted payload validation and comment create path: [backend/src/api/PostController.ts](https://github.com/spaceshelter/orbitar/blob/9da38b354dba856618d5878862d5e34b56349dfa/backend/src/api/PostController.ts#L45)
- encrypted payload storage: [backend/src/db/repositories/EncryptedPayloadRepository.ts](https://github.com/spaceshelter/orbitar/blob/9da38b354dba856618d5878862d5e34b56349dfa/backend/src/db/repositories/EncryptedPayloadRepository.ts#L12)
- encrypted payload batch fetch: [backend/src/api/EncryptedPayloadController.ts](https://github.com/spaceshelter/orbitar/blob/9da38b354dba856618d5878862d5e34b56349dfa/backend/src/api/EncryptedPayloadController.ts#L19)
- locked render / decrypt / auto-unlock reuse: [frontend/src/Components/EncryptedContentComponent.tsx](https://github.com/spaceshelter/orbitar/blob/9da38b354dba856618d5878862d5e34b56349dfa/frontend/src/Components/EncryptedContentComponent.tsx#L22)
