### PR TITLE
fix(feed): pin nightly toolchain to unbreak docker build

### DIFF
--- a/feed/rust-toolchain.toml
+++ b/feed/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-10-01"


### PR DESCRIPTION
The feed service's rust-toolchain.toml floated on channel = "nightly", so every fresh docker build (cache miss) picked up whatever nightly was current. As of today's nightly, cargo build failed compiling the old `traitobject 0.1.0` crate (pulled in transitively via nickel -> hyper 0.10):

  error[E0119]: conflicting implementations of trait `Trait` for type  `(dyn Send + Sync + 'static)`

Root cause: rustc's `order_dependent_trait_objects` lint (rust-lang/rust#56484) was promoted from a warning to a hard error in Rust 1.87 (stable, ~May 2025). `traitobject` relies on the old lenient behavior where `Send + Sync` and `Sync + Send` were treated as distinct trait object types.

Pinned the channel to nightly-2024-10-01, which predates the 1.87 dev cycle and still compiles cleanly.