### PR TITLE
Don't follow a link inside a spoiler on the tap that reveals it

### DIFF
--- a/frontend/src/Components/ContentComponent.tsx
+++ b/frontend/src/Components/ContentComponent.tsx
@@ -638,7 +638,14 @@ function updateImg(img: HTMLImageElement, setZoomedImg: (img: ZoomedImg | null) 
 }
 
 function updateSpoiler(spoiler: HTMLSpanElement) {
-  const spoilerOnClickHandler = () => {
+  const spoilerOnClickHandler = (event: MouseEvent) => {
+    // Where there is no hover, the tap that uncovers a spoiler is the only way to uncover it, so
+    // it cannot also mean "follow the link in there" - the reader could not read the link yet.
+    // Swallow that first tap; the handler removes itself, so the next one works normally.
+    // Where hover exists the blur is already gone before any click, so the click was deliberate.
+    if (!window.matchMedia('(hover: hover)').matches) {
+      event.preventDefault()
+    }
     spoiler.classList.remove('spoiler')
     spoiler.removeEventListener('click', spoilerOnClickHandler)
   }


### PR DESCRIPTION
Reported by @CapTolik on <a href="https://orbitar.space/s/dev/p46766">p46766</a>: *«чтобы если под спойлером ссылка — она бы не открывалась при нажатии на спойлер»*.

### Why

`updateSpoiler` hangs the click listener on the spoiler span itself. A tap on a link *inside* the spoiler bubbles up to it, so the spoiler uncovers **and** the link is followed, in one tap. On a touch screen that tap is the only way to uncover the spoiler — it cannot also have meant "go there", because the link was unreadable at the moment it was tapped.

### What changed

```ts
if (!window.matchMedia('(hover: hover)').matches) {
  event.preventDefault()
}
```

The handler already removes itself after the first click, so the second tap follows the link as usual. Only the reveal tap is swallowed.

### Why the `(hover: hover)` gate

On desktop `.spoiler:hover` lifts the blur with no click at all, so by the time anything is clicked the link is readable and the click was deliberate. Swallowing it there would cost a pointless extra click on every spoilered link. The gate is evaluated per click rather than once at module load, so a hybrid device that gains or loses a pointer is handled.

### Not covered

The spoiler is still only a cosmetic blur — the text sits in the page source either way. Hiding content for real is a server-side question, out of scope here.
