### PR TITLE
fix(spoiler): hide spoiler text by its own color, not by matching the background

### DIFF
--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -96,6 +96,10 @@ svg#spoiler-mask {
 
 .spoiler {
   background-color: var(--fg);
+  /* hide the text by its own color, not by matching the background: browser
+     "night mode" repaints backgrounds and breaks the match, leaving the text
+     readable under nothing but the 2px blur */
+  color: transparent;
   filter: blur(2px);
   opacity: 0.8;
   /* more blur to img video etc */
@@ -105,6 +109,7 @@ svg#spoiler-mask {
 
   &:hover {
     background-color: inherit;
+    color: inherit;
     filter: none;
     opacity: 1;
     & > * {

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -96,12 +96,18 @@ svg#spoiler-mask {
 
 .spoiler {
   background-color: var(--fg);
-  /* hide the text by its own color, not by matching the background: browser
-     "night mode" repaints backgrounds and breaks the match, leaving the text
-     readable under nothing but the 2px blur */
-  color: transparent;
   filter: blur(2px);
   opacity: 0.8;
+  /* hide the text by its own color, not by matching the background: browser
+     "night mode" repaints backgrounds and breaks the match, leaving the text
+     readable under nothing but the 2px blur.
+     children that set their own color (links, irony) never inherit that, so
+     cover them too; scoping to :not(:hover) hands each one its own color back
+     on reveal, without naming any of them here */
+  &:not(:hover),
+  &:not(:hover) * {
+    color: transparent;
+  }
   /* more blur to img video etc */
   & > * {
     filter: url('#spoiler-mask-filter');
@@ -109,7 +115,6 @@ svg#spoiler-mask {
 
   &:hover {
     background-color: inherit;
-    color: inherit;
     filter: none;
     opacity: 1;
     & > * {


### PR DESCRIPTION
### The bug

`<spoiler>` text is readable without tapping it, in browsers that repaint page backgrounds themselves. Reported on Android `via` with its night mode on: https://orbitar.space/p46766

### Why

The spoiler doesn't obscure text — it *cancels* it. `.spoiler` sets `background-color: var(--fg)`, and `var(--fg)` is exactly the color `body` draws text in, so the glyphs vanish into a plaque of their own color. The `blur(2px)` on top only softens the plaque's edges; it was never what made the text unreadable. (Nested images get a genuinely strong blur — the `#spoiler-mask-filter` SVG at `stdDeviation: 20` — which is why images always looked properly obscured and text never did.)

So the whole effect rests on a *color match* between foreground and background. A browser night mode darkens the near-white plaque and leaves the text color alone; the two stop cancelling, and 2px of blur is all that's left between the reader and the punchline.

The reporter's screenshot is the tell: in his dark theme `var(--fg)` is near-white, so an untouched plaque would render as a white bar. It's grey.

### The fix

`color: transparent` — hide the text by its own color instead of by matching the background. There is no longer a match to break, and nothing for a repaint to restore.

Children that carry their own `color` — a link, `<irony>` — never inherit that, so the rule covers descendants and is scoped rather than unwound:

```scss
&:not(:hover),
&:not(:hover) * {
  color: transparent;
}
```

`:not(:hover)` hands each child back *its own* color on reveal without the stylesheet having to name it; a `color: inherit` unwind would have painted links in body-text color instead. `#spoiler-mask-filter` was never a second line of defence for them — it composites `in` SourceGraphic, so glyph shapes come through it intact and only the color inside them smears. An image's alpha is a full rectangle, which is why images do get properly blurred by it.

Rendering is unchanged everywhere it already worked: fg-colored text on an fg-colored plaque, and transparent text on the same plaque, are the same pixels. The tap path removes the `.spoiler` class outright and is untouched. Net diff against `dev` is 10 added lines, nothing removed.

Deliberately **not** included: raising `blur(2px)`. It would also work — blur is geometric, so no amount of color mangling defeats it — but `filter: blur()` does not stay inside the element box, and a radius large enough to make text unreadable smears the lines above and below an inline spoiler. That is a visual tradeoff worth deciding on its own; this change costs nothing.

### Still not fixed (pre-existing, unchanged)

A spoiler remains cosmetic rather than secret: the text is in the page source, and `:hover` reveals it on desktop without a click. An `@`-mention keeps the icon its `:before` paints as a background image, which `color` cannot reach — the username text is covered, so what shows is that a mention is there, not who.
