### PR TITLE
fix: enforce ownership check on OAuth2 client edit

### DIFF
--- a/backend/src/api/OAuth2Controller.ts
+++ b/backend/src/api/OAuth2Controller.ts
@@ -303,7 +303,13 @@ export default class OAuth2Controller {
       if (!client) {
         return response.error('error', 'Client not found', 404)
       }
-      const result = await this.oauth2Manager.editClient(clientId, description, redirectUris, initialAuthorizationUrl)
+      const result = await this.oauth2Manager.editClient(
+        clientId,
+        userId,
+        description,
+        redirectUris,
+        initialAuthorizationUrl,
+      )
       if (!result) {
         return response.error('error', 'Failed to update client', 500)
       }

--- a/backend/src/db/repositories/OAuth2Repository.ts
+++ b/backend/src/db/repositories/OAuth2Repository.ts
@@ -218,6 +218,7 @@ export default class OAuth2Repository {
 
   async editClient(
     clientId: string,
+    userId: number,
     description: string,
     redirectUris: string,
     initialAuthorizationUrl: string,
@@ -229,12 +230,13 @@ export default class OAuth2Repository {
         description = :description,
         redirect_uris = :redirect_uris,
         initial_authorization_url = :initial_authorization_url
-      where client_id = :client_id`,
+      where client_id = :client_id and user_id = :user_id`,
         {
           description: description,
           redirect_uris: redirectUris,
           initial_authorization_url: initialAuthorizationUrl,
           client_id: clientId,
+          user_id: userId,
         },
       )
       .then((result) => result.affectedRows > 0)

--- a/backend/src/managers/OAuth2Manager.ts
+++ b/backend/src/managers/OAuth2Manager.ts
@@ -162,11 +162,27 @@ export default class OAuth2Manager {
 
   async editClient(
     clientId: string,
+    byUserId: number,
     description: string,
     redirectUris: string,
     initialAuthorizationUrl: string,
   ): Promise<boolean> {
-    return await this.oauthRepository.editClient(clientId, description, redirectUris, initialAuthorizationUrl)
+    const client = await this.oauthRepository.getClientByClientId(clientId)
+    if (!client) {
+      this.logger.error('Error editing OAuth client, no such client', { clientId })
+      return false
+    }
+
+    if (client.user_id !== byUserId) {
+      this.logger.error('Error editing OAuth client, not client owner initiated', {
+        clientId,
+        byUserId,
+        authorId: client.user_id,
+      })
+      return false
+    }
+
+    return await this.oauthRepository.editClient(clientId, byUserId, description, redirectUris, initialAuthorizationUrl)
   }
 
   async getClientsByClientIds(clientIds: string[], userId: number) {

--- a/backend/test/managers/OAuth2Manager.test.ts
+++ b/backend/test/managers/OAuth2Manager.test.ts
@@ -355,6 +355,50 @@ describe('OAuth2Manager', () => {
     })
   })
 
+  describe('editClient', () => {
+    it('edits client when owner initiates', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(createMockConfidentialClient({ user_id: 1 }))
+      mockRepo.editClient.mockResolvedValue(true)
+
+      const result = await manager.editClient('test-client-id', 1, 'new desc', 'https://new.uri', 'https://auth.url')
+
+      expect(result).toBe(true)
+      expect(mockRepo.editClient).toHaveBeenCalledWith(
+        'test-client-id',
+        1,
+        'new desc',
+        'https://new.uri',
+        'https://auth.url',
+      )
+    })
+
+    it('returns false for non-existent client', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(undefined)
+
+      const result = await manager.editClient('non-existent', 1, 'desc', 'https://uri', '')
+
+      expect(result).toBe(false)
+      expect(mockLogger.error).toHaveBeenCalledWith('Error editing OAuth client, no such client', {
+        clientId: 'non-existent',
+      })
+      expect(mockRepo.editClient).not.toHaveBeenCalled()
+    })
+
+    it('returns false when non-owner tries to edit', async () => {
+      mockRepo.getClientByClientId.mockResolvedValue(createMockConfidentialClient({ user_id: 1 }))
+
+      const result = await manager.editClient('test-client-id', 999, 'hacked', 'https://evil.uri', '')
+
+      expect(result).toBe(false)
+      expect(mockLogger.error).toHaveBeenCalledWith('Error editing OAuth client, not client owner initiated', {
+        clientId: 'test-client-id',
+        byUserId: 999,
+        authorId: 1,
+      })
+      expect(mockRepo.editClient).not.toHaveBeenCalled()
+    })
+  })
+
   describe('unAuthorizeClient', () => {
     it('resets consent scope and updates revoke date', async () => {
       mockRepo.resetConsentScope.mockResolvedValue(true)


### PR DESCRIPTION
The editClient endpoint did not verify that the requesting user owns the client being edited. Add user_id validation in OAuth2Manager (mirroring deleteClient logic) and an additional WHERE user_id guard in the repository SQL query. Includes unit tests for owner, non-owner, and missing-client scenarios.