### PR TITLE
Update GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -29,7 +29,7 @@ jobs:
         run: zip -m -P $BACKUP_PASSWORD ${{ env.backupFileName }}.zip ${{ env.backupFileName }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.backupFileName }}
           path: ${{ env.backupFileName }}.zip

--- a/.github/workflows/backup-media.yml
+++ b/.github/workflows/backup-media.yml
@@ -13,7 +13,7 @@ jobs:
     environment: StagingRO
     runs-on: [self-hosted, stage]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           path: media_backup_src
       - name: Run backup

--- a/.github/workflows/build-docker-dev.yml
+++ b/.github/workflows/build-docker-dev.yml
@@ -21,7 +21,7 @@ jobs:
             dc-file: [docker-compose.ssl.local.yml, docker-compose.local.yml]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Build backend & frontend
         run: docker compose -f ${{ matrix.dc-file }} build --no-cache backend frontend feed
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Validate docker-compose.dev.yml
         run: docker compose -f docker-compose.dev.yml config

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,12 @@ jobs:
       matrix:
         module: [backend, frontend]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "18"
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: npm-${{matrix.module}}-${{ hashFiles(format('./{0}/package.json', matrix.module)) }}

--- a/.github/workflows/deploy-universal.yml
+++ b/.github/workflows/deploy-universal.yml
@@ -76,7 +76,7 @@ jobs:
     environment: ${{ github.event.inputs.environment == 'stage' && 'Staging' || 'Production' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Verify environment
         run: |

--- a/.github/workflows/prettier-format.yml
+++ b/.github/workflows/prettier-format.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Ensure full history if needed
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 18
 

--- a/.github/workflows/restore-sanitized-db.yml
+++ b/.github/workflows/restore-sanitized-db.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Download DB backup
         id: get-db
@@ -39,7 +39,7 @@ jobs:
       - name: Load DB
         run: cat ${{ steps.get-db.outputs.db-dump-file }} | /usr/bin/mysql -h 127.0.0.1 -u root -p$MYSQL_ROOT_PASSWORD
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Remove PII
         run: |
@@ -61,7 +61,7 @@ jobs:
           zip -m -P $STAGING_BACKUP_PASSWORD stage-backup.zip stage-backup.sql
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: stage-backup
           path: stage-backup.zip
@@ -72,7 +72,7 @@ jobs:
     environment: Staging
     runs-on: [self-hosted, stage]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Download DB backup
         uses: ./.github/actions/get-db

--- a/.github/workflows/review-check.yml
+++ b/.github/workflows/review-check.yml
@@ -35,7 +35,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check reviews
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Determine PR number — from event (merge trigger) or input (manual dispatch)


### PR DESCRIPTION
## Summary

Split out of #535 per review — the two halves had opposite verification stories, and this half needs its own.

Bumps across 8 workflows: `actions/checkout` v2/v3→v7, `actions/upload-artifact` v4→v7, `actions/setup-node` v1/v3→v7, `actions/cache` v3→v6, `actions/github-script` v7→v9. All bumped majors run on `node24` and put a **minimum runner floor of 2.327.1** under self-hosted runners.

## Why the floor matters here

Four jobs run on self-hosted runners and none of them execute on `pull_request`, so green checks on this PR prove nothing about them: `deploy-universal/deployment` (`[self-hosted, ${{ inputs.environment }}]`), `backup-db` (`[self-hosted, prod]`, schedule), `backup-media` (`[self-hosted, stage]`, schedule), `restore-sanitized-db/restore-db` (`[self-hosted, stage]`, schedule). An incompatible runner would first surface as a failed deploy or a silently missing backup artifact, not a red check.

## Verification checklist

- [x] `ubuntu-latest` paths (`build-lint`, `build-docker`, `validate-docker-compose`, `prettier`) — covered by this PR's checks.
- [x] **prod runner = 2.336.0** ≥ 2.327.1 — read from "Set up job" in the nightly `backup-db` log (run 32923493952, 2026-08-26). Scheduled prod backup is safe.
- [x] **stage runner: version unknown and the runner itself looks unhealthy** — the last `restore-sanitized-db` run has `restore-db` stuck `waiting` since 2026-08-24, the prior one was cancelled, and `backup-media` has no runs to read a version from. Needs someone with admin access (runners API returns 403 for non-admins): Settings → Actions → Runners. This predates the bump.
- [x] `review-check` script vs `github-script@v9` breaking changes (`require('@actions/github')`, `getOctokit` redeclaration) — neither pattern present (checked in review).
- [ ] `review-check` runs from the **base** branch (`pull_request_target`), so the v9 bump cannot be exercised pre-merge: after merging, run its `workflow_dispatch` with `pr_number` of an already-merged PR once to confirm.
- [x] `setup-node` auto-caching double-up: non-issue — neither `backend/package.json` nor `frontend/package.json` has a `packageManager` field (checked in review).

Recommendation: hold merge until the stage runner question is answered or stage jobs are explicitly accepted as at-risk.