### PR TITLE
Add Redis-backed activity feed

### DIFF
--- a/backend/src/api/ActivityController.ts
+++ b/backend/src/api/ActivityController.ts
@@ -1,0 +1,44 @@
+import { Router } from 'express'
+import Joi from 'joi'
+import { Logger } from 'winston'
+
+import ActivityManager from '../managers/ActivityManager'
+import { APIRequest, APIResponse, validate } from './ApiMiddleware'
+import { OAuth2MiddlewareGenerator } from './OAuth2Middleware'
+import { ActivityFeedRequest, ActivityFeedResponse } from './types/requests/ActivityFeed'
+
+export default class ActivityController {
+  public readonly router = Router()
+  private readonly activityManager: ActivityManager
+  private readonly logger: Logger
+
+  constructor(activityManager: ActivityManager, oauth: OAuth2MiddlewareGenerator, logger: Logger) {
+    this.activityManager = activityManager
+    this.logger = logger
+
+    const activityFeedSchema = Joi.object<ActivityFeedRequest>({
+      after_id: Joi.number().integer().optional(),
+      limit: Joi.number().integer().min(1).max(100).default(100),
+    })
+
+    this.router.post('/feed/activity', oauth('чтение ленты активности'), validate(activityFeedSchema), (req, res) =>
+      this.getActivity(req, res),
+    )
+  }
+
+  async getActivity(request: APIRequest<ActivityFeedRequest>, response: APIResponse<ActivityFeedResponse>) {
+    if (!request.session.data.userId) {
+      return response.authRequired()
+    }
+
+    const { after_id: afterId, limit } = request.body
+
+    try {
+      const result = await this.activityManager.getPage(afterId, limit)
+      response.success(result)
+    } catch (err) {
+      this.logger.error('Activity feed error', { error: err, after_id: afterId, limit })
+      return response.error('error', 'Unknown error', 500)
+    }
+  }
+}

--- a/backend/src/api/InviteController.ts
+++ b/backend/src/api/InviteController.ts
@@ -6,6 +6,7 @@ import { Logger } from 'winston'
 
 import CodeError from '../CodeError'
 import { InviteRawWithIssuer } from '../db/types/InviteRaw'
+import ActivityManager from '../managers/ActivityManager'
 import InviteManager from '../managers/InviteManager'
 import UserManager from '../managers/UserManager'
 import { APIRequest, APIResponse, joiPassword, joiUsername, validate } from './ApiMiddleware'
