### PR TITLE
fix(profile): don't save the viewed user's display name on a stray Enter

### DIFF
--- a/frontend/src/Components/UserProfileName.tsx
+++ b/frontend/src/Components/UserProfileName.tsx
@@ -19,7 +19,12 @@ export default function UserProfileName(props: UserProfileNameProps) {
   const [editing, setEditing] = useState(false)
   const [name, setName] = useState(props.name)
   const api = useAPI()
+  // Only listen for Enter while our own name is actually being edited. When the input is not
+  // rendered the ref is detached and react-hotkeys-hook falls back to a document-wide listener,
+  // so Enter pressed in any other <input> on the page (e.g. the posts/comments filter) would
+  // otherwise save the *viewed* profile's name onto the current user's account.
   const refEditName = useHotkeys<HTMLInputElement>('enter', () => handleEditNameComplete(), {
+    enabled: editing && props.mine,
     enableOnFormTags: ['INPUT'],
     preventDefault: true,
   })
@@ -33,6 +38,9 @@ export default function UserProfileName(props: UserProfileNameProps) {
   }
 
   const handleEditNameComplete = async () => {
+    if (!props.mine || !editing) {
+      return
+    }
     try {
       await api.userAPI.saveName(name)
       setEditing(false)


### PR DESCRIPTION
## Problem

Users' display names (`users.name`, the line under the nickname) were getting silently replaced with **other users' display names**. Reported today by lndr (`/u/Lender`), whose name became naked_singularity's «Плод распущенного воображения одержимых личностей».

Prod log for that session (UTC, 2026‑08‑28):

```
15:19:47  POST /user/profile   {"username":"naked_singularity"}
15:19:48  POST /user/comments  {"username":"naked_singularity","filter":""}
15:19:51  POST /user/savename  {"name":"Плод распущенного воображения одержимых личностей"}
15:19:52  POST /user/comments  {"username":"naked_singularity","filter":"призраками"}
```

i.e. open someone's profile → Comments tab → type in the filter box → press **Enter** → your own display name is overwritten with theirs. At least two more users were hit the same way in the last 5 days (`mahinaci9` → "Denis Reich", `pesnya_skazka` → "прекрасное").

## Cause

`UserProfileName` registered its `enter` hotkey unconditionally (since #340):

```ts
const refEditName = useHotkeys<HTMLInputElement>('enter', () => handleEditNameComplete(), {
  enableOnFormTags: ['INPUT'],
  preventDefault: true,
})
```

- The ref is only attached to the `<input>` while editing. When it's detached, react-hotkeys-hook binds the listener to `document` instead, and `enableOnFormTags: ['INPUT']` lets it fire from **any** `<input>` on the page (posts/comments filter, karma inputs…).
- `handleEditNameComplete` didn't check `mine`, and `name` state mirrors the *viewed* profile's name — so it called `saveName(<other user's name>)` with the visitor's session.

## Fix

- `enabled: editing && props.mine` on the hotkey — with `enabled: false` the hook doesn't attach a listener at all, so Enter in the filter box is no longer intercepted (nor `preventDefault`ed).
- Defensive early return in `handleEditNameComplete` unless `props.mine && editing`.

## Test plan

- [x] `eslint`, `prettier --check`, `tsc --noEmit` pass
- [x] Open another user's profile → Posts/Comments tab → type in the filter → Enter: filter applies, **no** `POST /user/savename` in the network tab — verified locally (logged in as `Lender`, `/u/naked_singularity/comments`, filter «призраками» + Enter → only `/user/comments`, DB name unchanged)
- [x] Control: same steps with the pre-fix component → `POST /user/savename {"name":"🕳️"}` fires and `Lender`'s name is overwritten (bug reproduced, then fix restored)
- [x] Own profile → pencil → edit name → Enter saves (`POST /user/savename` fires, name updates) — verified locally

Follow-up (ops, not in this PR): restore the overwritten names on prod — `Lender` (495) → «Иљя Илюша Илюха», `mahinaci9` (383) → «Тайка», `pesnya_skazka` (918) → «де б я був, якби мене не було?» (values from this morning's staging snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEthEYzLXbksKU6Yiscjou
