### PR TITLE
fix: use crypto.randomBytes() for password reset codes

### DIFF
--- a/backend/src/db/repositories/UserRepository.ts
+++ b/backend/src/db/repositories/UserRepository.ts
@@ -50,7 +50,7 @@ export default class UserRepository {
   async generateAndSavePasswordResetForUser(userId: number): Promise<string | undefined> {
     const code = crypto
       .createHash('sha256')
-      .update(Math.random().toString() + userId)
+      .update(crypto.randomBytes(32).toString('hex') + userId)
       .digest('hex')
     await this.db.insert('user_password_reset', {
       user_id: userId.toString(),


### PR DESCRIPTION
Replace `Math.random()` with `crypto.randomBytes(32)` in `generateAndSavePasswordResetForUser()`.

`Math.random()` is a PRNG — its output is predictable and has insufficient entropy for security-sensitive tokens. `crypto.randomBytes(32)` provides 256 bits of cryptographic randomness from the OS CSPRNG.

One-line change, no new dependencies (`crypto` already imported).