### PR TITLE
Online users count

### DIFF
--- a/backend/src/api/StatusController.ts
+++ b/backend/src/api/StatusController.ts
@@ -1,5 +1,4 @@
 import { Router } from 'express'
-import { RedisClientType } from 'redis'
 import { Logger } from 'winston'
 
 import SiteManager from '../managers/SiteManager'
@@ -9,16 +8,12 @@ import { OAuth2MiddlewareGenerator } from './OAuth2Middleware'
 import { StatusRequest, StatusResponse } from './types/requests/Status'
 import { Enricher } from './utils/Enricher'
 
-const ONLINE_USERS_KEY = 'online_users'
-const ONLINE_WINDOW_SECONDS = 90 // 3 × 30s polling interval
-
 export default class StatusController {
   public readonly router = Router()
   private readonly siteManager: SiteManager
   private readonly userManager: UserManager
   private readonly logger: Logger
   private readonly enricher: Enricher
-  private readonly redis: RedisClientType
 
   constructor(
     enricher: Enricher,
@@ -26,13 +21,11 @@ export default class StatusController {
     userManager: UserManager,
     oauth: OAuth2MiddlewareGenerator,
     logger: Logger,
-    redis: RedisClientType,
   ) {
     this.siteManager = siteManager
     this.userManager = userManager
     this.enricher = enricher
     this.logger = logger
-    this.redis = redis
     this.router.post('/status', oauth('читать статус'), (req, res) => this.status(req, res))
   }
 
@@ -51,10 +44,12 @@ export default class StatusController {
         return response.error('error', 'Unknown error', 500)
       }
 
-      // track online users via Redis sorted set (score = unix timestamp)
-      const now = Math.floor(Date.now() / 1000)
-      await this.redis.zAdd(ONLINE_USERS_KEY, { score: now, value: String(userId) })
-      const onlineCount = await this.redis.zCount(ONLINE_USERS_KEY, now - ONLINE_WINDOW_SECONDS, '+inf')
+      let onlineCount = 0
+      try {
+        onlineCount = await this.userManager.trackOnline(userId)
+      } catch (err) {
+        this.logger.warn('Failed to track online users', { error: err })
+      }
 
       return response.success({
         user,

--- a/backend/src/api/StatusController.ts
+++ b/backend/src/api/StatusController.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express'
+import { RedisClientType } from 'redis'
 import { Logger } from 'winston'
 
 import SiteManager from '../managers/SiteManager'
@@ -8,12 +9,16 @@ import { OAuth2MiddlewareGenerator } from './OAuth2Middleware'
 import { StatusRequest, StatusResponse } from './types/requests/Status'
 import { Enricher } from './utils/Enricher'
 
+const ONLINE_USERS_KEY = 'online_users'
+const ONLINE_WINDOW_SECONDS = 90 // 3 × 30s polling interval
+
 export default class StatusController {
   public readonly router = Router()
   private readonly siteManager: SiteManager
   private readonly userManager: UserManager
   private readonly logger: Logger
   private readonly enricher: Enricher
+  private readonly redis: RedisClientType
 
   constructor(
     enricher: Enricher,
@@ -21,11 +26,13 @@ export default class StatusController {
     userManager: UserManager,
     oauth: OAuth2MiddlewareGenerator,
     logger: Logger,
+    redis: RedisClientType,
   ) {
     this.siteManager = siteManager
     this.userManager = userManager
     this.enricher = enricher
     this.logger = logger
+    this.redis = redis
     this.router.post('/status', oauth('читать статус'), (req, res) => this.status(req, res))
   }
 
@@ -44,9 +51,15 @@ export default class StatusController {
         return response.error('error', 'Unknown error', 500)
       }
 
+      // track online users via Redis sorted set (score = unix timestamp)
+      const now = Math.floor(Date.now() / 1000)
+      await this.redis.zAdd(ONLINE_USERS_KEY, { score: now, value: String(userId) })
+      const onlineCount = await this.redis.zCount(ONLINE_USERS_KEY, now - ONLINE_WINDOW_SECONDS, '+inf')
+
       return response.success({
         user,
         ...stats,
+        onlineCount,
       })
     } catch (err) {
       this.logger.error(err)

--- a/backend/src/api/types/requests/Status.ts
+++ b/backend/src/api/types/requests/Status.ts
@@ -12,4 +12,5 @@ export type StatusResponse = {
     unread: number
     visible: number
   }
+  onlineCount: number
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -228,6 +228,7 @@ const requests = [
     userManager,
     oauthMiddlewareGenerator,
     logger.child({ service: 'STATUS' }),
+    redis.client,
   ),
   new VoteController(voteManager, userManager, oauthMiddlewareGenerator, logger.child({ service: 'VOTE' })),
   new UserController(

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -227,7 +227,7 @@ const requests = [
     siteManager,
     userManager,
     oauthMiddlewareGenerator,
-    logger.child({ service: 'STATUS' }),    
+    logger.child({ service: 'STATUS' }),
   ),
   new VoteController(voteManager, userManager, oauthMiddlewareGenerator, logger.child({ service: 'VOTE' })),
   new UserController(

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -227,8 +227,7 @@ const requests = [
     siteManager,
     userManager,
     oauthMiddlewareGenerator,
-    logger.child({ service: 'STATUS' }),
-    redis.client,
+    logger.child({ service: 'STATUS' }),    
   ),
   new VoteController(voteManager, userManager, oauthMiddlewareGenerator, logger.child({ service: 'VOTE' })),
   new UserController(

--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -267,6 +267,19 @@ export default class UserManager {
     return isActive === 'true'
   }
 
+  private static readonly ONLINE_USERS_KEY = 'online_users'
+  private static readonly ONLINE_WINDOW_SECONDS = 90 // 3 × 30s polling interval
+
+  async trackOnline(userId: number): Promise<number> {
+    const now = Math.floor(Date.now() / 1000)
+    const pipeline = this.redis.multi()
+    pipeline.zRemRangeByScore(UserManager.ONLINE_USERS_KEY, '-inf', now - UserManager.ONLINE_WINDOW_SECONDS)
+    pipeline.zAdd(UserManager.ONLINE_USERS_KEY, { score: now, value: String(userId) })
+    pipeline.zCard(UserManager.ONLINE_USERS_KEY)
+    const results = await pipeline.exec()
+    return results[2] as number
+  }
+
   async getUserRatingBySubsite(userId: number): Promise<UserRatingBySubsite> {
     const ratingBySubsite: UserRatingOnSubsite[] = await this.voteRepository.getUserRatingOnSubsites(userId)
     const postRatingBySubsite: Record<string, number> = {}

--- a/frontend/src/API/APIHelper.ts
+++ b/frontend/src/API/APIHelper.ts
@@ -109,6 +109,7 @@ export default class APIHelper {
     this.appState.setWatchCommentsCount(status.watch.comments)
     this.appState.setUnreadNotificationsCount(status.notifications.unread)
     this.appState.setVisibleNotificationsCount(status.notifications.visible)
+    this.appState.setOnlineCount(status.onlineCount)
     this.appState.setAppLoadingState(AppLoadingState.authorized)
     this.appState.setLatestHash(fingerprint || '')
   }

--- a/frontend/src/API/AuthAPI.ts
+++ b/frontend/src/API/AuthAPI.ts
@@ -12,6 +12,7 @@ export type StatusResponse = {
     unread: number
     visible: number
   }
+  onlineCount: number
 }
 
 type SignInRequest = Record<string, unknown>

--- a/frontend/src/AppState/AppState.tsx
+++ b/frontend/src/AppState/AppState.tsx
@@ -71,6 +71,9 @@ export class AppState {
     @observable
     watchCommentsCount = 0;
 
+    @observable
+    onlineCount = 0;
+
     @observable.struct
     subscriptions: SiteWithUserInfo[] | undefined = undefined;
 
@@ -175,6 +178,11 @@ export class AppState {
     @action
     setWatchCommentsCount(value: number) {
         this.watchCommentsCount = value;
+    }
+
+    @action
+    setOnlineCount(value: number) {
+        this.onlineCount = value;
     }
 
     @action

--- a/frontend/src/Components/Topbar.module.scss
+++ b/frontend/src/Components/Topbar.module.scss
@@ -26,19 +26,16 @@
     padding-right: 28px;
   }
   .onlineCount {
-  display: flex;
-  align-items: center;  
-  color: var(--fg);
-  gap: 5px;
-  cursor: default;
+    display: flex;
+    align-items: center;
+    color: var(--fg);
+    gap: 4px;
+    cursor: default;
+    font-size: 16px;
 
-  &::before {
-    content: '';
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background-color: #4caf50;
+    span {
+      font-size: 20px;
+      color: var(--primary);
     }
   }
 

--- a/frontend/src/Components/Topbar.module.scss
+++ b/frontend/src/Components/Topbar.module.scss
@@ -25,6 +25,22 @@
   .right {
     padding-right: 28px;
   }
+  .onlineCount {
+  display: flex;
+  align-items: center;  
+  color: var(--fg);
+  gap: 5px;
+  cursor: default;
+
+  &::before {
+    content: '';
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background-color: #4caf50;
+    }
+  }
 
   //:global{ }
 
@@ -107,3 +123,5 @@ button.notificationButton {
   font-weight: normal;
   gap: 0;
 }
+
+

--- a/frontend/src/Components/Topbar.module.scss
+++ b/frontend/src/Components/Topbar.module.scss
@@ -120,5 +120,3 @@ button.notificationButton {
   font-weight: normal;
   gap: 0;
 }
-
-

--- a/frontend/src/Components/Topbar.tsx
+++ b/frontend/src/Components/Topbar.tsx
@@ -136,8 +136,10 @@ const WatchButton = observer(() => {
 
 const OnlineCount = observer(() => {
   const { onlineCount } = useAppState()
+  if (!onlineCount) return null
   return (
     <div className={styles.onlineCount} title='Пользователей онлайн'>
+      <span className='i i-user' />
       {onlineCount}
     </div>
   )

--- a/frontend/src/Components/Topbar.tsx
+++ b/frontend/src/Components/Topbar.tsx
@@ -63,6 +63,7 @@ export const Topbar = observer((props: TopbarProps) => {
         </div>
 
         <div className={styles.right}>
+          <OnlineCount />
           <SearchButton />
           <WatchButton />
           <NotificationsButton onClick={handleNotificationsToggle} />
@@ -130,6 +131,15 @@ const WatchButton = observer(() => {
       <HotIcon />
       <span className={styles.label}>{watchCommentsCount > 0 ? watchCommentsCount : ''}</span>
     </ReloadingLink>
+  )
+})
+
+const OnlineCount = observer(() => {
+  const { onlineCount } = useAppState()
+  return (
+    <div className={styles.onlineCount} title='Пользователей онлайн'>
+      {onlineCount}
+    </div>
   )
 })
 


### PR DESCRIPTION
LazyKarlson and Claude)

Each active user hits /status every 30s — we use this as a heartbeat.
On each request, backend updates a Redis Sorted Set (ZADD online_users <timestamp> <userId>) and counts users seen in the last 90 seconds (ZCOUNT). The result is returned in the /status response and displayed in the topbar's right section with a green dot.

Changes:

StatusController — ZADD + ZCOUNT on every /status request
StatusResponse — new onlineCount field
AppState — observable onlineCount + setOnlineCount action
Topbar — OnlineCount component in .right