### PR TITLE
Fix protocol validation for OAuth2 apps

### DIFF
--- a/backend/src/api/ApiMiddleware.ts
+++ b/backend/src/api/ApiMiddleware.ts
@@ -137,46 +137,41 @@ export const joiSiteName = Joi.string().min(siteNameMinLengthChars).max(siteName
 
 export const joiClientId = Joi.string().max(36).min(36)
 
+export const validateSingleRedirectUri = (url: string): boolean => {
+  try {
+    const urlObj = new URL(url)
+
+    // RFC 6749 Section 3.1.2: no fragments
+    if (urlObj.hash && urlObj.hash !== '#') {
+      return false
+    }
+
+    if (urlObj.protocol === 'http:' || urlObj.protocol === 'https:') {
+      const hostname = urlObj.hostname
+      const isLocalhost =
+        hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1'
+      const allowHttp = isLocalhost || process.env.NODE_ENV === 'development'
+      return isURL(url, {
+        require_tld: !isLocalhost && process.env.NODE_ENV !== 'development',
+        require_protocol: true,
+        allow_fragments: false,
+        protocols: ['https', ...(allowHttp ? ['http'] : [])],
+      })
+    }
+
+    // Custom protocols: minimal validation
+    return Boolean(urlObj.protocol) && urlObj.protocol !== ':'
+  } catch (err) {
+    return false
+  }
+}
+
 export const urisListValidator = Joi.string().custom((value, helpers) => {
   // remove optional trailing slash with star to support urls like https://example.com/*
   const urls = value.split(',').map((url) => url.trim().replace(/\/*$/, ''))
   for (const url of urls) {
-    try {
-      const urlObj = new URL(url)
-
-      // RFC 6749 Section 3.1.2: no fragments
-      if (urlObj.hash && urlObj.hash !== '#') {
-        return helpers.error('any.invalid', {
-          message: 'Redirect URIs must not include fragment components (RFC 6749)',
-        })
-      }
-
-      // Strict validation for http/https
-      if (urlObj.protocol === 'http:' || urlObj.protocol === 'https:') {
-        const hostname = urlObj.hostname
-        const isLocalhost =
-          hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1'
-        const allowHttp = isLocalhost || process.env.NODE_ENV === 'development'
-        if (
-          !isURL(url, {
-            require_tld: !isLocalhost && process.env.NODE_ENV !== 'development',
-            require_protocol: true,
-            allow_fragments: false,
-            protocols: ['https', ...(allowHttp ? ['http'] : [])],
-          })
-        ) {
-          return helpers.error('any.invalid')
-        }
-      } else {
-        // Custom protocols: minimal validation
-        if (!urlObj.protocol || urlObj.protocol === ':') {
-          return helpers.error('any.invalid', {
-            message: 'Custom protocol URIs must have a valid protocol scheme',
-          })
-        }
-      }
-    } catch (err) {
-      return helpers.error('any.invalid', { message: 'Invalid URI format' })
+    if (!validateSingleRedirectUri(url)) {
+      return helpers.error('any.invalid')
     }
   }
   return value

--- a/backend/src/api/ApiMiddleware.ts
+++ b/backend/src/api/ApiMiddleware.ts
@@ -176,3 +176,11 @@ export const urisListValidator = Joi.string().custom((value, helpers) => {
   }
   return value
 }, 'URLs Validation')
+
+export const singleUriValidator = Joi.string().custom((value, helpers) => {
+  const url = value.trim().replace(/\/*$/, '')
+  if (!validateSingleRedirectUri(url)) {
+    return helpers.error('any.invalid')
+  }
+  return value
+}, 'URL Validation')

--- a/backend/src/api/OAuth2Controller.ts
+++ b/backend/src/api/OAuth2Controller.ts
@@ -9,7 +9,7 @@ import { OAuth2ClientRaw } from '../db/types/OAuth2'
 import OAuth2Manager from '../managers/OAuth2Manager'
 import UserManager from '../managers/UserManager'
 import { escapeRegExp } from '../parser/regexprs'
-import { APIRequest, APIResponse, joiClientId, urisListValidator, validate } from './ApiMiddleware'
+import { APIRequest, APIResponse, joiClientId, singleUriValidator, urisListValidator, validate } from './ApiMiddleware'
 import { ExpressOauth2ScopesFilter } from './OAuth2Middleware'
 import { OAuth2ClientEntity } from './types/entities/OAuth2ClientEntity'
 import {
@@ -49,7 +49,7 @@ const clientRegisterSchema = Joi.object<OAuth2RegisterRequest>({
     .messages({
       'string.uri': 'The field must be a valid URL.',
     }),
-  initialAuthorizationUrl: urisListValidator.max(255).allow(null).allow('').messages({
+  initialAuthorizationUrl: singleUriValidator.max(255).allow(null).allow('').messages({
     'any.invalid': 'The field must be a valid URL.',
   }),
   redirectUris: urisListValidator.max(255).required().messages({
@@ -65,7 +65,7 @@ const clientRegisterSchema = Joi.object<OAuth2RegisterRequest>({
 const clientEditSchema = Joi.object<OAuth2EditRequest>({
   clientId: Joi.string().min(36).max(36).required(),
   description: Joi.string().max(255).required().allow(''),
-  initialAuthorizationUrl: urisListValidator.max(255).allow(null).allow('').messages({
+  initialAuthorizationUrl: singleUriValidator.max(255).allow(null).allow('').messages({
     'any.invalid': 'The field must be a valid URL.',
   }),
   redirectUris: urisListValidator.max(255).required().messages({

--- a/backend/src/api/OAuth2Controller.ts
+++ b/backend/src/api/OAuth2Controller.ts
@@ -49,16 +49,9 @@ const clientRegisterSchema = Joi.object<OAuth2RegisterRequest>({
     .messages({
       'string.uri': 'The field must be a valid URL.',
     }),
-  initialAuthorizationUrl: Joi.string()
-    .uri({
-      scheme: ['http', 'https'],
-    })
-    .max(255)
-    .allow(null)
-    .allow('')
-    .messages({
-      'string.uri': 'The field must be a valid URL.',
-    }),
+  initialAuthorizationUrl: urisListValidator.max(255).allow(null).allow('').messages({
+    'any.invalid': 'The field must be a valid URL.',
+  }),
   redirectUris: urisListValidator.max(255).required().messages({
     'any.required': 'Redirect URIs are required.',
     'any.invalid': 'Please enter valid comma-separated URIs.',
@@ -72,16 +65,9 @@ const clientRegisterSchema = Joi.object<OAuth2RegisterRequest>({
 const clientEditSchema = Joi.object<OAuth2EditRequest>({
   clientId: Joi.string().min(36).max(36).required(),
   description: Joi.string().max(255).required().allow(''),
-  initialAuthorizationUrl: Joi.string()
-    .uri({
-      scheme: ['http', 'https'],
-    })
-    .max(255)
-    .allow(null)
-    .allow('')
-    .messages({
-      'string.uri': 'The field must be a valid URL.',
-    }),
+  initialAuthorizationUrl: urisListValidator.max(255).allow(null).allow('').messages({
+    'any.invalid': 'The field must be a valid URL.',
+  }),
   redirectUris: urisListValidator.max(255).required().messages({
     'any.required': 'Redirect URIs are required.',
     'any.invalid': 'Please enter valid comma-separated URIs.',

--- a/backend/test/api/singleUriValidator.test.ts
+++ b/backend/test/api/singleUriValidator.test.ts
@@ -1,0 +1,52 @@
+import { singleUriValidator } from '../../src/api/ApiMiddleware'
+
+describe('singleUriValidator', () => {
+  const validate = (value: string) => {
+    const result = singleUriValidator.validate(value)
+    return { isValid: !result.error, error: result.error?.message }
+  }
+
+  const originalNodeEnv = process.env.NODE_ENV
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv
+  })
+
+  it('accepts a single https URL', () => {
+    process.env.NODE_ENV = 'production'
+    expect(validate('https://example.com/start').isValid).toBe(true)
+  })
+
+  it('accepts a URL with commas in query params (no splitting)', () => {
+    process.env.NODE_ENV = 'production'
+    expect(validate('https://example.com/start?tags=a,b,c').isValid).toBe(true)
+  })
+
+  it('accepts custom protocol URIs', () => {
+    process.env.NODE_ENV = 'production'
+    expect(validate('myapp://open').isValid).toBe(true)
+  })
+
+  it('accepts http://localhost in production', () => {
+    process.env.NODE_ENV = 'production'
+    expect(validate('http://localhost:3000/start').isValid).toBe(true)
+  })
+
+  it('rejects http://example.com in production', () => {
+    process.env.NODE_ENV = 'production'
+    expect(validate('http://example.com/start').isValid).toBe(false)
+  })
+
+  it('rejects URLs with fragments', () => {
+    process.env.NODE_ENV = 'production'
+    expect(validate('https://example.com/start#frag').isValid).toBe(false)
+  })
+
+  it('does not split on commas — treats input as one URL', () => {
+    // A list like "https://a.com,http://example.com" must NOT be accepted by
+    // splitting and validating each piece; the whole string is one URL.
+    // The second part "http://example.com" would pass urisListValidator but
+    // the combined string is an invalid single URL.
+    process.env.NODE_ENV = 'production'
+    expect(validate('https://a.com,http://example.com').isValid).toBe(false)
+  })
+})

--- a/frontend/src/Components/UserProfileClientAppsCreateForm.tsx
+++ b/frontend/src/Components/UserProfileClientAppsCreateForm.tsx
@@ -79,40 +79,34 @@ export default function UserProfileClientAppsCreateForm(props: UserProfileClient
     return isValid
   }
 
+  const isValidRedirectUri = (url: string): boolean => {
+    try {
+      const urlObj = new URL(url)
+      if (urlObj.hash && urlObj.hash !== '#') {
+        return false
+      }
+      if (urlObj.protocol === 'http:' || urlObj.protocol === 'https:') {
+        const hostname = urlObj.hostname
+        const isLocalhost =
+          hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1'
+        const allowHttp = isLocalhost || process.env.NODE_ENV === 'development'
+        return isURL(url, {
+          require_tld: !isLocalhost && process.env.NODE_ENV !== 'development',
+          require_protocol: true,
+          allow_fragments: false,
+          protocols: ['https', ...(allowHttp ? ['http'] : [])],
+        })
+      }
+      return Boolean(urlObj.protocol) && urlObj.protocol !== ':'
+    } catch (err) {
+      return false
+    }
+  }
+
   const validateUrls = (value: string) => {
     const urls = value.split(',').map((url) => url.trim())
     for (const url of urls) {
-      try {
-        const urlObj = new URL(url)
-
-        // RFC 6749 Section 3.1.2: no fragments
-        if (urlObj.hash && urlObj.hash !== '#') {
-          return 'Redirect URIs must not include fragment components'
-        }
-
-        // Strict validation for http/https
-        if (urlObj.protocol === 'http:' || urlObj.protocol === 'https:') {
-          const hostname = urlObj.hostname
-          const isLocalhost =
-            hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1'
-          const allowHttp = isLocalhost || process.env.NODE_ENV === 'development'
-          if (
-            !isURL(url, {
-              require_tld: !isLocalhost && process.env.NODE_ENV !== 'development',
-              require_protocol: true,
-              allow_fragments: false,
-              protocols: ['https', ...(allowHttp ? ['http'] : [])],
-            })
-          ) {
-            return 'Invalid HTTP/HTTPS URL'
-          }
-        } else {
-          // Custom protocols: minimal validation
-          if (!urlObj.protocol || urlObj.protocol === ':') {
-            return 'Custom protocol URIs must have a valid protocol scheme'
-          }
-        }
-      } catch (err) {
+      if (!isValidRedirectUri(url)) {
         return 'Invalid URI format'
       }
     }
@@ -120,15 +114,11 @@ export default function UserProfileClientAppsCreateForm(props: UserProfileClient
   }
 
   const validateOptionalUrl = (value: string) => {
-    return (
-      value.trim() === '' ||
-      isURL(value, {
-        require_tld: process.env.NODE_ENV !== 'development',
-        require_protocol: true,
-        protocols: ['https', ...(process.env.NODE_ENV === 'development' ? ['http', 'https'] : [])],
-      }) ||
-      'Введите валидный URL-адрес или оставьте поле пустым'
-    )
+    const trimmed = value.trim()
+    if (trimmed === '') {
+      return true
+    }
+    return isValidRedirectUri(trimmed) || 'Введите валидный URL-адрес или оставьте поле пустым'
   }
 
   const [submitting, setSubmitting] = useState(false)

--- a/frontend/src/Components/UserProfileClientAppsCreateForm.tsx
+++ b/frontend/src/Components/UserProfileClientAppsCreateForm.tsx
@@ -92,12 +92,16 @@ export default function UserProfileClientAppsCreateForm(props: UserProfileClient
 
         // Strict validation for http/https
         if (urlObj.protocol === 'http:' || urlObj.protocol === 'https:') {
+          const hostname = urlObj.hostname
+          const isLocalhost =
+            hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]' || hostname === '::1'
+          const allowHttp = isLocalhost || process.env.NODE_ENV === 'development'
           if (
             !isURL(url, {
-              require_tld: process.env.NODE_ENV !== 'development',
+              require_tld: !isLocalhost && process.env.NODE_ENV !== 'development',
               require_protocol: true,
               allow_fragments: false,
-              protocols: ['https', ...(process.env.NODE_ENV === 'development' ? ['http'] : [])],
+              protocols: ['https', ...(allowHttp ? ['http'] : [])],
             })
           ) {
             return 'Invalid HTTP/HTTPS URL'


### PR DESCRIPTION
`http://` is accepted when:

  1. Host is a loopback address — `localhost`, `127.0.0.1`, `[::1]`, or `::1` (with or without port, any path). Allowed in every environment (dev, stage, prod)
  2. `NODE_ENV === 'development'` — any host, http allowed for local dev convenience.

  Everywhere else (stage/prod with a non-loopback host), only `https://` is accepted. Custom schemes like `myapp://`
  are unaffected and still pass through.