### PR TITLE
Fix null reference in checkPassword for non-existent users

### DIFF
--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -145,11 +145,14 @@ export default class UserManager {
 
   async checkPassword(username: string, password: string): Promise<UserInfo | false> {
     const user = await this.getByUsername(username)
+    if (!user) {
+      return false
+    }
     if (this.isBarmaliniUser(user.id)) {
       return this.isValidBarmaliniPassword(password) ? user : false
     }
 
-    const passwordHash = user && (await this.userRepository.getPasswordHashByUserId(user.id))
+    const passwordHash = await this.userRepository.getPasswordHashByUserId(user.id)
 
     if (!passwordHash || !(await bcrypt.compare(password, passwordHash))) {
       return false


### PR DESCRIPTION
## Summary
- Add early `if (!user) return false` before barmalini check in `checkPassword()` (UserManager.ts)
- Prevents `TypeError: Cannot read property 'id' of undefined` when `getByUsername()` returns undefined for non-existent users
- Removes redundant `user &&` guard on passwordHash line (user guaranteed non-null after early return)

**Security audit finding H-02:** Non-existent username causes 500 error instead of graceful "wrong credentials" response, leaking username enumeration information via error response differences.

## Test plan
- [ ] Verify login with non-existent username returns same error as wrong password
- [ ] Verify login with valid username + wrong password still works correctly
- [ ] Verify barmalini login still works correctly