### PR TITLE
colored post author username in comments

### DIFF
--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -32,6 +32,7 @@ interface CommentProps {
   unreadOnly?: boolean
   hideRating?: boolean
   currentUsername?: string
+  postAuthorUsername?: string
 }
 
 export default function CommentComponent(props: CommentProps) {
@@ -133,6 +134,7 @@ export default function CommentComponent(props: CommentProps) {
           postLinkIsNew={props.unreadOnly}
           date={created}
           editFlag={editFlag}
+          isPostAuthor={!!props.postAuthorUsername && author.username === props.postAuthorUsername}
         />
         {editingText === false ? (
           showHistory ? (
@@ -280,6 +282,7 @@ export default function CommentComponent(props: CommentProps) {
                 unreadOnly={props.unreadOnly}
                 idx={idx}
                 currentUsername={props.currentUsername}
+                postAuthorUsername={props.postAuthorUsername}
               />
             ))
           ) : (

--- a/frontend/src/Components/SignatureComponent.module.scss
+++ b/frontend/src/Components/SignatureComponent.module.scss
@@ -32,6 +32,16 @@
     }
   }
 
+  .postAuthor {
+    color: var(--primary);
+    &:before {
+      color: var(--primary);
+    }
+    &:hover {
+      color: var(--primaryHover);
+    }
+  }
+
   .toggleHistory {
     border: none;
     background: none;

--- a/frontend/src/Components/SignatureComponent.module.scss
+++ b/frontend/src/Components/SignatureComponent.module.scss
@@ -33,7 +33,7 @@
   }
 
   .postAuthor {
-    color: var(--primary);
+    &,
     &:before {
       color: var(--primary);
     }

--- a/frontend/src/Components/SignatureComponent.tsx
+++ b/frontend/src/Components/SignatureComponent.tsx
@@ -23,6 +23,7 @@ interface SignatureComponentProps {
   parentCommentAuthor?: string
   date: Date
   commentId?: number
+  isPostAuthor?: boolean
 }
 
 export const SignatureComponent = (props: SignatureComponentProps) => {
@@ -35,7 +36,7 @@ export const SignatureComponent = (props: SignatureComponentProps) => {
       ) : (
         ''
       )}
-      <Username className={styles.username} user={props.author} /> •{' '}
+      <Username className={props.isPostAuthor ? styles.postAuthor : styles.username} user={props.author} /> •{' '}
       <PostLink post={props.postLink} commentId={props.commentId}>
         <DateComponent date={props.date} />
       </PostLink>

--- a/frontend/src/Components/SignatureComponent.tsx
+++ b/frontend/src/Components/SignatureComponent.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 
 import { EditFlag } from '@api/PostAPI'
+import classNames from 'classnames'
 
 import { PostLinkInfo } from '../Types/PostInfo'
 import { UserBaseInfo } from '../Types/UserInfo'
@@ -36,7 +37,8 @@ export const SignatureComponent = (props: SignatureComponentProps) => {
       ) : (
         ''
       )}
-      <Username className={props.isPostAuthor ? styles.postAuthor : styles.username} user={props.author} /> •{' '}
+      <Username className={classNames(styles.username, props.isPostAuthor && styles.postAuthor)} user={props.author} />{' '}
+      •{' '}
       <PostLink post={props.postLink} commentId={props.commentId}>
         <DateComponent date={props.date} />
       </PostLink>

--- a/frontend/src/Pages/PostPage.tsx
+++ b/frontend/src/Pages/PostPage.tsx
@@ -146,6 +146,7 @@ export default function PostPage() {
                     unreadOnly={unreadOnly}
                     onEdit={handleCommentEdit}
                     currentUsername={userInfo?.username}
+                    postAuthorUsername={post.author.username}
                   />
                 ))
               ) : error ? (


### PR DESCRIPTION
The comment author's username is highlighted in var(--primary) when they are the post author; otherwise it stays var(--fgSoftest).

Implementation:

PostPage — passes postAuthorUsername={post.author.username} to the root CommentComponent
CommentComponent — accepts postAuthorUsername, computes isPostAuthor by comparing it to the comment author, passes both down recursively to the full comment tree
SignatureComponent — accepts isPostAuthor, applies classNames(styles.username, isPostAuthor && styles.postAuthor)
SignatureComponent.module.scss — .postAuthor modifier overrides color to var(--primary) on top of the base .username styles
![2026-03-18 12 50 17 orbitar local af4ad8960845](https://github.com/user-attachments/assets/3046eb9e-3014-471d-9b3b-45211544a634)

