### PR TITLE
feat(notifications): per-user notification mute

### DIFF
--- a/backend/migrations/20260722000000-user-notification-mute.js
+++ b/backend/migrations/20260722000000-user-notification-mute.js
@@ -1,0 +1,55 @@
+'use strict'
+
+var dbm
+var type
+var seed
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate
+  type = dbm.dataType
+  seed = seedLink
+}
+
+exports.up = async function (db) {
+  // Per-user notification mute list.
+  // (user_id) mutes notifications triggered by (muted_user_id).
+  // This is mute, not ignore: the muted user's posts/comments stay fully visible;
+  // only the notifications (and web push) they would trigger for the muter are suppressed.
+  await db.createTable('user_notification_mute', {
+    user_id: {
+      type: 'int',
+      primaryKey: true,
+      foreignKey: {
+        name: 'idx_mute_user',
+        table: 'users',
+        rules: { onDelete: 'cascade', onUpdate: 'cascade' },
+        mapping: 'user_id',
+      },
+    },
+    muted_user_id: {
+      type: 'int',
+      primaryKey: true,
+      foreignKey: {
+        name: 'idx_mute_muted_user',
+        table: 'users',
+        rules: { onDelete: 'cascade', onUpdate: 'cascade' },
+        mapping: 'user_id',
+      },
+    },
+    created_at: { type: 'datetime', notNull: true, defaultValue: new String('CURRENT_TIMESTAMP') },
+  })
+  return null
+}
+
+exports.down = function (db, callback) {
+  db.dropTable('user_notification_mute', callback)
+  return null
+}
+
+exports._meta = {
+  version: 1,
+}

--- a/backend/src/api/NotificationsController.ts
+++ b/backend/src/api/NotificationsController.ts
@@ -10,6 +10,14 @@ import { sharedReadRateLimiter } from './RateLimiters'
 import { NotificationEntity } from './types/entities/NotificationEntity'
 import { NotificationsListRequest, NotificationsListResponse } from './types/requests/NotificationsList'
 import {
+  NotificationsMutedRequest,
+  NotificationsMutedResponse,
+  NotificationsMuteRequest,
+  NotificationsMuteResponse,
+  NotificationsUnmuteRequest,
+  NotificationsUnmuteResponse,
+} from './types/requests/NotificationsMute'
+import {
   NotificationsHideRequest,
   NotificationsHideResponse,
   NotificationsReadRequest,
@@ -25,6 +33,10 @@ import { NotificationsSubscribeRequest, NotificationsSubscribeResponse } from '.
 
 const hideAllSchema = Joi.object<NotificationsHideAllRequest>({
   readOnly: Joi.boolean(),
+})
+
+const muteSchema = Joi.object<NotificationsMuteRequest>({
+  userId: Joi.number().integer().positive().required(),
 })
 
 export default class NotificationsController {
@@ -71,6 +83,23 @@ export default class NotificationsController {
     )
     this.router.post('/notifications/subscribe', sharedReadRateLimiter, oauth('подписка на уведомления'), (req, res) =>
       this.subscribe(req, res),
+    )
+    this.router.post(
+      '/notifications/mute',
+      sharedReadRateLimiter,
+      oauth('отключать уведомления от пользователя'),
+      validate(muteSchema),
+      (req, res) => this.mute(req, res),
+    )
+    this.router.post(
+      '/notifications/unmute',
+      sharedReadRateLimiter,
+      oauth('включать уведомления от пользователя'),
+      validate(muteSchema),
+      (req, res) => this.unmute(req, res),
+    )
+    this.router.post('/notifications/muted', sharedReadRateLimiter, oauth('список отключённых'), (req, res) =>
+      this.muted(req, res),
     )
   }
 
@@ -184,5 +213,64 @@ export default class NotificationsController {
     await this.userManager.setPushSubscription(request.session.data.userId, request.body.subscription)
 
     response.status(200).success({})
+  }
+
+  async mute(request: APIRequest<NotificationsMuteRequest>, response: APIResponse<NotificationsMuteResponse>) {
+    if (!request.session.data.userId) {
+      return response.authRequired()
+    }
+
+    const userId = request.session.data.userId
+    const { userId: mutedUserId } = request.body
+
+    if (mutedUserId === userId) {
+      return response.error('mute-self', 'You cannot mute yourself', 400)
+    }
+
+    try {
+      const target = await this.userManager.getById(mutedUserId)
+      if (!target) {
+        return response.error('user-not-found', 'User not found', 404)
+      }
+
+      await this.notificationManager.muteUser(userId, mutedUserId)
+      return response.success({ muted: true })
+    } catch (err) {
+      this.logger.error('Notifications mute error', { error: err, mutedUserId })
+      return response.error('error', 'Unknown error', 500)
+    }
+  }
+
+  async unmute(request: APIRequest<NotificationsUnmuteRequest>, response: APIResponse<NotificationsUnmuteResponse>) {
+    if (!request.session.data.userId) {
+      return response.authRequired()
+    }
+
+    const userId = request.session.data.userId
+    const { userId: mutedUserId } = request.body
+
+    try {
+      await this.notificationManager.unmuteUser(userId, mutedUserId)
+      return response.success({ muted: false })
+    } catch (err) {
+      this.logger.error('Notifications unmute error', { error: err, mutedUserId })
+      return response.error('error', 'Unknown error', 500)
+    }
+  }
+
+  async muted(request: APIRequest<NotificationsMutedRequest>, response: APIResponse<NotificationsMutedResponse>) {
+    if (!request.session.data.userId) {
+      return response.authRequired()
+    }
+
+    const userId = request.session.data.userId
+
+    try {
+      const users = await this.notificationManager.getMutedUsers(userId)
+      return response.success({ users })
+    } catch (err) {
+      this.logger.error('Notifications muted list error', { error: err })
+      return response.error('error', 'Unknown error', 500)
+    }
   }
 }

