### PR TITLE
Allow http redirect URIs for localhost, 127.0.0.1, and [::1]

### DIFF
--- a/backend/src/api/ApiMiddleware.ts
+++ b/backend/src/api/ApiMiddleware.ts
@@ -153,12 +153,16 @@ export const urisListValidator = Joi.string().custom((value, helpers) => {
 
       // Strict validation for http/https
       if (urlObj.protocol === 'http:' || urlObj.protocol === 'https:') {
+        const hostname = urlObj.hostname
+        const isLocalhost =
+          hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1'
+        const allowHttp = isLocalhost || process.env.NODE_ENV === 'development'
         if (
           !isURL(url, {
-            require_tld: process.env.NODE_ENV !== 'development',
+            require_tld: !isLocalhost && process.env.NODE_ENV !== 'development',
             require_protocol: true,
             allow_fragments: false,
-            protocols: ['https', ...(process.env.NODE_ENV === 'development' ? ['http'] : [])],
+            protocols: ['https', ...(allowHttp ? ['http'] : [])],
           })
         ) {
           return helpers.error('any.invalid')

--- a/backend/test/api/urisListValidator.test.ts
+++ b/backend/test/api/urisListValidator.test.ts
@@ -71,6 +71,69 @@ describe('urisListValidator', () => {
     })
   })
 
+  describe('HTTP URLs for local development hosts (any environment)', () => {
+    const originalNodeEnv = process.env.NODE_ENV
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalNodeEnv
+    })
+
+    it('accepts http://localhost in production', () => {
+      process.env.NODE_ENV = 'production'
+      expect(validate('http://localhost/callback').isValid).toBe(true)
+    })
+
+    it('accepts http://localhost with port in production', () => {
+      process.env.NODE_ENV = 'production'
+      expect(validate('http://localhost:3000/callback').isValid).toBe(true)
+    })
+
+    it('accepts http://127.0.0.1 in production', () => {
+      process.env.NODE_ENV = 'production'
+      expect(validate('http://127.0.0.1/callback').isValid).toBe(true)
+    })
+
+    it('accepts http://127.0.0.1 with port in production', () => {
+      process.env.NODE_ENV = 'production'
+      expect(validate('http://127.0.0.1:5000/callback').isValid).toBe(true)
+    })
+
+    it('accepts http://[::1] in production', () => {
+      process.env.NODE_ENV = 'production'
+      expect(validate('http://[::1]/callback').isValid).toBe(true)
+    })
+
+    it('accepts http://[::1] with port in production', () => {
+      process.env.NODE_ENV = 'production'
+      expect(validate('http://[::1]:3000/callback').isValid).toBe(true)
+    })
+
+    it('still rejects http:// for non-local hosts in production', () => {
+      process.env.NODE_ENV = 'production'
+      expect(validate('http://example.com/callback').isValid).toBe(false)
+    })
+
+    it('rejects http://localhost.localdomain in production', () => {
+      process.env.NODE_ENV = 'production'
+      expect(validate('http://localhost.localdomain/callback').isValid).toBe(false)
+    })
+
+    it('rejects http://*.local in production', () => {
+      process.env.NODE_ENV = 'production'
+      expect(validate('http://mydevbox.local/callback').isValid).toBe(false)
+    })
+
+    it('accepts https://localhost in production', () => {
+      process.env.NODE_ENV = 'production'
+      expect(validate('https://localhost/callback').isValid).toBe(true)
+    })
+
+    it('accepts local http mixed with https in comma-separated list', () => {
+      process.env.NODE_ENV = 'production'
+      expect(validate('http://localhost:3000/callback,https://example.com/callback').isValid).toBe(true)
+    })
+  })
+
   describe('Custom protocol URIs (for mobile/desktop apps)', () => {
     it('accepts myapp:// scheme', () => {
       const result = validate('myapp://callback')


### PR DESCRIPTION
OAuth2 client registration and editing now accept `http://` (not just `https://`) as redirect URI scheme for local development hosts: `localhost`, `127.0.0.1` and `[::1]`.
This applies in all environments, not only in development mode, so that TUI/CLI apps can use loopback redirect URIs per RFC 8252 §7.3.