### PR TITLE
Fix the review-check warning grammar

### DIFF
--- a/.github/workflows/review-check.yml
+++ b/.github/workflows/review-check.yml
@@ -71,30 +71,29 @@ jobs:
             // account is the sole reviewer always require post-merge review.
             const automatedAccount = 'Aivean2';
 
-            let shouldFlag = false;
-            let reason = '';
+            // Each branch spells out the whole sentence. The three reasons have no
+            // common grammatical shape, so a shared "merged with ..." prefix cannot
+            // host all of them.
+            let headline = '';
 
             if (prAuthor === automatedAccount) {
               // Case 1: PR authored by automated account — always flag
-              shouldFlag = true;
-              reason = `authored by automated account ${automatedAccount}`;
+              headline = `This PR was authored by automated account ${automatedAccount}.`;
             } else if (approverLogins.length === 0) {
               // Case 2: Merged with zero approved reviews
-              shouldFlag = true;
-              reason = 'no approved reviews';
+              headline = 'This PR was merged with no approved reviews.';
             } else if (
               approverLogins.length === 1 &&
               approverLogins[0] === automatedAccount
             ) {
-              // Case 3: Only reviewer is the automated account
-              shouldFlag = true;
-              reason = `only reviewed by automated account ${automatedAccount}`;
+              // Case 3: Only approver is the automated account
+              headline = `This PR was approved only by automated account ${automatedAccount}.`;
             }
 
-            if (shouldFlag) {
+            if (headline) {
               const body = [
                 `> [!WARNING]`,
-                `> **This PR was merged with ${reason}.**`,
+                `> **${headline}**`,
                 `> Post-merge review may be required.`,
                 `>`,
                 `> cc @spaceshelter/reviewers`,
@@ -107,7 +106,7 @@ jobs:
                 body: body,
               });
 
-              core.info(`Flagged PR #${prNumber}: ${reason}`);
+              core.info(`Flagged PR #${prNumber}: ${headline}`);
             } else {
               core.info(
                 `PR #${prNumber} has independent review from: ${approverLogins.join(', ')}`


### PR DESCRIPTION
Every comment this workflow has posted so far is ungrammatical — 7 of 7, most recently on #531:

> **This PR was merged with authored by automated account Aivean2.**

### Why

The reasons are interpolated into a fixed `This PR was merged with ${reason}.` prefix, but only one of the three (`no approved reviews`) is a noun phrase. The other two are verb phrases — and so was the pre-#507 wording `only reviewed by associated account(s): …`, which is why #505/#506 read the same way. The prefix has never composed with anything but that one branch.

### What changed

Each branch writes the whole sentence; the template just bolds it.

| case | rendered |
| --- | --- |
| author is the automated account | **This PR was authored by automated account Aivean2.** |
| merged with zero approvals | **This PR was merged with no approved reviews.** |
| sole approver is the automated account | **This PR was approved only by automated account Aivean2.** |

Which PRs get flagged, the `Post-merge review may be required.` line and the `cc` are unchanged.

Checked by running the `github-script` body straight out of the YAML against stubbed `github`/`context`/`core`, over all three flag branches plus the no-flag one.