--- a/backend/src/api/UserController.ts
+++ b/backend/src/api/UserController.ts
@@ -5,6 +5,7 @@ import { Logger } from 'winston'
 
 import { VoteFeedFilterTimeoutError } from '../db/repositories/VoteFeedReadRepository'
 import InviteManager from '../managers/InviteManager'
+import NotificationManager from '../managers/NotificationManager'
 import OAuth2Manager from '../managers/OAuth2Manager'
 import PostManager from '../managers/PostManager'
 import { UserGender, UserRatingBySubsite } from '../managers/types/UserInfo'
@@ -49,6 +50,7 @@ export default class UserController {
   private readonly logger: Logger
   private readonly enricher: Enricher
   private readonly oauthManager: OAuth2Manager
+  private readonly notificationManager: NotificationManager
 
   constructor(
     enricher: Enricher,
@@ -58,6 +60,7 @@ export default class UserController {
     inviteManager: InviteManager,
     oauth: OAuth2MiddlewareGenerator,
     oauthManager: OAuth2Manager,
+    notificationManager: NotificationManager,
     logger: Logger,
   ) {
     this.enricher = enricher
@@ -66,6 +69,7 @@ export default class UserController {
     this.voteFeedManager = voteFeedManager
     this.inviteManager = inviteManager
     this.oauthManager = oauthManager
+    this.notificationManager = notificationManager
     this.logger = logger
 
     const profileSchema = Joi.object<UserProfileRequest>({
@@ -227,6 +231,7 @@ export default class UserController {
       const numberOfComments = (await this.postManager.getUserCommentsTotal(profileInfo.id, '')) || 0
       const visitedDaysAgo = await this.userManager.getUserVisitedDaysAgo(profileInfo.id)
       const hasOwnApps = await this.oauthManager.hasOwnApps(profileInfo.id)
+      const isMuted = profileInfo.id !== userId && (await this.notificationManager.isMuted(userId, profileInfo.id))
 
       // if viewing own profile, get available invites number
       let numberOfInvitesAvailable = 0
@@ -265,6 +270,7 @@ export default class UserController {
         publicKey,
         visitedDaysAgo,
         hasOwnApps,
+        isMuted,
       })
     } catch (error) {
       this.logger.error('Could not get user profile', { username })

--- a/backend/src/api/types/requests/NotificationsMute.ts
+++ b/backend/src/api/types/requests/NotificationsMute.ts
@@ -1,0 +1,23 @@
+import { UserBaseEntity } from '../entities/UserEntity'
+
+export type NotificationsMuteRequest = {
+  userId: number
+}
+
+export type NotificationsMuteResponse = {
+  muted: boolean
+}
+
+export type NotificationsUnmuteRequest = {
+  userId: number
+}
+
+export type NotificationsUnmuteResponse = {
+  muted: boolean
+}
+
+export type NotificationsMutedRequest = Record<string, never>
+
+export type NotificationsMutedResponse = {
+  users: UserBaseEntity[]
+}

--- a/backend/src/api/types/requests/UserProfile.ts
+++ b/backend/src/api/types/requests/UserProfile.ts
@@ -22,6 +22,9 @@ export type UserProfileResponse = {
   hasOwnApps: boolean
 
   visitedDaysAgo: number
+
+  // Whether the requesting user has muted this profile's notifications.
+  isMuted: boolean
 }
 
 export type TrialProgressDebugInfo = {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -247,6 +247,7 @@ const requests = [
     inviteManager,
     oauthMiddlewareGenerator,
     oauth2Manager,
+    notificationManager,
     logger.child({ service: 'USER' }),
   ),
   new FeedController(

--- a/backend/src/db/repositories/NotificationsRepository.ts
+++ b/backend/src/db/repositories/NotificationsRepository.ts
@@ -3,6 +3,13 @@ import { ResultSetHeader } from 'mysql2'
 import DB from '../DB'
 import { NotificationRaw } from '../types/NotificationRaw'
 
+// Excludes notifications triggered by a user the recipient has muted.
+// `by_user_id is null` keeps authorless/system notifications (a bare `not in` would
+// drop them, since `NULL not in (...)` is NULL, not true).
+const NOT_MUTED =
+  '(by_user_id is null or by_user_id not in ' +
+  '(select muted_user_id from user_notification_mute where user_id=:user_id))'
+
 export default class NotificationsRepository {
   private db: DB
 
@@ -12,7 +19,7 @@ export default class NotificationsRepository {
 
   async getUnreadNotificationsCount(forUserId: number): Promise<number> {
     const result = await this.db.fetchOne<{ cnt: string }>(
-      'select count(*) cnt from notifications where user_id=:user_id and `read`=0',
+      `select count(*) cnt from notifications where user_id=:user_id and \`read\`=0 and ${NOT_MUTED}`,
       {
         user_id: forUserId,
       },
@@ -22,7 +29,7 @@ export default class NotificationsRepository {
 
   async getVisibleNotificationsCount(forUserId: number): Promise<number> {
     const result = await this.db.fetchOne<{ cnt: string }>(
-      'select count(*) cnt from notifications where user_id=:user_id and hidden=0',
+      `select count(*) cnt from notifications where user_id=:user_id and hidden=0 and ${NOT_MUTED}`,
       {
         user_id: forUserId,
       },
@@ -32,12 +39,52 @@ export default class NotificationsRepository {
 
   async getNotifications(forUserId: number, limit = 20): Promise<NotificationRaw[]> {
     return await this.db.fetchAll<NotificationRaw>(
-      'select * from notifications where user_id=:user_id and hidden=0 order by notification_id desc limit :limit',
+      `select * from notifications where user_id=:user_id and hidden=0 and ${NOT_MUTED} ` +
+        'order by notification_id desc limit :limit',
       {
         user_id: forUserId,
         limit,
       },
     )
+  }
+
+  async muteUser(forUserId: number, mutedUserId: number): Promise<void> {
+    await this.db.query(
+      'insert into user_notification_mute (user_id, muted_user_id) values (:user_id, :muted_user_id) ' +
+        'on duplicate key update user_id=user_id',
+      {
+        user_id: forUserId,
+        muted_user_id: mutedUserId,
+      },
+    )
+  }
+
+  async unmuteUser(forUserId: number, mutedUserId: number): Promise<void> {
+    await this.db.query('delete from user_notification_mute where user_id=:user_id and muted_user_id=:muted_user_id', {
+      user_id: forUserId,
+      muted_user_id: mutedUserId,
+    })
+  }
+
+  async getMutedUserIds(forUserId: number): Promise<number[]> {
+    const rows = await this.db.fetchAll<{ muted_user_id: number }>(
+      'select muted_user_id from user_notification_mute where user_id=:user_id order by created_at desc',
+      {
+        user_id: forUserId,
+      },
+    )
+    return rows.map((r) => r.muted_user_id)
+  }
+
+  async isMuted(forUserId: number, mutedUserId: number): Promise<boolean> {
+    const row = await this.db.fetchOne<{ one: number }>(
+      'select 1 one from user_notification_mute where user_id=:user_id and muted_user_id=:muted_user_id',
+      {
+        user_id: forUserId,
+        muted_user_id: mutedUserId,
+      },
+    )
+    return !!row
   }
 
   async addNotification(

--- a/backend/src/managers/NotificationManager.ts
+++ b/backend/src/managers/NotificationManager.ts
@@ -261,6 +261,37 @@ export default class NotificationManager {
     return true
   }
 
+  async muteUser(forUserId: number, mutedUserId: number) {
+    if (forUserId === mutedUserId) {
+      return false
+    }
+    await this.notificationsRepository.muteUser(forUserId, mutedUserId)
+    // Unread/visible counts change when a user is muted.
+    this.userCache.deleteUserStatsCache(forUserId)
+    return true
+  }
+
+  async unmuteUser(forUserId: number, mutedUserId: number) {
+    await this.notificationsRepository.unmuteUser(forUserId, mutedUserId)
+    this.userCache.deleteUserStatsCache(forUserId)
+  }
+
+  async isMuted(forUserId: number, mutedUserId: number): Promise<boolean> {
+    return this.notificationsRepository.isMuted(forUserId, mutedUserId)
+  }
+
+  async getMutedUsers(forUserId: number): Promise<{ id: number; username: string; gender: number }[]> {
+    const ids = await this.notificationsRepository.getMutedUserIds(forUserId)
+    const users: { id: number; username: string; gender: number }[] = []
+    for (const id of ids) {
+      const user = await this.userCache.getById(id)
+      if (user) {
+        users.push({ id: user.id, username: user.username, gender: user.gender })
+      }
+    }
+    return users
+  }
+
   async setRead(forUserId: number, notificationId: number) {
     await this.notificationsRepository.setRead(forUserId, notificationId)
     this.userCache.deleteUserStatsCache(forUserId)
@@ -294,6 +325,12 @@ export default class NotificationManager {
     }
 
     if (!notification.source.byUserId || !notification.source.commentId) {
+      return
+    }
+
+    // Respect the recipient's mute list: a muted author's push ping is suppressed
+    // (the notification row is still stored, so unmuting restores it in the list).
+    if (await this.notificationsRepository.isMuted(forUserId, notification.source.byUserId)) {
       return
     }
 

--- a/backend/test/api/NotificationsController.test.ts
+++ b/backend/test/api/NotificationsController.test.ts
@@ -1,0 +1,215 @@
+import NotificationsController from '../../src/api/NotificationsController'
+
+// --- Mock factories ---
+
+function createMockNotificationManager() {
+  return {
+    getNotifications: jest.fn().mockResolvedValue([]),
+    setRead: jest.fn().mockResolvedValue(undefined),
+    setReadAndHidden: jest.fn().mockResolvedValue(undefined),
+    setReadAll: jest.fn().mockResolvedValue(undefined),
+    setHiddenAll: jest.fn().mockResolvedValue(undefined),
+    muteUser: jest.fn().mockResolvedValue(true),
+    unmuteUser: jest.fn().mockResolvedValue(undefined),
+    isMuted: jest.fn().mockResolvedValue(false),
+    getMutedUsers: jest.fn().mockResolvedValue([{ id: 20, username: 'spammer', gender: 1 }]),
+  }
+}
+
+function createMockUserManager() {
+  return {
+    getById: jest.fn().mockResolvedValue({ id: 20, username: 'spammer', gender: 1 }),
+    getPushSubscription: jest.fn().mockResolvedValue(undefined),
+  }
+}
+
+function createMockOauth() {
+  return jest.fn().mockReturnValue((_req, _res, next) => next())
+}
+
+function createMockLogger() {
+  return {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    verbose: jest.fn(),
+    debug: jest.fn(),
+  }
+}
+
+function createMockRequest(userId: number, body: Record<string, unknown> = {}) {
+  return {
+    session: {
+      data: { userId },
+    },
+    body,
+  } as any
+}
+
+function createMockResponse() {
+  const res: any = {
+    success: jest.fn(),
+    error: jest.fn(),
+    authRequired: jest.fn(),
+    status: jest.fn(),
+  }
+  res.status.mockReturnValue(res)
+  return res
+}
+
+function createController(overrides: Record<string, any> = {}) {
+  const deps = {
+    notificationManager: createMockNotificationManager(),
+    userManager: createMockUserManager(),
+    oauth: createMockOauth(),
+    logger: createMockLogger(),
+    ...overrides,
+  }
+
+  const controller = new NotificationsController(
+    deps.notificationManager as any,
+    deps.userManager as any,
+    deps.oauth as any,
+    deps.logger as any,
+  )
+
+  return { controller, ...deps }
+}
+
+// --- Tests ---
+
+describe('NotificationsController', () => {
+  describe('router registration', () => {
+    it('should register mute/unmute/muted routes', () => {
+      const { controller } = createController()
+      const routes = controller.router.stack.filter((layer) => layer.route).map((layer) => layer.route.path)
+
+      expect(routes).toEqual(
+        expect.arrayContaining(['/notifications/mute', '/notifications/unmute', '/notifications/muted']),
+      )
+    })
+  })
+
+  describe('mute', () => {
+    it('should require authentication', async () => {
+      const { controller } = createController()
+      const req = createMockRequest(0, { userId: 20 })
+      const res = createMockResponse()
+
+      await controller.mute(req, res)
+
+      expect(res.authRequired).toHaveBeenCalled()
+      expect(res.success).not.toHaveBeenCalled()
+    })
+
+    it('should reject muting yourself', async () => {
+      const { controller, notificationManager } = createController()
+      const req = createMockRequest(10, { userId: 10 })
+      const res = createMockResponse()
+
+      await controller.mute(req, res)
+
+      expect(res.error).toHaveBeenCalledWith('mute-self', expect.any(String), 400)
+      expect(notificationManager.muteUser).not.toHaveBeenCalled()
+    })
+
+    it('should 404 when the target user does not exist', async () => {
+      const userManager = createMockUserManager()
+      userManager.getById.mockResolvedValue(undefined)
+
+      const { controller, notificationManager } = createController({ userManager })
+      const req = createMockRequest(10, { userId: 999 })
+      const res = createMockResponse()
+
+      await controller.mute(req, res)
+
+      expect(res.error).toHaveBeenCalledWith('user-not-found', expect.any(String), 404)
+      expect(notificationManager.muteUser).not.toHaveBeenCalled()
+    })
+
+    it('should mute a valid user', async () => {
+      const { controller, notificationManager } = createController()
+      const req = createMockRequest(10, { userId: 20 })
+      const res = createMockResponse()
+
+      await controller.mute(req, res)
+
+      expect(notificationManager.muteUser).toHaveBeenCalledWith(10, 20)
+      expect(res.success).toHaveBeenCalledWith({ muted: true })
+    })
+
+    it('should handle errors and return 500', async () => {
+      const notificationManager = createMockNotificationManager()
+      notificationManager.muteUser.mockRejectedValue(new Error('DB down'))
+
+      const { controller, logger } = createController({ notificationManager })
+      const req = createMockRequest(10, { userId: 20 })
+      const res = createMockResponse()
+
+      await controller.mute(req, res)
+
+      expect(logger.error).toHaveBeenCalled()
+      expect(res.error).toHaveBeenCalledWith('error', 'Unknown error', 500)
+    })
+  })
+
+  describe('unmute', () => {
+    it('should require authentication', async () => {
+      const { controller } = createController()
+      const req = createMockRequest(0, { userId: 20 })
+      const res = createMockResponse()
+
+      await controller.unmute(req, res)
+
+      expect(res.authRequired).toHaveBeenCalled()
+    })
+
+    it('should unmute a user', async () => {
+      const { controller, notificationManager } = createController()
+      const req = createMockRequest(10, { userId: 20 })
+      const res = createMockResponse()
+
+      await controller.unmute(req, res)
+
+      expect(notificationManager.unmuteUser).toHaveBeenCalledWith(10, 20)
+      expect(res.success).toHaveBeenCalledWith({ muted: false })
+    })
+
+    it('should handle errors and return 500', async () => {
+      const notificationManager = createMockNotificationManager()
+      notificationManager.unmuteUser.mockRejectedValue(new Error('DB down'))
+
+      const { controller, logger } = createController({ notificationManager })
+      const req = createMockRequest(10, { userId: 20 })
+      const res = createMockResponse()
+
+      await controller.unmute(req, res)
+
+      expect(logger.error).toHaveBeenCalled()
+      expect(res.error).toHaveBeenCalledWith('error', 'Unknown error', 500)
+    })
+  })
+
+  describe('muted', () => {
+    it('should require authentication', async () => {
+      const { controller } = createController()
+      const req = createMockRequest(0)
+      const res = createMockResponse()
+
+      await controller.muted(req, res)
+
+      expect(res.authRequired).toHaveBeenCalled()
+    })
+
+    it('should return the muted users list', async () => {
+      const { controller, notificationManager } = createController()
+      const req = createMockRequest(10)
+      const res = createMockResponse()
+
+      await controller.muted(req, res)
+
+      expect(notificationManager.getMutedUsers).toHaveBeenCalledWith(10)
+      expect(res.success).toHaveBeenCalledWith({ users: [{ id: 20, username: 'spammer', gender: 1 }] })
+    })
+  })
+})

--- a/backend/test/api/UserControllerVotes.test.ts
+++ b/backend/test/api/UserControllerVotes.test.ts
@@ -30,6 +30,7 @@ describe('UserController votes', () => {
       {} as any,
       jest.fn(() => (_request: any, _response: any, next: any) => next()) as any,
       {} as any,
+      {} as any,
       logger as any,
     )
 

--- a/backend/test/managers/NotificationManager.test.ts
+++ b/backend/test/managers/NotificationManager.test.ts
@@ -1,0 +1,123 @@
+import NotificationManager from '../../src/managers/NotificationManager'
+
+// --- Mock factories ---
+
+function createMockNotificationsRepository() {
+  return {
+    muteUser: jest.fn().mockResolvedValue(undefined),
+    unmuteUser: jest.fn().mockResolvedValue(undefined),
+    isMuted: jest.fn().mockResolvedValue(false),
+    getMutedUserIds: jest.fn().mockResolvedValue([]),
+  }
+}
+
+function createMockUserCache() {
+  return {
+    getById: jest.fn(),
+    deleteUserStatsCache: jest.fn(),
+  }
+}
+
+function createMockLogger() {
+  return {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    verbose: jest.fn(),
+    debug: jest.fn(),
+  }
+}
+
+function createManager(overrides: Record<string, any> = {}) {
+  const notificationsRepository = overrides.notificationsRepository || createMockNotificationsRepository()
+  const userCache = overrides.userCache || createMockUserCache()
+  const logger = createMockLogger()
+
+  const manager = new NotificationManager(
+    {} as any, // commentRepository
+    notificationsRepository as any,
+    {} as any, // postRepository
+    userCache as any,
+    {} as any, // siteRepository
+    (() => ({})) as any, // siteManagerLazy
+    {} as any, // webPushRepository
+    {} as any, // vapidConfig (empty -> web push disabled)
+    {} as any, // siteConfig
+    logger as any,
+  )
+
+  return { manager, notificationsRepository, userCache, logger }
+}
+
+// --- Tests ---
+
+describe('NotificationManager mute', () => {
+  describe('muteUser', () => {
+    it('should refuse to mute yourself and not touch the repository', async () => {
+      const { manager, notificationsRepository, userCache } = createManager()
+
+      const result = await manager.muteUser(10, 10)
+
+      expect(result).toBe(false)
+      expect(notificationsRepository.muteUser).not.toHaveBeenCalled()
+      expect(userCache.deleteUserStatsCache).not.toHaveBeenCalled()
+    })
+
+    it('should persist the mute and invalidate the recipient stats cache', async () => {
+      const { manager, notificationsRepository, userCache } = createManager()
+
+      const result = await manager.muteUser(10, 20)
+
+      expect(result).toBe(true)
+      expect(notificationsRepository.muteUser).toHaveBeenCalledWith(10, 20)
+      // Unread/visible badge counts change, so the cache must be dropped.
+      expect(userCache.deleteUserStatsCache).toHaveBeenCalledWith(10)
+    })
+  })
+
+  describe('unmuteUser', () => {
+    it('should remove the mute and invalidate the stats cache', async () => {
+      const { manager, notificationsRepository, userCache } = createManager()
+
+      await manager.unmuteUser(10, 20)
+
+      expect(notificationsRepository.unmuteUser).toHaveBeenCalledWith(10, 20)
+      expect(userCache.deleteUserStatsCache).toHaveBeenCalledWith(10)
+    })
+  })
+
+  describe('isMuted', () => {
+    it('should delegate to the repository', async () => {
+      const notificationsRepository = createMockNotificationsRepository()
+      notificationsRepository.isMuted.mockResolvedValue(true)
+      const { manager } = createManager({ notificationsRepository })
+
+      await expect(manager.isMuted(10, 20)).resolves.toBe(true)
+      expect(notificationsRepository.isMuted).toHaveBeenCalledWith(10, 20)
+    })
+  })
+
+  describe('getMutedUsers', () => {
+    it('should expand muted ids to user info and skip missing users', async () => {
+      const notificationsRepository = createMockNotificationsRepository()
+      notificationsRepository.getMutedUserIds.mockResolvedValue([20, 30, 40])
+
+      const userCache = createMockUserCache()
+      userCache.getById.mockImplementation(async (id: number) => {
+        if (id === 30) {
+          return undefined // deleted / unknown user, should be skipped
+        }
+        return { id, username: `user${id}`, gender: 1, extra: 'ignored' }
+      })
+
+      const { manager } = createManager({ notificationsRepository, userCache })
+
+      const users = await manager.getMutedUsers(10)
+
+      expect(users).toEqual([
+        { id: 20, username: 'user20', gender: 1 },
+        { id: 40, username: 'user40', gender: 1 },
+      ])
+    })
+  })
+})

--- a/frontend/src/API/NotificationsAPI.ts
+++ b/frontend/src/API/NotificationsAPI.ts
@@ -53,6 +53,13 @@ export type WebPushSubscribeRequest = {
 }
 export type WebPushSubscribeResponse = Record<string, unknown>
 
+export type NotificationsMuteRequest = {
+  userId: number
+}
+export type NotificationsMuteResponse = {
+  muted: boolean
+}
+
 export default class NotificationsAPI {
   api: APIBase
 
@@ -90,6 +97,18 @@ export default class NotificationsAPI {
   subscribe(subscription: PushSubscription): Promise<WebPushSubscribeResponse> {
     return this.api.request<WebPushSubscribeRequest, WebPushSubscribeResponse>('/notifications/subscribe', {
       subscription: subscription.toJSON(),
+    })
+  }
+
+  muteUser(userId: number): Promise<NotificationsMuteResponse> {
+    return this.api.request<NotificationsMuteRequest, NotificationsMuteResponse>('/notifications/mute', {
+      userId,
+    })
+  }
+
+  unmuteUser(userId: number): Promise<NotificationsMuteResponse> {
+    return this.api.request<NotificationsMuteRequest, NotificationsMuteResponse>('/notifications/unmute', {
+      userId,
     })
   }
 }

--- a/frontend/src/API/NotificationsAPIHelper.ts
+++ b/frontend/src/API/NotificationsAPIHelper.ts
@@ -53,4 +53,12 @@ export default class NotificationsAPIHelper {
   subscribe(subscription: PushSubscription) {
     return this.api.subscribe(subscription)
   }
+
+  async muteUser(userId: number) {
+    return await this.api.muteUser(userId)
+  }
+
+  async unmuteUser(userId: number) {
+    return await this.api.unmuteUser(userId)
+  }
 }

--- a/frontend/src/API/UserAPI.ts
+++ b/frontend/src/API/UserAPI.ts
@@ -29,6 +29,7 @@ type UserProfileResponse = {
   publicKey: string
   hasOwnApps: boolean
   visitedDaysAgo: number
+  isMuted: boolean
 }
 type UserProfilePostsRequest = {
   username: string

--- a/frontend/src/API/UserAPIHelper.ts
+++ b/frontend/src/API/UserAPIHelper.ts
@@ -17,6 +17,7 @@ export type UserProfileResult = {
   publicKey: string
   visitedDaysAgo: number
   hasOwnApps: boolean
+  isMuted: boolean
 }
 
 export default class UserAPIHelper {

--- a/frontend/src/Pages/UserPage.module.scss
+++ b/frontend/src/Pages/UserPage.module.scss
@@ -136,6 +136,22 @@
   font-weight: bold;
 }
 
+.muteButton {
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 4px 12px;
+  background-color: var(--bg);
+  border: 1px solid var(--disabled-fg);
+  border-radius: 4px;
+  color: var(--fgSoft);
+  font-size: 14px;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--fg);
+  }
+}
+
 .userinfo {
   color: var(--fg);
   display: flex;

--- a/frontend/src/Pages/UserPage.tsx
+++ b/frontend/src/Pages/UserPage.tsx
@@ -8,6 +8,7 @@ import { useUserProfile } from '../API/use/useUserProfile'
 import { useAPI, useAppState } from '../AppState/AppState'
 import DateComponent from '../Components/DateComponent'
 import RatingSwitch from '../Components/RatingSwitch'
+import Button from '../Components/UI/Button'
 import Username from '../Components/Username'
 import UserProfileBio from '../Components/UserProfileBio'
 import UserProfileClientsApps from '../Components/UserProfileClientsApps'
@@ -36,6 +37,7 @@ export const UserPage = observer(() => {
   const [state, refreshProfile] = useUserProfile(username || '')
 
   const [inviteListTruncated, setInviteListTruncated] = useState(true)
+  const [muted, setMuted] = useState(false)
 
   const isPosts = page === 'posts'
   const isComments = page === 'comments'
@@ -49,6 +51,7 @@ export const UserPage = observer(() => {
   useEffect(() => {
     if (state.status === 'ready') {
       document.title = state.profile.profile.username
+      setMuted(state.profile.isMuted)
     }
   }, [state])
 
@@ -120,6 +123,11 @@ export const UserPage = observer(() => {
       refreshProfile()
     }
 
+    const handleToggleMute = () => {
+      const request = muted ? api.notifications.unmuteUser(user.id) : api.notifications.muteUser(user.id)
+      request.then(() => setMuted(!muted)).catch((e) => console.error('Failed to toggle notification mute', e))
+    }
+
     return (
       <div className={styles.container}>
         <div className={styles.header}>
@@ -150,6 +158,21 @@ export const UserPage = observer(() => {
           <div className={styles.name}>
             <UserProfileName name={user.name} mine={!!isMyProfile} />
           </div>
+          {!isMyProfile && (
+            <Button
+              variant='ghost'
+              size='small'
+              className={styles.muteButton}
+              onClick={handleToggleMute}
+              title={
+                muted
+                  ? 'Снова получать уведомления от этого пользователя'
+                  : 'Не получать уведомления (упоминания и ответы) от этого пользователя. Его посты и комментарии останутся видны.'
+              }
+            >
+              {muted ? 'Включить уведомления' : 'Отключить уведомления'}
+            </Button>
+          )}
         </div>
 
         <div className={styles.controls}>


### PR DESCRIPTION
## Per-user notification mute

Adds the ability to **mute notifications from a specific user** — the platform's first per-user suppression primitive.

This is **mute, not ignore/block**: a muted user's posts and comments stay fully visible everywhere; only the *notifications* (mentions + answers) and *web-push pings* they would trigger **for the muter** are suppressed. Muting is fully reversible with no data loss — the notification rows are still stored and reappear on unmute.

### Motivation
Requested by community members as spam protection: stop being pinged by someone without hiding their content or breaking threads.

### How it works
- New `user_notification_mute(user_id, muted_user_id)` table (composite PK, both FK → `users`, cascade) + migration.
- The mute filter is applied at the **notification-serving layer** (`NotificationsRepository`): muted authors are excluded from the notification list and from the unread/visible badge counts. Authorless/system notifications are preserved (a bare `NOT IN` would drop them, since `NULL not in (...)` is `NULL`).
- Web-push pings from muted authors are suppressed in `NotificationManager` (the row is still stored, so unmuting restores it in the list).
- Endpoints: `POST /notifications/mute`, `/notifications/unmute`, `/notifications/muted` (list).
- `isMuted` flag added to the user profile response so the UI can render the toggle state.

### Frontend
- Mute/unmute toggle button on the user profile page (hidden on your own profile).
- Notifications API client stubs.

### Tests / checks
- `NotificationsController` unit tests: auth guards, self-mute rejection, unknown-target 404, mute/unmute/list happy paths, error handling.
- `NotificationManager` unit tests: self-mute guard, stats-cache invalidation, muted-list expansion (skips deleted users).
- Full backend suite green (`npx jest`), `tsc --noEmit` clean (backend + frontend), eslint clean, prettier applied.

### Status — ready for review

Un-drafted 2026-07-28: CI is green, the backend suite is green, and there is nothing
outstanding on my side. The four questions I opened the draft with are answered below with
defaults, so this is mergeable as-is — each one is a small change if you'd prefer otherwise.

1. **Endpoint placement** — kept under `/notifications/*`, matching the existing
   notification-scoped routes (`/notifications/read`, `/hide`, `/subscribe`).
2. **Mute vs. full block** — kept notification-only, which is what was asked for. A broader
   "block" (hiding content / blocking replies) remains a separate, larger change.
3. **Migration timestamp** `20260722000000` — kept; happy to rename to any scheme you prefer.
4. **Rate limiting** — kept on `sharedReadRateLimiter`, which is what the other
   state-changing routes in this same controller (`/notifications/hide`,
   `/notifications/subscribe`) already use. Consistent with the existing pattern here;
   introducing a dedicated write limiter would be a controller-wide decision rather than a
   mute-specific one.

Feedback welcome — happy to rework any of the above.
