### PR TITLE
fix(comments): placeholder says what the form is answering

### DIFF
--- a/frontend/src/Components/CommentComponent.tsx
+++ b/frontend/src/Components/CommentComponent.tsx
@@ -161,6 +161,7 @@ export default function CommentComponent(props: CommentProps) {
           <CreateCommentComponentRestricted
             post={props.comment.postLink}
             comment={props.comment}
+            isEdit={true}
             open={true}
             text={editingText}
             onAnswer={handleEditComplete}

--- a/frontend/src/Components/CreateCommentComponent.tsx
+++ b/frontend/src/Components/CreateCommentComponent.tsx
@@ -15,7 +15,6 @@ import getCaretCoordinates from 'textarea-caret'
 import { useDebouncedCallback } from 'use-debounce'
 
 import { CommentInfo, PostLinkInfo } from '../Types/PostInfo'
-import { UserGender } from '../Types/UserInfo'
 import ContentComponent from './ContentComponent'
 import MediaUploader, { CreateGalleryOption, MediaResult } from './MediaUploader'
 import { PollCreationWizard, PollCreationWizardSubmitData } from './PollCreationWizard'
@@ -47,12 +46,34 @@ interface CreateCommentProps {
   parentAuthorUserName?: string
 
   /**
+   * The form edits `comment` instead of replying to it.
+   * Only affects the placeholder — the caller still owns the submit handler.
+   */
+  isEdit?: boolean
+
+  /**
    * Optional tab index for the textarea. When provided, formatting buttons
    * will use the next index in sequence.
    */
   textareaTabIndex?: number
 
   onAnswer: (text: string, post?: PostLinkInfo, comment?: CommentInfo) => Promise<CommentInfo | string | undefined>
+}
+
+/**
+ * Tells the three uses of this form apart, because an empty textarea looks
+ * the same in all of them: a reply to a comment, a reply to the post itself,
+ * and everything else (new post, edits) where a hint would only get in the way.
+ */
+function getPlaceholderText(props: CreateCommentProps): string {
+  if (props.isEdit) {
+    return ''
+  }
+  if (props.comment) {
+    const parentAuthor = props.comment.author?.username
+    return parentAuthor ? `Ваш ответ на комментарий @${parentAuthor}` : 'Ваш ответ на комментарий'
+  }
+  return props.post ? 'Ваш ответ на пост' : ''
 }
 
 // same as CreateCommentComponent, but with slow mode and other restrictions
@@ -184,13 +205,7 @@ export default function CreateCommentComponent(props: CreateCommentProps) {
 
   const api = useAPI()
 
-  const pronoun =
-    props?.comment?.author?.gender === UserGender.he
-      ? 'ему'
-      : props?.comment?.author?.gender === UserGender.she
-        ? 'ей'
-        : ''
-  const placeholderText = props.comment ? `Ваш ответ ${pronoun}` : ''
+  const placeholderText = getPlaceholderText(props)
   const disabledButtons = isPosting || previewing !== null || mailForm
 
   const state = useAppState()


### PR DESCRIPTION
### Проблема

Форма ответа под постом и форма ответа под комментарием в пустом состоянии выглядят одинаково — placeholder у корневой формы пустой. Отсюда классическая осечка: пишешь ответ конкретному человеку, отправляешь, и он уезжает в корень треда. Повод: https://orbitar.space/s/ai/p7541#1665511 (запрос — @4vanger, https://orbitar.space/s/ai/p7541#1665808).

### Что делает PR

Placeholder теперь называет адресата, одной формой — «Ваш ответ на …»:

| Форма | Было | Стало |
|---|---|---|
| корневая, под постом | *(пусто)* | `Ваш ответ на пост` |
| ответ на комментарий | `Ваш ответ ему` / `ей` / `Ваш ответ ` | `Ваш ответ на комментарий @username` |
| ответ на комментарий, автор неизвестен | `Ваш ответ ` | `Ваш ответ на комментарий` |
| редактирование своего комментария | `Ваш ответ ему` | *(пусто)* |
| новый пост / bio / инвайт | *(пусто)* | *(пусто)*, без изменений |

Два побочных исправления, оба следуют из того же различения:

1. **Редактирование.** `CommentComponent` передаёт в форму тот же `comment` и при ответе, и при правке, поэтому при правке собственного комментария placeholder предлагал ответить самому себе. Добавлен явный флаг `isEdit` — единственный вызов, которому он нужен.
2. **Род.** Старый вариант склонял местоимение по `gender` автора и для пользователей без указанного рода схлопывался в `Ваш ответ ` с висящим пробелом. Имя однозначно для всех.

Все восемь мест, где рендерится `CreateCommentComponent`, перечислены и проверены: изменились ровно три (корневая форма поста, ответ на комментарий, правка комментария), остальные пять как были с пустым placeholder'ом.

### Правки после ревью

- Строка ответа на комментарий приведена к общей форме: `Ваш ответ @username` → `Ваш ответ на комментарий @username` (https://orbitar.space/s/ai/p7541#1665827). Теперь все три варианта читаются одинаково — «Ваш ответ на пост» / «Ваш ответ на комментарий @username» / «Ваш ответ на комментарий», и вариант без автора стал ровно префиксом варианта с автором.

### Проверки

- `npx prettier --check` — чисто (файлы не переформатировались)
- `npx eslint` — 0 ошибок (остались только прежние warning'и на не тронутых строках)
- `npx tsc --noEmit` — чисто
