### PR TITLE
Mark comments as read on view, not on entering the post

### DIFF
--- a/frontend/src/API/use/usePost.ts
+++ b/frontend/src/API/use/usePost.ts
@@ -10,6 +10,8 @@ type UsePost = {
   site?: SiteInfo
   post?: PostInfo
   comments?: CommentInfo[]
+  /** Every loaded comment, before the `?new` filter is applied. */
+  rawComments?: CommentInfo[]
   error?: string
   anonymousUser?: UserInfo
 
@@ -158,9 +160,6 @@ export function usePost(siteName: string, postId: number, showUnreadOnly?: boole
           setRawComments(result.comments)
 
           setComments(filterComments(result.comments, unreadOnly || false))
-
-          // mark all comments as read
-          api.post.read(postId, result.post.comments, result.lastCommentId).then()
         })
         .catch((error) => {
           console.error('Could not load post', postId, error)
@@ -208,6 +207,7 @@ export function usePost(siteName: string, postId: number, showUnreadOnly?: boole
     site,
     post,
     comments,
+    rawComments,
     error,
     anonymousUser,
     postComment,

--- a/frontend/src/API/use/useReadProgress.ts
+++ b/frontend/src/API/use/useReadProgress.ts
@@ -1,0 +1,114 @@
+import { RefObject, useCallback, useEffect, useRef } from 'react'
+
+import { useAppState } from '../../AppState/AppState'
+import { CommentInfo } from '../../Types/PostInfo'
+import { computeReadProgress } from '../../Utils/readProgress'
+
+// Progress is flushed this long after the last comment scrolled into view, so that one swipe
+// through a dozen comments costs one request instead of a dozen.
+const FLUSH_DELAY = 1000
+
+/**
+ * Marks comments as read as they are scrolled into view, instead of when the post is opened.
+ *
+ * Opening a post used to spend its whole unread state, so `?new` only ever worked once: the very
+ * visit that showed the new comments also cleared them, and a misclick before reading them lost
+ * them for good. Now whatever the reader did not reach stays new.
+ *
+ * @param allComments   every loaded comment, used to compute the prefix (in `?new` mode the
+ *                      rendered subset alone cannot tell where the prefix currently ends)
+ * @param renderedComments  the comments actually in the DOM, used to (re)attach the observer
+ */
+export function useReadProgress(
+  postId: number,
+  allComments: CommentInfo[] | undefined,
+  renderedComments: CommentInfo[] | undefined,
+  containerRef: RefObject<HTMLElement>,
+) {
+  const { api } = useAppState()
+  const allCommentsRef = useRef(allComments)
+  const seenRef = useRef(new Set<number>())
+  // prefix last handed to the backend; -1 so that the first flush always goes through, which is
+  // what clears the post's notifications
+  const sentRef = useRef(-1)
+  const timerRef = useRef<number>()
+
+  useEffect(() => {
+    seenRef.current = new Set<number>()
+    sentRef.current = -1
+  }, [postId])
+
+  useEffect(() => {
+    allCommentsRef.current = allComments
+  }, [allComments])
+
+  const flush = useCallback(() => {
+    window.clearTimeout(timerRef.current)
+    const comments = allCommentsRef.current
+    if (!comments) {
+      return
+    }
+    const { lastCommentId, readComments } = computeReadProgress(comments, seenRef.current)
+    if (lastCommentId <= sentRef.current) {
+      return
+    }
+    sentRef.current = lastCommentId
+    api.post.read(postId, readComments, lastCommentId || undefined).then()
+  }, [api, postId])
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container || !renderedComments) {
+      return
+    }
+    // a comment hidden behind the topbar is not on screen yet
+    const topbarHeight = document.getElementById('topbar')?.clientHeight || 0
+    const observer = new IntersectionObserver(
+      (entries) => {
+        let advanced = false
+        for (const entry of entries) {
+          if (!entry.isIntersecting) {
+            continue
+          }
+          observer.unobserve(entry.target)
+          const commentId = parseInt((entry.target as HTMLElement).dataset.commentId || '', 10)
+          if (commentId && !seenRef.current.has(commentId)) {
+            seenRef.current.add(commentId)
+            advanced = true
+          }
+        }
+        if (advanced) {
+          window.clearTimeout(timerRef.current)
+          timerRef.current = window.setTimeout(flush, FLUSH_DELAY)
+        }
+      },
+      { rootMargin: `-${topbarHeight}px 0px 0px 0px` },
+    )
+    // `div.comment`, not just `[data-comment-id]`: the parser puts that attribute on the expand
+    // button of an inline comment link too, and such a link may well point into this very post
+    container.querySelectorAll('div.comment[data-comment-id]').forEach((comment) => observer.observe(comment))
+    return () => observer.disconnect()
+  }, [renderedComments, containerRef, flush])
+
+  // report what the backend already knows as soon as the post loads - the bookmark does not move,
+  // but the post's notifications are cleared, as they were before
+  useEffect(() => {
+    flush()
+  }, [allComments, flush])
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        flush()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('pagehide', flush)
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      window.removeEventListener('pagehide', flush)
+      // leaving the post: save whatever the debounce still holds
+      flush()
+    }
+  }, [flush])
+}

--- a/frontend/src/Pages/PostPage.tsx
+++ b/frontend/src/Pages/PostPage.tsx
@@ -4,6 +4,7 @@ import { Link, useLocation, useParams, useSearchParams } from 'react-router-dom'
 import Button from '@ui/Button'
 
 import { usePost } from '../API/use/usePost'
+import { useReadProgress } from '../API/use/useReadProgress'
 import { useAppState } from '../AppState/AppState'
 import CommentComponent from '../Components/CommentComponent'
 import { CreateCommentComponentRestricted } from '../Components/CreateCommentComponent'