@@ -25,6 +26,7 @@ export default class InviteController {
   public router = Router()
   private inviteManager: InviteManager
   private userManager: UserManager
+  private activityManager: ActivityManager
   private enricher: Enricher
   private logger: Logger
 
@@ -32,11 +34,13 @@ export default class InviteController {
     inviteManager: InviteManager,
     userManager: UserManager,
     enricher: Enricher,
+    activityManager: ActivityManager,
     oauth: OAuth2MiddlewareGenerator,
     logger: Logger,
   ) {
     this.inviteManager = inviteManager
     this.userManager = userManager
+    this.activityManager = activityManager
     this.enricher = enricher
 
     this.logger = logger
@@ -151,6 +155,12 @@ export default class InviteController {
       const passwordHash = await bcrypt.hash(password, 10)
 
       const user = await this.userManager.registerByInvite(code, username, name, email, passwordHash, gender)
+
+      this.activityManager.push({
+        type: 'user:registered',
+        userId: user.id,
+        username: user.username,
+      })
 
       this.logger.info(`Invite ${code} used by #${user.id} @${user.username}`, { invite: code, username })
 

--- a/backend/src/api/PostController.ts
+++ b/backend/src/api/PostController.ts
@@ -5,6 +5,7 @@ import { APIError, AuthenticationError, RateLimitError } from 'openai'
 import { Logger } from 'winston'
 
 import CodeError from '../CodeError'
+import ActivityManager from '../managers/ActivityManager'
 import FeedManager from '../managers/FeedManager'
 import PostManager from '../managers/PostManager'
 import SiteManager from '../managers/SiteManager'
@@ -41,6 +42,7 @@ export default class PostController {
   private readonly userManager: UserManager
   private readonly siteManager: SiteManager
   private readonly translationManager: TranslationManager
+  private readonly activityManager: ActivityManager
   private readonly logger: Logger
   private readonly enricher: Enricher
 
@@ -79,6 +81,7 @@ export default class PostController {
     siteManager: SiteManager,
     userManager: UserManager,
     translationManager: TranslationManager,
+    activityManager: ActivityManager,
     oauth: OAuth2MiddlewareGenerator,
     logger: Logger,
   ) {
@@ -88,6 +91,7 @@ export default class PostController {
     this.siteManager = siteManager
     this.feedManager = feedManager
     this.translationManager = translationManager
+    this.activityManager = activityManager
     this.logger = logger
 
     const getSchema = Joi.object<PostGetRequest>({
@@ -336,6 +340,15 @@ export default class PostController {
         users,
       } = await this.enricher.enrichRawPosts([postInfo])
 
+      const user = await this.userManager.getById(userId)
+      this.activityManager.push({
+        type: 'post:edited',
+        userId,
+        username: user.username,
+        postId: id,
+        site: postInfo.site,
+      })
+
       this.logger.info(`Post edited by #${userId}`, { user_id: userId, post_id: id, format, content, title })
       response.success({ post, users })
     } catch (err) {
@@ -379,6 +392,15 @@ export default class PostController {
       const {
         posts: [post],
       } = await this.enricher.enrichRawPosts([postInfo])
+
+      const user = await this.userManager.getById(userId)
+      this.activityManager.push({
+        type: 'post:created',
+        userId,
+        username: user.username,
+        postId: postInfo.id,
+        site,
+      })
 
       this.logger.info(`Post created by #${userId}`, { user_id: userId, site, format, content, title })
       response.success({ post })
@@ -459,6 +481,14 @@ export default class PostController {
       comment.canEdit = overrideUserId === userId
 
       const users: Record<number, UserEntity> = { [overrideUserId]: await this.userManager.getById(overrideUserId) }
+
+      this.activityManager.push({
+        type: 'comment:created',
+        userId: overrideUserId,
+        username: users[overrideUserId].username,
+        postId,
+        commentId: commentInfo.id,
+      })
 
       this.logger.info(`Comment created by #${overrideUserId} @${users[overrideUserId].username}`, {
         comment: content,
@@ -595,6 +625,15 @@ export default class PostController {
         allComments: [comment],
         users,
       } = await this.enricher.enrichRawComments([commentInfo], {}, format, () => false)
+
+      const user = await this.userManager.getById(userId)
+      this.activityManager.push({
+        type: 'comment:edited',
+        userId,
+        username: user.username,
+        postId: commentInfo.post,
+        commentId,
+      })
 
       response.success({
         comment: comment,

--- a/backend/src/api/SiteController.ts
+++ b/backend/src/api/SiteController.ts
@@ -4,6 +4,7 @@ import Joi from 'joi'
 import { Logger } from 'winston'
 
 import CodeError from '../CodeError'
+import ActivityManager from '../managers/ActivityManager'
 import FeedManager from '../managers/FeedManager'
 import SiteManager from '../managers/SiteManager'
 import UserManager from '../managers/UserManager'
@@ -23,6 +24,7 @@ export default class SiteController {
   private readonly feedManager: FeedManager
   private readonly siteManager: SiteManager
   private readonly userManager: UserManager
+  private readonly activityManager: ActivityManager
   private readonly enricher: Enricher
 
   // 60 per hour
@@ -37,6 +39,7 @@ export default class SiteController {
     feedManager: FeedManager,
     siteManager: SiteManager,
     userManager: UserManager,
+    activityManager: ActivityManager,
     oauth: OAuth2MiddlewareGenerator,
     logger: Logger,
   ) {
@@ -45,6 +48,7 @@ export default class SiteController {
     this.feedManager = feedManager
     this.siteManager = siteManager
     this.userManager = userManager
+    this.activityManager = activityManager
 
     const siteSchema = Joi.object<SiteRequest>({
       site: Joi.string().required(),
@@ -199,6 +203,14 @@ export default class SiteController {
       }
 
       const siteInfo = await this.siteManager.createSite(userId, site, name)
+
+      const user = await this.userManager.getById(userId)
+      this.activityManager.push({
+        type: 'site:created',
+        userId,
+        username: user.username,
+        site,
+      })
 
       response.success({ site: siteInfo })
     } catch (error) {

--- a/backend/src/api/VoteController.ts
+++ b/backend/src/api/VoteController.ts
@@ -4,6 +4,7 @@ import Joi from 'joi'
 import { RateLimiterMemory } from 'rate-limiter-flexible'
 import { Logger } from 'winston'
 
+import ActivityManager from '../managers/ActivityManager'
 import UserManager from '../managers/UserManager'
 import VoteManager from '../managers/VoteManager'
 import { APIRequest, APIResponse, validate } from './ApiMiddleware'
@@ -17,6 +18,7 @@ export default class VoteController {
   public router = Router()
   private voteManager: VoteManager
   private userManager: UserManager
+  private activityManager: ActivityManager
   private logger: Logger
 
   // 60 requests per two minutes
@@ -36,9 +38,16 @@ export default class VoteController {
     duration: 60 * 60, // Per hour
   })
 
-  constructor(voteManager: VoteManager, userManager: UserManager, oauth: OAuth2MiddlewareGenerator, logger: Logger) {
+  constructor(
+    voteManager: VoteManager,
+    userManager: UserManager,
+    activityManager: ActivityManager,
+    oauth: OAuth2MiddlewareGenerator,
+    logger: Logger,
+  ) {
     this.voteManager = voteManager
     this.userManager = userManager
+    this.activityManager = activityManager
     this.logger = logger
 
     const voteSchema = Joi.object<VoteSetRequest>({
@@ -114,6 +123,33 @@ export default class VoteController {
         user_id: userId,
         item_id: id,
       })
+
+      const user = await this.userManager.getById(userId)
+      const activityType =
+        type === 'post'
+          ? ('vote:post' as const)
+          : type === 'comment'
+            ? ('vote:comment' as const)
+            : ('vote:karma' as const)
+
+      const activityEntry: Parameters<ActivityManager['push']>[0] = {
+        type: activityType,
+        userId,
+        username: user.username,
+        vote: rangedVote,
+      }
+
+      if (type === 'post') {
+        activityEntry.postId = id
+      } else if (type === 'comment') {
+        activityEntry.commentId = id
+      } else if (type === 'user') {
+        const targetUserInfo = await this.userManager.getById(id)
+        activityEntry.targetUserId = id
+        activityEntry.targetUsername = targetUserInfo?.username ?? null
+      }
+
+      this.activityManager.push(activityEntry)
 
       response.success({
         type: type,

--- a/backend/src/api/types/entities/ActivityEntity.ts
+++ b/backend/src/api/types/entities/ActivityEntity.ts
@@ -1,0 +1,27 @@
+export type ActivityActionType =
+  | 'post:created'
+  | 'post:edited'
+  | 'comment:created'
+  | 'comment:edited'
+  | 'vote:post'
+  | 'vote:comment'
+  | 'vote:karma'
+  | 'poll:voted'
+  | 'poll:ended'
+  | 'site:created'
+  | 'user:registered'
+
+export interface ActivityEntry {
+  id: number
+  type: ActivityActionType
+  timestamp: string
+  userId: number | null
+  username: string | null
+  postId?: number | null
+  commentId?: number | null
+  site?: string | null
+  vote?: number | null
+  targetUserId?: number | null
+  targetUsername?: string | null
+  pollId?: number | null
+}

--- a/backend/src/api/types/requests/ActivityFeed.ts
+++ b/backend/src/api/types/requests/ActivityFeed.ts
@@ -1,0 +1,13 @@
+import { ActivityEntry } from '../entities/ActivityEntity'
+
+export interface ActivityFeedRequest {
+  after_id?: number
+  limit?: number
+}
+
+export interface ActivityFeedResponse {
+  entries: ActivityEntry[]
+  oldestId: number | null
+  newestId: number | null
+  limit: number
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,6 +9,7 @@ import helmet from 'helmet'
 import jsonStringify from 'safe-stable-stringify'
 import winston from 'winston'
 
+import ActivityController from './api/ActivityController'
 import { apiMiddleware } from './api/ApiMiddleware'
 import AuthController from './api/AuthController'
 import FeedController from './api/FeedController'
@@ -40,6 +41,7 @@ import UserCredentials from './db/repositories/UserCredentials'
 import UserRepository from './db/repositories/UserRepository'
 import VoteRepository from './db/repositories/VoteRepository'
 import WebPushRepository from './db/repositories/WebPushRepository'
+import ActivityManager from './managers/ActivityManager'
 import FeedManager from './managers/FeedManager'
 import InviteManager from './managers/InviteManager'
 import NotificationManager from './managers/NotificationManager'
@@ -196,6 +198,7 @@ const postManager = new PostManager(
 )
 const voteManager = new VoteManager(voteRepository, postManager, userManager, redis.client)
 const searchManager = new SearchManager(userManager, siteManager, logger.child({ service: 'SEARCH' }))
+const activityManager = new ActivityManager(redis.client, logger.child({ service: 'ACTIVITY' }))
 const oauth2Manager = new OAuth2Manager(oauthRepository, userManager, logger.child({ service: 'OAUTH2' }))
 const pollManager = new PollManager(pollRepository, userManager)
 
@@ -209,6 +212,7 @@ const requests = [
     inviteManager,
     userManager,
     apiEnricher,
+    activityManager,
     oauthMiddlewareGenerator,
     logger.child({ service: 'INVITE' }),
   ),
@@ -219,6 +223,7 @@ const requests = [
     siteManager,
     userManager,
     translationManager,
+    activityManager,
     oauthMiddlewareGenerator,
     logger.child({ service: 'POST' }),
   ),
@@ -229,7 +234,13 @@ const requests = [
     oauthMiddlewareGenerator,
     logger.child({ service: 'STATUS' }),
   ),
-  new VoteController(voteManager, userManager, oauthMiddlewareGenerator, logger.child({ service: 'VOTE' })),
+  new VoteController(
+    voteManager,
+    userManager,
+    activityManager,
+    oauthMiddlewareGenerator,
+    logger.child({ service: 'VOTE' }),
+  ),
   new UserController(
     apiEnricher,
     userManager,
@@ -254,6 +265,7 @@ const requests = [
     feedManager,
     siteManager,
     userManager,
+    activityManager,
     oauthMiddlewareGenerator,
     logger.child({ service: 'SITE' }),
   ),
@@ -266,6 +278,7 @@ const requests = [
   new SearchController(userManager, searchManager, oauthMiddlewareGenerator, logger.child({ service: 'SEARCH' })),
   new OAuth2Controller(oauth2Manager, userManager, oauthScopesFilter, app.oauth, logger.child({ service: 'OAUTH2' })),
   new PollController(pollManager, userManager, oauthMiddlewareGenerator, logger.child({ service: 'POLL' })),
+  new ActivityController(activityManager, oauthMiddlewareGenerator, logger.child({ service: 'ACTIVITY' })),
 ]
 
 const filterLog = winston.format((info) => {

--- a/backend/src/managers/ActivityManager.ts
+++ b/backend/src/managers/ActivityManager.ts
@@ -1,0 +1,236 @@
+import { RedisClientType } from 'redis'
+import { Logger } from 'winston'
+
+import { ActivityEntry } from '../api/types/entities/ActivityEntity'
+
+const ACTIVITY_FEED_KEY = 'activity_feed'
+const ACTIVITY_FEED_SEQ_KEY = 'activity_feed:seq'
+const ACTIVITY_FEED_POLL_ENDED_KEY = 'activity_feed:poll_ended'
+
+const ACTIVITY_FEED_MAX_SIZE = 10000
+const ACTIVITY_FEED_PAGE_SIZE = 100
+
+type ActivityPushInput = Omit<ActivityEntry, 'id' | 'timestamp'>
+
+export default class ActivityManager {
+  private redis: RedisClientType
+  private logger: Logger
+
+  /**
+   * Promise-chain queue to serialize push operations.
+   * Prevents INCR/LPUSH race condition where concurrent pushes
+   * could interleave, resulting in out-of-order IDs in the list.
+   */
+  private pushQueue: Promise<void> = Promise.resolve()
+
+  /**
+   * Poll expiration timers, keyed by pollId.
+   * Used to schedule poll:ended events.
+   */
+  private pollTimers: Map<number, NodeJS.Timeout> = new Map()
+
+  constructor(redis: RedisClientType, logger: Logger) {
+    this.redis = redis
+    this.logger = logger
+  }
+
+  /**
+   * Push an activity entry to the feed.
+   * Serialized via promise-chain queue to guarantee ID ordering.
+   * Failures are logged but never rethrown — primary actions proceed regardless.
+   */
+  async push(entry: ActivityPushInput): Promise<void> {
+    this.pushQueue = this.pushQueue.then(() => this._doPush(entry)).catch(() => {})
+    return this.pushQueue
+  }
+
+  private async _doPush(entry: ActivityPushInput): Promise<void> {
+    try {
+      const id = await this.redis.incr(ACTIVITY_FEED_SEQ_KEY)
+      const activityEntry: ActivityEntry = {
+        ...entry,
+        id,
+        timestamp: new Date().toISOString(),
+      }
+      await this.redis.lPush(ACTIVITY_FEED_KEY, JSON.stringify(activityEntry))
+      await this.redis.lTrim(ACTIVITY_FEED_KEY, 0, ACTIVITY_FEED_MAX_SIZE - 1)
+    } catch (err) {
+      this.logger.error('Failed to push activity entry', { error: err, entry })
+    }
+  }
+
+  /**
+   * Get a page of activity entries.
+   *
+   * Since IDs are monotonic and contiguous (guaranteed by serialized push),
+   * we can compute the offset directly when after_id is provided:
+   *   offset = newestId - afterId
+   *
+   * Falls back to scanning if the optimization fails (e.g., gaps from trimming).
+   */
+  async getPage(
+    afterId?: number,
+    limit?: number,
+  ): Promise<{
+    entries: ActivityEntry[]
+    oldestId: number | null
+    newestId: number | null
+    limit: number
+  }> {
+    const pageLimit = Math.min(Math.max(limit || ACTIVITY_FEED_PAGE_SIZE, 1), ACTIVITY_FEED_PAGE_SIZE)
+
+    const listLen = await this.redis.lLen(ACTIVITY_FEED_KEY)
+    if (listLen === 0) {
+      return { entries: [], oldestId: null, newestId: null, limit: pageLimit }
+    }
+
+    // Get boundary IDs for gap detection
+    const [newestRaw, oldestRaw] = await Promise.all([
+      this.redis.lIndex(ACTIVITY_FEED_KEY, 0),
+      this.redis.lIndex(ACTIVITY_FEED_KEY, -1),
+    ])
+
+    const newestId = newestRaw ? (JSON.parse(newestRaw) as ActivityEntry).id : null
+    const oldestId = oldestRaw ? (JSON.parse(oldestRaw) as ActivityEntry).id : null
+
+    if (newestId === null || oldestId === null) {
+      return { entries: [], oldestId: null, newestId: null, limit: pageLimit }
+    }
+
+    let entries: ActivityEntry[]
+
+    if (afterId === undefined || afterId === null) {
+      // No cursor — return the newest entries
+      const raw = await this.redis.lRange(ACTIVITY_FEED_KEY, 0, pageLimit - 1)
+      entries = raw.map((r) => JSON.parse(r) as ActivityEntry)
+    } else {
+      // Optimized offset computation: since IDs are contiguous, offset = newestId - afterId
+      const offset = newestId - afterId
+      if (offset <= 0) {
+        // afterId is at or beyond the newest — nothing to return
+        return { entries: [], oldestId, newestId, limit: pageLimit }
+      }
+
+      // Entries older than afterId start at index `offset` from the left
+      const raw = await this.redis.lRange(ACTIVITY_FEED_KEY, offset, offset + pageLimit - 1)
+      entries = raw.map((r) => JSON.parse(r) as ActivityEntry)
+
+      // Verify the optimization: if the first entry's ID is not what we expect,
+      // fall back to scanning (handles gaps from trimming)
+      if (entries.length > 0 && entries[0].id >= afterId) {
+        // Optimization failed — scan for the correct position
+        entries = await this._scanAfter(afterId, pageLimit)
+      }
+    }
+
+    return { entries, oldestId, newestId, limit: pageLimit }
+  }
+
+  /**
+   * Fallback scan for getPage when optimized offset fails.
+   */
+  private async _scanAfter(afterId: number, limit: number): Promise<ActivityEntry[]> {
+    const batchSize = 100
+    let offset = 0
+    const result: ActivityEntry[] = []
+
+    while (result.length < limit) {
+      const raw = await this.redis.lRange(ACTIVITY_FEED_KEY, offset, offset + batchSize - 1)
+      if (raw.length === 0) break
+
+      for (const r of raw) {
+        const entry = JSON.parse(r) as ActivityEntry
+        if (entry.id < afterId) {
+          result.push(entry)
+          if (result.length >= limit) break
+        }
+      }
+
+      offset += batchSize
+    }
+
+    return result
+  }
+
+  // --- Poll expiration scheduling ---
+
+  /**
+   * Schedule a poll:ended event for a poll with an expiration time.
+   * Deduplicates using a Redis set to handle server restarts.
+   */
+  schedulePollExpiration(pollId: number, expiresAt: Date, postId?: number, site?: string): void {
+    const now = Date.now()
+    const delay = expiresAt.getTime() - now
+
+    if (delay <= 0) {
+      // Already expired — emit immediately (with dedup check)
+      this._emitPollEnded(pollId, postId, site).catch(() => {})
+      return
+    }
+
+    // Clear existing timer if any
+    const existing = this.pollTimers.get(pollId)
+    if (existing) {
+      clearTimeout(existing)
+    }
+
+    const timer = setTimeout(() => {
+      this.pollTimers.delete(pollId)
+      this._emitPollEnded(pollId, postId, site).catch(() => {})
+    }, delay)
+
+    // Prevent timer from keeping the process alive
+    timer.unref()
+    this.pollTimers.set(pollId, timer)
+  }
+
+  /**
+   * Emit a poll:ended event with deduplication via Redis set.
+   */
+  private async _emitPollEnded(pollId: number, postId?: number, site?: string): Promise<void> {
+    try {
+      const alreadyProcessed = await this.redis.sIsMember(ACTIVITY_FEED_POLL_ENDED_KEY, String(pollId))
+      if (alreadyProcessed) return
+
+      await this.redis.sAdd(ACTIVITY_FEED_POLL_ENDED_KEY, String(pollId))
+      await this.push({
+        type: 'poll:ended',
+        userId: null,
+        username: null,
+        postId: postId ?? null,
+        pollId,
+        site: site ?? null,
+      })
+    } catch (err) {
+      this.logger.error('Failed to emit poll:ended', { error: err, pollId })
+    }
+  }
+
+  /**
+   * On server startup, schedule timers for all polls with future expiration.
+   * Uses overlap to catch polls that expired during downtime.
+   */
+  async initPollExpirationTimers(
+    getExpiringPolls: (since: Date) => Promise<
+      Array<{
+        pollId: number
+        expiresAt: Date
+        postId?: number
+        site?: string
+      }>
+    >,
+  ): Promise<void> {
+    const overlapMs = 60 * 60 * 1000 // 1 hour overlap
+    const since = new Date(Date.now() - overlapMs)
+
+    try {
+      const polls = await getExpiringPolls(since)
+      for (const poll of polls) {
+        this.schedulePollExpiration(poll.pollId, poll.expiresAt, poll.postId, poll.site)
+      }
+      this.logger.info(`Scheduled ${polls.length} poll expiration timer(s)`)
+    } catch (err) {
+      this.logger.error('Failed to initialize poll expiration timers', { error: err })
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements activity feed per [pazoozoo's spec](https://orbitar.space/p400044) + Aivean's review corrections.

**New files (4):**
- `ActivityManager` — Redis list with serialized push (promise-chain queue prevents ID interleaving), optimized cursor pagination (offset = newestId - afterId with scan fallback), LTRIM to max size. Poll expiration scheduling with Redis SISMEMBER dedup + 1h overlap on startup.
- `ActivityController` — `POST /feed/activity` with OAuth middleware, Joi validation, cursor-based pagination
- `ActivityEntity` — 11 action types: post/comment CRUD, 3 vote types, site:created, user:registered, poll:voted/ended
- `ActivityFeed` — request/response types

**Event hooks in (5 modified files):**
- `PostController` — post:created, post:edited, comment:created, comment:edited
- `VoteController` — vote:post, vote:comment, vote:karma (with targetUserId/targetUsername for karma)
- `SiteController` — site:created
- `InviteController` — user:registered
- `app.ts` — wires ActivityManager + ActivityController, passes activityManager to all emitting controllers

**Design decisions per review:**
- Sites identified by domain string only (no numeric `siteId`) — matches existing API convention where `SiteEntity.site` is a string
- Users identified by both `id` + `username` (both already public in `UserEntity`)
- `ACTIVITY_FEED_MAX_SIZE` (10000) and `PAGE_SIZE` (100) are hardcoded constants, not env vars
- OAuth middleware on the endpoint for external client access
- Batch entity endpoints deferred to separate PR
- Poll event types defined + scheduling infra ready, but actual emission hooks pending PollManager/PollController merge

## Test plan
- [ ] Verify TypeScript compilation (`npx tsc --noEmit` passes clean)
- [ ] Manual test: create post → check Redis for activity entry
- [ ] Manual test: vote on post/comment/karma → verify correct activity type + fields
- [ ] Manual test: `POST /feed/activity` returns paginated entries
- [ ] Manual test: cursor-based pagination with `after_id`
- [ ] Verify anonymous post comments use `overrideUserId` (not original userId)