### PR TITLE
docs(oauth): match redirect-URI help text to the shipped loopback rule

### DIFF
--- a/frontend/src/Components/UserProfileClientAppsCreateForm.tsx
+++ b/frontend/src/Components/UserProfileClientAppsCreateForm.tsx
@@ -201,7 +201,8 @@ export default function UserProfileClientAppsCreateForm(props: UserProfileClient
             />
             <p>
               <span className={classNames('i', 'i-info')}></span> Поддерживаются HTTPS URLs и custom protocol URIs
-              (например, myapp://callback для мобильных приложений). В development режиме также разрешены HTTP URLs.
+              (например, myapp://callback для мобильных приложений). HTTP URLs разрешены для localhost, 127.0.0.1 и
+              [::1].
             </p>
             {errors.redirectUris && <p className={styles.error}>{errors.redirectUris.message}</p>}
           </label>


### PR DESCRIPTION
The redirect-URI hint under the client-app form still tells users that HTTP URLs are allowed only in development mode. That stopped being accurate once the loopback rule landed on `dev`: `isValidRedirectUri` accepts `http://` for `localhost`, `127.0.0.1` and `[::1]` independently of `NODE_ENV`, so in a production build the hint under-describes what the field actually accepts.

This updates the hint to state the real rule. Text only — validation logic untouched.

**Scope note (rescoped 2026-09-01):** this PR originally carried the validation change as well. That half has since landed on `dev` separately, so only the stale hint was left, and the branch had gone conflicting against it. Rebased onto current `dev` and reduced to the two-line text change.