@@ -23,11 +24,10 @@ export default function PostPage() {
   const { site, userInfo } = useAppState()
   const containerRef = useRef<HTMLDivElement>(null)
   const unreadOnly = search.get('new') !== null
-  const { post, comments, anonymousUser, postComment, editComment, editPost, error, reload, updatePost } = usePost(
-    site,
-    postId,
-    unreadOnly,
-  )
+  const { post, comments, rawComments, anonymousUser, postComment, editComment, editPost, error, reload, updatePost } =
+    usePost(site, postId, unreadOnly)
+
+  useReadProgress(postId, rawComments, comments, containerRef)
 
   useEffect(() => {
     let docTitle = `Пост #${postId}`

--- a/frontend/src/Utils/readProgress.ts
+++ b/frontend/src/Utils/readProgress.ts
@@ -1,0 +1,47 @@
+import { CommentInfo } from '../Types/PostInfo'
+
+export type ReadProgress = {
+  /** Last comment of the continuous read prefix, 0 when nothing is read yet. */
+  lastCommentId: number
+  /** How many comments that prefix covers, including own comments above it. */
+  readComments: number
+}
+
+function flatten(comments: CommentInfo[], into: CommentInfo[]): CommentInfo[] {
+  for (const comment of comments) {
+    into.push(comment)
+    if (comment.answers) {
+      flatten(comment.answers, into)
+    }
+  }
+  return into
+}
+
+/**
+ * Works out how far the read bookmark of a post may be advanced.
+ *
+ * The bookmark is a prefix - `last_read_comment_id` plus the number of comments at or below it -
+ * so a comment only counts as read once every older comment counts as read as well. Reading out
+ * of order advances nothing until the gap in front of it is filled, which is deliberate: the
+ * prefix must never claim that an unreached comment has been read.
+ *
+ * A comment counts as read when it has been on screen (`seen`), or when the backend already
+ * treats it as read - `isNew` is set only for comments above the bookmark that the reader did
+ * not write themselves.
+ */
+export function computeReadProgress(comments: CommentInfo[], seen: Set<number>): ReadProgress {
+  const all = flatten(comments, []).sort((a, b) => a.id - b.id)
+
+  let lastCommentId = 0
+  for (const comment of all) {
+    if (comment.isNew && !seen.has(comment.id)) {
+      break
+    }
+    lastCommentId = comment.id
+  }
+
+  // same set the backend counts: everything up to the prefix, plus own comments after it
+  const readComments = all.filter((comment) => comment.id <= lastCommentId || !comment.isNew).length
+
+  return { lastCommentId, readComments }
+}


### PR DESCRIPTION
Closes the first half of #496.

### Why

Opening a post marked **every** comment in it as read, before the reader had seen anything — `usePost.reload()` fired `api.post.read(postId, post.comments, lastCommentId)` straight after the fetch, with a `// mark all comments as read` next to it.

So `?new` worked exactly once per new comment: the visit that showed it also spent it. Any way out of the post before you got to the bottom — tapping a spoiler that turns out to hide a link, following a quote, a stray back gesture — cost you the whole unread set, and a long thread had to be re-read from the top. That is what @CapTolik ran into on <a href="https://orbitar.space/s/dev/p46766">p46766</a>, and the spoiler was only one of the ways to trip it.

### What changed

Comments are marked read as they are **scrolled into view**. An `IntersectionObserver` collects the comments that have actually been on screen; progress is flushed 1s after scrolling settles, and again on `visibilitychange`/`pagehide`/unmount.

The bookmark the backend stores is a *prefix* — `last_read_comment_id` plus the number of comments at or below it — so the advance is the longest continuous run of comments that are either already read or have been seen:

```
comments   1   2   3*  4*  5*      * = isNew
seen                   x   x
prefix ────────┘                   3 is unseen, so 4 and 5 stay new
```

Conservative by construction: the prefix can never claim an unreached comment was read. Reading out of order advances nothing until the gap in front is filled — storing that tail is the other half of #496 and needs storage that can express it (the bitset in the issue).

Progress is also flushed once on load. That call cannot move the bookmark (it carries the prefix the backend already has, so `setRead` early-outs), but it still runs `setReadForPost`, so a post's notifications keep clearing on entry exactly as before.

### No API or schema change

`isNew` is already set per comment as `author !== me && id > last_read_comment_id`, so the client already knows which comments the backend counts as read, and `/post/read` already accepts a prefix. Nothing new on the wire.

### Files

- `Utils/readProgress.ts` — `computeReadProgress(comments, seen)`, pure, the whole rule in ~20 lines
- `API/use/useReadProgress.ts` — observer, debounce, flush-on-leave
- `API/use/usePost.ts` — drop the read-on-load, expose `rawComments` (the `?new` view renders a subset, and the prefix has to be computed over all of them)
- `Pages/PostPage.tsx` — wire it up

### Notes for review

- **Behaviour change worth a look:** a post you open and leave without scrolling now stays unread in the feed. That is the point of #496, but it is the change people will notice first.
- `div.comment[data-comment-id]`, not `[data-comment-id]` — the parser puts that attribute on the expand button of an inline comment link too (`TheParser.ts:360`), and such a link can point into the post you are reading. (`PostPage.tsx:69` has the same latent ambiguity; left alone here.)
- The `pagehide` flush is best-effort — a hard navigation can cut the request. The 1s debounce means at most the last second of scrolling is lost, not the visit.
- `computeReadProgress` is pure and was checked against 13 cases covering out-of-order reads, own comments above the prefix, nesting, and a never-opened post. Not committed as a test file: the frontend has no test runner wired into CI yet (#468).
- Touches `PostPage.tsx`, so it will want a rebase against #504 whichever lands second.
