### PR TITLE
Bump react-tweet to 3.3.1 to fix broken tweet embeds

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -49,7 +49,7 @@
         "react-scripts": "^5.0.0",
         "react-textarea-autosize": "^8.4.0",
         "react-toastify": "^8.2.0",
-        "react-tweet": "^3.2.2",
+        "react-tweet": "^3.3.1",
         "react-zoom-pan-pinch": "^3.1.0",
         "scrypt-js": "^3.0.1",
         "textarea-caret": "^3.1.0",
@@ -15309,9 +15309,9 @@
       }
     },
     "node_modules/react-tweet": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-tweet/-/react-tweet-3.2.2.tgz",
-      "integrity": "sha512-hIkxAVPpN2RqWoDEbo3TTnN/pDcp9/Jb6pTgiA4EbXa9S+m2vHIvvZKHR+eS0PDIsYqe+zTmANRa5k6+/iwGog==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-tweet/-/react-tweet-3.3.1.tgz",
+      "integrity": "sha512-0Gj1YgBTe1K85NBMoWBlUc17Rdc67gIJLlacrVgj+3jWIoXpFfxPdZ1U5OnWkkF9zxhphqs2pY1i//JBfP3Qog==",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.3",
@@ -30335,9 +30335,9 @@
       }
     },
     "react-tweet": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-tweet/-/react-tweet-3.2.2.tgz",
-      "integrity": "sha512-hIkxAVPpN2RqWoDEbo3TTnN/pDcp9/Jb6pTgiA4EbXa9S+m2vHIvvZKHR+eS0PDIsYqe+zTmANRa5k6+/iwGog==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-tweet/-/react-tweet-3.3.1.tgz",
+      "integrity": "sha512-0Gj1YgBTe1K85NBMoWBlUc17Rdc67gIJLlacrVgj+3jWIoXpFfxPdZ1U5OnWkkF9zxhphqs2pY1i//JBfP3Qog==",
       "requires": {
         "@swc/helpers": "^0.5.3",
         "clsx": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "react-scripts": "^5.0.0",
     "react-textarea-autosize": "^8.4.0",
     "react-toastify": "^8.2.0",
-    "react-tweet": "^3.2.2",
+    "react-tweet": "^3.3.1",
     "react-zoom-pan-pinch": "^3.1.0",
     "scrypt-js": "^3.0.1",
     "textarea-caret": "^3.1.0",


### PR DESCRIPTION
## Problem
Twitter/X link expands stopped working: clicking the expand button mounts an empty embed, with an uncaught `TypeError: ... is not iterable` in the console.

## Root cause
X changed its syndication API (early June 2026): tweet payloads no longer include empty entity arrays — `entities.hashtags`, `urls`, `user_mentions`, `symbols` are now omitted when the tweet has none. `react-tweet@3.2.2` iterates them unguarded in `getEntities`/`addEntities`, so rendering crashes for virtually every tweet. The data fetch itself succeeds (200), only the render dies.

## Fix
`react-tweet@3.3.1` (released 2026-06-03 in response to this exact API change) guards the missing arrays (`if (!entities?.length) return`). This PR bumps just that dependency — no code changes needed; peer deps unchanged (React ^18).

## Verification
Reproduced and verified on local dev (post `/s/ai/p39673`, whose tweet payload has a fully empty `entities` object):
- before: empty embed + `TypeError: n is not iterable`
- after: tweet renders correctly (text, media, dark theme), no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)