### PR TITLE
test(parser): make wrong-key decryption assertions deterministic

### DIFF
--- a/backend/src/parser/CryptoUtils.ts
+++ b/backend/src/parser/CryptoUtils.ts
@@ -7,6 +7,10 @@ export function aesEncryptToBase64(data, key) {
   return CryptoJS.enc.Base64.stringify(toEncode)
 }
 
+// CBC+Pkcs7 without a MAC: a wrong key or corrupted input usually fails the
+// padding/UTF-8 checks and yields '', but can occasionally decode to garbage.
+// Callers must validate the returned plaintext (isValidBarmaliniPassword
+// parses it as a date and applies a time window).
 export function aesDecryptFromBase64(base64data, key) {
   try {
     const decoded = CryptoJS.enc.Base64.parse(base64data)

--- a/backend/test/parser/CryptoUtils.test.ts
+++ b/backend/test/parser/CryptoUtils.test.ts
@@ -1,30 +1,38 @@
-import {aesDecryptFromBase64, aesEncryptToBase64} from '../../src/parser/CryptoUtils';
+import { aesDecryptFromBase64, aesEncryptToBase64 } from '../../src/parser/CryptoUtils'
 
 test('aes encode decode', () => {
-    const key = 'mVRW8ycqHYZQSgYcBN8PUz8hVRWB5n5q';
-    expect(aesDecryptFromBase64(aesEncryptToBase64('test', key), key)).toBe('test');
-    expect(aesDecryptFromBase64('TGBv/lDGJdJo9SK8kDxiaEnu3i9dFxUhl5pDJVDzCG8=', key)).toBe('test');
-});
+  const key = 'mVRW8ycqHYZQSgYcBN8PUz8hVRWB5n5q'
+  expect(aesDecryptFromBase64(aesEncryptToBase64('test', key), key)).toBe('test')
+  expect(aesDecryptFromBase64('TGBv/lDGJdJo9SK8kDxiaEnu3i9dFxUhl5pDJVDzCG8=', key)).toBe('test')
+})
 
 test('wrong input', () => {
-    const key = 'mVRW8ycqHYZQSgYcBN8PUz8hVRWB5n5q';
-    expect(aesDecryptFromBase64(aesEncryptToBase64('test', key), key + '1')).toBe('');
-    expect(aesDecryptFromBase64('a' + aesEncryptToBase64('test', key), key)).toBe('');
-    expect(aesDecryptFromBase64('TGBv/lDGJdJo9SK8kDxiaEnu4i9dFxUhl5pDJVDzCG8=', key)).toBe('');
-});
+  const key = 'mVRW8ycqHYZQSgYcBN8PUz8hVRWB5n5q'
+  // 'test' encrypted under `key` (same vector as the round-trip test above).
+  // CBC+Pkcs7 without a MAC cannot promise '' for every wrong-key input: with
+  // ~1/256 probability the garbage plaintext carries coincidentally valid
+  // padding, so re-encrypting with a random IV each run made the old strict
+  // assertion flake. Fixed ciphertexts keep the assertion strict AND
+  // deterministic; the random-IV encrypt path stays covered by the
+  // round-trip tests.
+  const cipher = 'TGBv/lDGJdJo9SK8kDxiaEnu3i9dFxUhl5pDJVDzCG8='
+  expect(aesDecryptFromBase64(cipher, key + '1')).toBe('')
+  expect(aesDecryptFromBase64('a' + cipher, key)).toBe('')
+  expect(aesDecryptFromBase64('TGBv/lDGJdJo9SK8kDxiaEnu4i9dFxUhl5pDJVDzCG8=', key)).toBe('')
+})
 
 test('random input', () => {
-    const key = 'mVRW8ycqHYZQSgYcBN8PUz8hVRWB5n5q';
-    // try length 1 to 10
-    for (let l = 1; l < 10; l++) {
-        // 10 tries
-        for (let i = 0; i < 10; i++) {
-            // generate random string
-            let s = '';
-            for (let i = 0; i < l; i++) {
-                s += String.fromCharCode(Math.floor(Math.random() * 256));
-            }
-            expect(aesDecryptFromBase64(aesEncryptToBase64(s, key), key)).toBe(s);
-        }
+  const key = 'mVRW8ycqHYZQSgYcBN8PUz8hVRWB5n5q'
+  // try length 1 to 10
+  for (let l = 1; l < 10; l++) {
+    // 10 tries
+    for (let i = 0; i < 10; i++) {
+      // generate random string
+      let s = ''
+      for (let i = 0; i < l; i++) {
+        s += String.fromCharCode(Math.floor(Math.random() * 256))
+      }
+      expect(aesDecryptFromBase64(aesEncryptToBase64(s, key), key)).toBe(s)
     }
-});
+  }
+})


### PR DESCRIPTION
## Summary

`CryptoUtils.test.ts › wrong input` intermittently fails CI (latest: run 32896847698 on #525 after a dev merge re-triggered the workflow). The test decrypted freshly-encrypted data with a wrong key and demanded `''`, but `aesDecryptFromBase64` is CBC+Pkcs7 without a MAC: with ~1/256 probability the garbage plaintext carries coincidentally valid padding and a non-empty string comes back. The encrypt IV is random, so every run sampled a new lottery ticket.

Measured over 10,000 iterations of the original scenario: 56 non-empty results (~1/178 per assertion; reviewer independently measured 35/8000 and 39/8000) — with two such assertions the test flaked roughly once per ~90 CI runs.

## Change

- The wrong-key and corrupted-input assertions now run against the **fixed ciphertext** already used by the round-trip test, so the strict `''` expectation stays and the RNG leaves the path entirely (per review): deterministic by construction, no weakened contract.
- Documented the no-MAC contract at `aesDecryptFromBase64`; the only production caller (`isValidBarmaliniPassword`) validates the decrypted value by parsing it as a date with a ±1h window (reviewer confirmed 0/8000 garbage outputs pass it).

## Verification

- `npx jest test/parser/CryptoUtils.test.ts` — 3/3, repeated runs stable.
- Both fixed-vector assertions verified to return `''` independently by reviewer and author.