### PR TITLE
Display Orbitar Award trophy badges on user profile

### DIFF
--- a/backend/src/api/UserController.ts
+++ b/backend/src/api/UserController.ts
@@ -209,7 +209,7 @@ export default class UserController {
       const numberOfComments = (await this.postManager.getUserCommentsTotal(profileInfo.id, '')) || 0
       const visitedDaysAgo = await this.userManager.getUserVisitedDaysAgo(profileInfo.id)
       const hasOwnApps = await this.oauthManager.hasOwnApps(profileInfo.id)
-      const orbitorAwardWins = await this.userManager.getOrbitorAwardWins(profileInfo.username)
+      const orbitarAwardWins = await this.userManager.getOrbitarAwardWins(profileInfo.username)
 
       // if viewing own profile, get available invites number
       let numberOfInvitesAvailable = 0
@@ -248,7 +248,7 @@ export default class UserController {
         publicKey,
         visitedDaysAgo,
         hasOwnApps,
-        orbitorAwardWins: orbitorAwardWins.length ? orbitorAwardWins : undefined,
+        orbitarAwardWins: orbitarAwardWins.length ? orbitarAwardWins : undefined,
       })
     } catch (error) {
       this.logger.error('Could not get user profile', { username })

--- a/backend/src/api/UserController.ts
+++ b/backend/src/api/UserController.ts
@@ -209,6 +209,7 @@ export default class UserController {
       const numberOfComments = (await this.postManager.getUserCommentsTotal(profileInfo.id, '')) || 0
       const visitedDaysAgo = await this.userManager.getUserVisitedDaysAgo(profileInfo.id)
       const hasOwnApps = await this.oauthManager.hasOwnApps(profileInfo.id)
+      const orbitorAwardWins = await this.userManager.getOrbitorAwardWins(profileInfo.username)
 
       // if viewing own profile, get available invites number
       let numberOfInvitesAvailable = 0
@@ -247,6 +248,7 @@ export default class UserController {
         publicKey,
         visitedDaysAgo,
         hasOwnApps,
+        orbitorAwardWins: orbitorAwardWins.length ? orbitorAwardWins : undefined,
       })
     } catch (error) {
       this.logger.error('Could not get user profile', { username })

--- a/backend/src/api/types/requests/UserProfile.ts
+++ b/backend/src/api/types/requests/UserProfile.ts
@@ -22,7 +22,7 @@ export type UserProfileResponse = {
   hasOwnApps: boolean
 
   visitedDaysAgo: number
-  orbitorAwardWins?: { awardNum: number; postId?: number }[]
+  orbitarAwardWins?: { awardNum: number; postId?: number }[]
 }
 
 export type TrialProgressDebugInfo = {

--- a/backend/src/api/types/requests/UserProfile.ts
+++ b/backend/src/api/types/requests/UserProfile.ts
@@ -22,6 +22,7 @@ export type UserProfileResponse = {
   hasOwnApps: boolean
 
   visitedDaysAgo: number
+  orbitorAwardWins?: { awardNum: number; postId?: number }[]
 }
 
 export type TrialProgressDebugInfo = {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -166,6 +166,7 @@ const userManager = new UserManager(
   redis.client,
   config.site,
   logger.child({ service: 'USER' }),
+  pollRepository,
 )
 const inviteManager = new InviteManager(inviteRepository, theParser, userManager)
 siteManager = new SiteManager(siteRepository, userManager)

--- a/backend/src/db/repositories/PollRepository.ts
+++ b/backend/src/db/repositories/PollRepository.ts
@@ -134,6 +134,27 @@ export default class PollRepository {
     await connection.query(`UPDATE polls SET ${setClauses.join(', ')} WHERE poll_id = ?`, params)
   }
 
+  /**
+   * Returns the latest completed poll for each unique question matching 'Премия Орбитара #%'.
+   * Used to compute Orbitor Award winners.
+   */
+  async getOrbitorAwardPolls(awardAuthorId: number): Promise<PollRaw[]> {
+    return this.db.fetchAll<PollRaw>(
+      `SELECT p.*
+       FROM polls p
+       INNER JOIN (
+         SELECT question, MAX(created_at) AS latest_created_at
+         FROM polls
+         WHERE author_id = :awardAuthorId
+           AND question LIKE 'Премия Орбитара #%'
+           AND expires_at IS NOT NULL
+           AND expires_at < NOW()
+         GROUP BY question
+       ) AS latest ON p.question = latest.question AND p.created_at = latest.latest_created_at`,
+      { awardAuthorId },
+    )
+  }
+
   async getVoters(pollId: number, optionId: number): Promise<UserBaseEntity[]> {
     const voters = await this.db.fetchAll<UserBaseEntity>(
       `SELECT u.user_id as id, u.username, u.gender 

--- a/backend/src/db/repositories/PollRepository.ts
+++ b/backend/src/db/repositories/PollRepository.ts
@@ -136,9 +136,9 @@ export default class PollRepository {
 
   /**
    * Returns the latest completed poll for each unique question matching 'Премия Орбитара #%'.
-   * Used to compute Orbitor Award winners.
+   * Used to compute Orbitar Award winners.
    */
-  async getOrbitorAwardPolls(awardAuthorId: number): Promise<PollRaw[]> {
+  async getOrbitarAwardPolls(awardAuthorId: number): Promise<PollRaw[]> {
     return this.db.fetchAll<PollRaw>(
       `SELECT p.*
        FROM polls p

--- a/backend/src/db/repositories/PostRepository.ts
+++ b/backend/src/db/repositories/PostRepository.ts
@@ -80,6 +80,13 @@ export default class PostRepository {
     return await this.db.fetchOne<PostRaw>('select * from posts where post_id=:post_id', { post_id: postId })
   }
 
+  async getOrbitorAwardPosts(authorId: number): Promise<{ post_id: number; title: string }[]> {
+    return this.db.fetchAll<{ post_id: number; title: string }>(
+      `SELECT post_id, title FROM posts WHERE author_id = :authorId AND title LIKE 'Премия Орбитара #%'`,
+      { authorId },
+    )
+  }
+
   async getPostsTotal(siteId: number): Promise<number> {
     const result = await this.db.query(`select count(*) cnt from posts where site_id=:site_id`, { site_id: siteId })
     if (!result || !result[0]) {

--- a/backend/src/db/repositories/PostRepository.ts
+++ b/backend/src/db/repositories/PostRepository.ts
@@ -80,7 +80,7 @@ export default class PostRepository {
     return await this.db.fetchOne<PostRaw>('select * from posts where post_id=:post_id', { post_id: postId })
   }
 
-  async getOrbitorAwardPosts(authorId: number): Promise<{ post_id: number; title: string }[]> {
+  async getOrbitarAwardPosts(authorId: number): Promise<{ post_id: number; title: string }[]> {
     return this.db.fetchAll<{ post_id: number; title: string }>(
       `SELECT post_id, title FROM posts WHERE author_id = :authorId AND title LIKE 'Премия Орбитара #%'`,
       { authorId },

--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -7,6 +7,7 @@ import { FeedSorting } from '../api/types/entities/common'
 import { TrialProgressDebugInfo } from '../api/types/requests/UserProfile'
 import { config, SiteConfig } from '../config'
 import CommentRepository from '../db/repositories/CommentRepository'
+import PollRepository from '../db/repositories/PollRepository'
 import PostRepository from '../db/repositories/PostRepository'
 import UserCredentials from '../db/repositories/UserCredentials'
 import UserRepository from '../db/repositories/UserRepository'
@@ -53,6 +54,7 @@ export default class UserManager {
   private voteRepository: VoteRepository
   private commentRepository: CommentRepository
   private postRepository: PostRepository
+  private pollRepository: PollRepository
   private notificationManager: NotificationManager
   private webPushRepository: WebPushRepository
   private readonly redis: RedisClientType
@@ -61,6 +63,15 @@ export default class UserManager {
   private readonly logger: Logger
   private readonly mailLogger: Logger
   private readonly parser: TheParser
+
+  private static readonly ORBITOR_AWARD_AUTHOR_ID = 2154
+  private static readonly ORBITOR_AWARD_CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24h
+
+  private orbitorAwardWinnersCache: {
+    wins: Map<string, { awardNum: number; postId?: number }[]>
+    lastUpdatedTs: number
+  } = { wins: new Map(), lastUpdatedTs: 0 }
+  private orbitorAwardRefreshing = false
 
   private cachedNumActiveUsersThatCanVote = {
     expirationMs: 1000 * 60 * 60 /* 1 hour */,
@@ -91,12 +102,14 @@ export default class UserManager {
     redis: RedisClientType,
     siteConfig: SiteConfig,
     logger: Logger,
+    pollRepository: PollRepository,
   ) {
     this.credentialsRepository = credentialsRepository
     this.userRepository = userRepository
     this.voteRepository = voteRepository
     this.commentRepository = commentRepository
     this.postRepository = postRepository
+    this.pollRepository = pollRepository
     this.notificationManager = notificationManager
     this.webPushRepository = webPushRepository
     this.userCache = userCache
@@ -105,6 +118,72 @@ export default class UserManager {
     this.logger = logger
     this.mailLogger = logger.child({ service: 'MAIL' })
     this.parser = parser
+  }
+
+  private async refreshOrbitorAwardWinners(): Promise<void> {
+    if (this.orbitorAwardRefreshing) {
+      return
+    }
+    this.orbitorAwardRefreshing = true
+    try {
+      const [polls, awardPosts] = await Promise.all([
+        this.pollRepository.getOrbitorAwardPolls(UserManager.ORBITOR_AWARD_AUTHOR_ID),
+        this.postRepository.getOrbitorAwardPosts(UserManager.ORBITOR_AWARD_AUTHOR_ID),
+      ])
+
+      // Build map: awardNum → postId
+      const postIdByAwardNum = new Map<number, number>()
+      for (const post of awardPosts) {
+        const num = parseInt(post.title.match(/#(\d+)/)?.[1] ?? '', 10)
+        if (!isNaN(num)) {
+          postIdByAwardNum.set(num, post.post_id)
+        }
+      }
+
+      const wins = new Map<string, { awardNum: number; postId?: number }[]>()
+      for (const poll of polls) {
+        const options: string[] = Array.isArray(poll.options)
+          ? poll.options
+          : (JSON.parse(poll.options as unknown as string) as string[])
+        let maxVotes = -1
+        let winnerIdx = -1
+        for (let i = 0; i < options.length; i++) {
+          const votes = (poll[`opt${i}`] as number) || 0
+          if (votes > maxVotes) {
+            maxVotes = votes
+            winnerIdx = i
+          }
+        }
+        if (winnerIdx >= 0 && maxVotes > 0) {
+          const winner = options[winnerIdx]
+          const awardNum = parseInt(poll.question.match(/#(\d+)/)?.[1] ?? '', 10)
+          const entry: { awardNum: number; postId?: number } = { awardNum: isNaN(awardNum) ? 0 : awardNum }
+          const postId = postIdByAwardNum.get(entry.awardNum)
+          if (postId) {
+            entry.postId = postId
+          }
+          const arr = wins.get(winner) || []
+          arr.push(entry)
+          wins.set(winner, arr)
+        }
+      }
+      this.orbitorAwardWinnersCache = { wins, lastUpdatedTs: Date.now() }
+      this.logger.info(`Orbitor Award winners cache refreshed: ${wins.size} winner(s)`)
+    } finally {
+      this.orbitorAwardRefreshing = false
+    }
+  }
+
+  async getOrbitorAwardWins(username: string): Promise<{ awardNum: number; postId?: number }[]> {
+    const isStale = Date.now() - this.orbitorAwardWinnersCache.lastUpdatedTs > UserManager.ORBITOR_AWARD_CACHE_TTL_MS
+    if (isStale && !this.orbitorAwardRefreshing) {
+      try {
+        await this.refreshOrbitorAwardWinners()
+      } catch (e) {
+        this.logger.error('Failed to refresh Orbitor Award winners cache', { error: e })
+      }
+    }
+    return this.orbitorAwardWinnersCache.wins.get(username) || []
   }
 
   // TODO migrate all usage to direct calls to userCache

--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -64,14 +64,15 @@ export default class UserManager {
   private readonly mailLogger: Logger
   private readonly parser: TheParser
 
-  private static readonly ORBITOR_AWARD_AUTHOR_ID = 2154
-  private static readonly ORBITOR_AWARD_CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24h
+  
+  private static readonly ORBITAR_AWARD_AUTHOR_ID = 2154 // OrbitarPremium bot user ID
+  private static readonly ORBITAR_AWARD_CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24h
 
-  private orbitorAwardWinnersCache: {
+  private orbitarAwardWinnersCache: {
     wins: Map<string, { awardNum: number; postId?: number }[]>
     lastUpdatedTs: number
   } = { wins: new Map(), lastUpdatedTs: 0 }
-  private orbitorAwardRefreshing = false
+  private orbitarAwardRefreshing = false
 
   private cachedNumActiveUsersThatCanVote = {
     expirationMs: 1000 * 60 * 60 /* 1 hour */,
@@ -120,15 +121,15 @@ export default class UserManager {
     this.parser = parser
   }
 
-  private async refreshOrbitorAwardWinners(): Promise<void> {
-    if (this.orbitorAwardRefreshing) {
+  private async refreshOrbitarAwardWinners(): Promise<void> {
+    if (this.orbitarAwardRefreshing) {
       return
     }
-    this.orbitorAwardRefreshing = true
+    this.orbitarAwardRefreshing = true
     try {
       const [polls, awardPosts] = await Promise.all([
-        this.pollRepository.getOrbitorAwardPolls(UserManager.ORBITOR_AWARD_AUTHOR_ID),
-        this.postRepository.getOrbitorAwardPosts(UserManager.ORBITOR_AWARD_AUTHOR_ID),
+        this.pollRepository.getOrbitarAwardPolls(UserManager.ORBITAR_AWARD_AUTHOR_ID),
+        this.postRepository.getOrbitarAwardPosts(UserManager.ORBITAR_AWARD_AUTHOR_ID),
       ])
 
       // Build map: awardNum → postId
@@ -167,23 +168,23 @@ export default class UserManager {
           wins.set(winner, arr)
         }
       }
-      this.orbitorAwardWinnersCache = { wins, lastUpdatedTs: Date.now() }
-      this.logger.info(`Orbitor Award winners cache refreshed: ${wins.size} winner(s)`)
+      this.orbitarAwardWinnersCache = { wins, lastUpdatedTs: Date.now() }
+      this.logger.info(`Orbitar Award winners cache refreshed: ${wins.size} winner(s)`)
     } finally {
-      this.orbitorAwardRefreshing = false
+      this.orbitarAwardRefreshing = false
     }
   }
 
-  async getOrbitorAwardWins(username: string): Promise<{ awardNum: number; postId?: number }[]> {
-    const isStale = Date.now() - this.orbitorAwardWinnersCache.lastUpdatedTs > UserManager.ORBITOR_AWARD_CACHE_TTL_MS
-    if (isStale && !this.orbitorAwardRefreshing) {
+  async getOrbitarAwardWins(username: string): Promise<{ awardNum: number; postId?: number }[]> {
+    const isStale = Date.now() - this.orbitarAwardWinnersCache.lastUpdatedTs > UserManager.ORBITAR_AWARD_CACHE_TTL_MS
+    if (isStale && !this.orbitarAwardRefreshing) {
       try {
-        await this.refreshOrbitorAwardWinners()
+        await this.refreshOrbitarAwardWinners()
       } catch (e) {
-        this.logger.error('Failed to refresh Orbitor Award winners cache', { error: e })
+        this.logger.error('Failed to refresh Orbitar Award winners cache', { error: e })
       }
     }
-    return this.orbitorAwardWinnersCache.wins.get(username) || []
+    return this.orbitarAwardWinnersCache.wins.get(username) || []
   }
 
   // TODO migrate all usage to direct calls to userCache

--- a/frontend/src/API/UserAPI.ts
+++ b/frontend/src/API/UserAPI.ts
@@ -29,7 +29,7 @@ type UserProfileResponse = {
   publicKey: string
   hasOwnApps: boolean
   visitedDaysAgo: number
-  orbitorAwardWins?: { awardNum: number; postId?: number }[]
+  orbitarAwardWins?: { awardNum: number; postId?: number }[]
 }
 type UserProfilePostsRequest = {
   username: string

--- a/frontend/src/API/UserAPI.ts
+++ b/frontend/src/API/UserAPI.ts
@@ -29,6 +29,7 @@ type UserProfileResponse = {
   publicKey: string
   hasOwnApps: boolean
   visitedDaysAgo: number
+  orbitorAwardWins?: { awardNum: number; postId?: number }[]
 }
 type UserProfilePostsRequest = {
   username: string

--- a/frontend/src/API/UserAPIHelper.ts
+++ b/frontend/src/API/UserAPIHelper.ts
@@ -17,6 +17,7 @@ export type UserProfileResult = {
   publicKey: string
   visitedDaysAgo: number
   hasOwnApps: boolean
+  orbitorAwardWins?: { awardNum: number; postId?: number }[]
 }
 
 export default class UserAPIHelper {

--- a/frontend/src/API/UserAPIHelper.ts
+++ b/frontend/src/API/UserAPIHelper.ts
@@ -17,7 +17,7 @@ export type UserProfileResult = {
   publicKey: string
   visitedDaysAgo: number
   hasOwnApps: boolean
-  orbitorAwardWins?: { awardNum: number; postId?: number }[]
+  orbitarAwardWins?: { awardNum: number; postId?: number }[]
 }
 
 export default class UserAPIHelper {

--- a/frontend/src/Pages/UserPage.module.scss
+++ b/frontend/src/Pages/UserPage.module.scss
@@ -64,6 +64,14 @@
 
 .username {
   font-size: 40px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.awardBadge {
+  font-size: 24px;
+  cursor: pointer;
 }
 
 .name {

--- a/frontend/src/Pages/UserPage.module.scss
+++ b/frontend/src/Pages/UserPage.module.scss
@@ -70,8 +70,7 @@
 }
 
 .awardBadge {
-  font-size: 24px;
-  cursor: pointer;
+  font-size: 24px;  
 }
 
 .name {

--- a/frontend/src/Pages/UserPage.tsx
+++ b/frontend/src/Pages/UserPage.tsx
@@ -111,7 +111,7 @@ export const UserPage = observer(() => {
             <div>
               <div className={styles.username}>
                 {user.username}
-                {profile.orbitorAwardWins?.map(({ awardNum, postId }) =>
+                {profile.orbitarAwardWins?.map(({ awardNum, postId }) =>
                   postId ? (
                     <Link
                       key={awardNum}

--- a/frontend/src/Pages/UserPage.tsx
+++ b/frontend/src/Pages/UserPage.tsx
@@ -109,7 +109,25 @@ export const UserPage = observer(() => {
         <div className={styles.header}>
           <div className={styles.row}>
             <div>
-              <div className={styles.username}>{user.username}</div>
+              <div className={styles.username}>
+                {user.username}
+                {profile.orbitorAwardWins?.map(({ awardNum, postId }) =>
+                  postId ? (
+                    <Link
+                      key={awardNum}
+                      className={styles.awardBadge}
+                      to={`/p${postId}`}
+                      title={`Лауреат Премии Орбитара #${awardNum}`}
+                    >
+                      🏆
+                    </Link>
+                  ) : (
+                    <span key={awardNum} className={styles.awardBadge} title={`Лауреат Премии Орбитара #${awardNum}`}>
+                      🏆
+                    </span>
+                  ),
+                )}
+              </div>
             </div>
 
             <div className={styles.karma}>


### PR DESCRIPTION
Users who won the community "Премия Орбитара" (Orbitar Award) polls now have 🏆 trophy badges displayed next to their username on the profile page. Each badge links to the corresponding award announcement post and shows the award number in a tooltip on hover.

How it works
The Orbitor Award is determined by community polls created by a dedicated account with questions matching the pattern Премия Орбитара #N. The winner is the option (username) with the most votes in the completed poll.

Winner resolution:
`PollRepository.getOrbitorAwardPolls()` fetches the latest completed poll for each unique award question (deduplicates by `GROUP BY question / MAX(created_at)`).
`PostRepository.getOrbitorAwardPosts()` fetches award announcement posts by the same author, matching the same title pattern.
`UserManager.refreshOrbitorAwardWinners()` runs both queries in parallel (`Promise.all`), extracts the award number from each question/title via `/#(\d+)/` regex, determines the winner by `argmax(opt0…opt31)`, and correlates polls with posts by award number to attach a  `postId` to each win.

Caching:
The result is stored as a process-level in-memory `Map<username, {awardNum, postId?}[]>` — one shared cache for all users.
The cache is refreshed lazily: on any profile request, if more than 24 hours have passed since the last update, a refresh is triggered.
A boolean `orbitorAwardRefreshing` flag prevents concurrent refreshes under parallel requests.
The cache is lost on server restart and rebuilt on the first profile request.

API:
`GET /user/profile` response gains an optional field `orbitorAwardWins: {awardNum: number, postId?: number}[]`, omitted entirely when the user has no wins.

Frontend:
 `UserPage` renders one 🏆 badge per win next to the username.
If a matching post is found, the badge is a `<Link to="/p{postId}">` with `title="Лауреат Премии Орбитара #N"`.
If no post is found (fallback), it renders as a `<span>` with the same tooltip.