### PR TITLE
feat(admin): loopback-only cache admin server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,4 @@ Within `frontend/` and `backend/` you can run:
 
 - Architecture overview: `docs/architecture.md`
 - API documentation: `docs/api/README.md`
+- Admin cache server (loopback-only ops endpoints): `docs/admin-server.md`

--- a/backend/src/admin/AdminServer.ts
+++ b/backend/src/admin/AdminServer.ts
@@ -190,8 +190,8 @@ export function buildAdminRoutes(deps: AdminDeps): AdminRoute[] {
       path: '/cache/karma/evict',
       description:
         'Delete the Redis karma caches of one user (userId or username): active_karma_votes, trial_progress, ' +
-        'remove_votes_when_karma_is_low, is_user_active. With asVoter=true also the active_karma_votes and ' +
-        'trial_progress of everyone the user has karma-voted (those are keyed by voter username). ' +
+        'remove_votes_when_karma_is_low, is_user_active. With asVoter=true also active_karma_votes_<targetId> of ' +
+        'everyone the user has karma-voted: that value is a map keyed by voter username, so it goes stale on a rename. ' +
         'karma_penalty is state, never touched.',
       schema: userRef.keys({ asVoter: Joi.boolean().default(false) }),
       handler: async (params) => {

--- a/backend/src/admin/AdminServer.ts
+++ b/backend/src/admin/AdminServer.ts
@@ -100,6 +100,14 @@ async function resolveUserId(userManager: UserManager, params: AdminParams): Pro
   return user.id
 }
 
+/** Session ids are bearer credentials; keep them out of the (root-readable) logs. */
+function maskSecrets(params: AdminParams): AdminParams {
+  if (typeof params.sessionId !== 'string') {
+    return params
+  }
+  return { ...params, sessionId: params.sessionId.slice(0, 6) + '…' }
+}
+
 export function buildAdminRoutes(deps: AdminDeps): AdminRoute[] {
   const { userManager, siteManager, feedManager, postManager, inviteManager } = deps
   return [
@@ -260,17 +268,18 @@ export function createAdminApp(deps: AdminDeps, logger: Logger): express.Express
         return
       }
       const params = value as AdminParams
+      const loggedParams = maskSecrets(params)
       try {
         const payload = await route.handler(params)
-        logger.info(`${route.method} ${route.path}`, { params, payload })
+        logger.info(`${route.method} ${route.path}`, { params: loggedParams, payload })
         res.json({ result: 'success', payload })
       } catch (err) {
         if (err instanceof AdminError) {
-          logger.warn(`${route.method} ${route.path}: ${err.message}`, { params })
+          logger.warn(`${route.method} ${route.path}: ${err.message}`, { params: loggedParams })
           res.status(err.status).json({ result: 'error', code: err.code, message: err.message })
           return
         }
-        logger.error(`${route.method} ${route.path} failed`, { params, error: err })
+        logger.error(`${route.method} ${route.path} failed`, { params: loggedParams, error: err })
         res.status(500).json({
           result: 'error',
           code: 'error',

--- a/backend/src/admin/AdminServer.ts
+++ b/backend/src/admin/AdminServer.ts
@@ -1,0 +1,317 @@
+import http from 'http'
+
+import express, { NextFunction, Request, Response } from 'express'
+import Joi from 'joi'
+import { Logger } from 'winston'
+
+import FeedManager from '../managers/FeedManager'
+import InviteManager from '../managers/InviteManager'
+import PostManager from '../managers/PostManager'
+import SiteManager from '../managers/SiteManager'
+import UserManager from '../managers/UserManager'
+import { evictSessionFromMemory, evictSessionsFromMemory, sessionMemoryStats } from '../session/Session'
+
+/**
+ * Loopback-only operations server.
+ *
+ * It listens on 127.0.0.1 inside the backend container, so the only way to reach it is
+ * `docker exec <backend> curl localhost:<ADMIN_PORT>/...`, i.e. root access to the box.
+ * Nothing here is proxied by Caddy and there are no credentials to leak.
+ *
+ * Every route is a building block over a single cache. Anything that is already easy to do
+ * with SQL or redis-cli (data changes, re-parsing content via parser_version, ...) does not
+ * belong here; this exists only for state that lives in the process memory or that cannot
+ * be targeted safely from outside.
+ *
+ * Responses use the same {result, payload} envelope as the public API. `GET /` lists the routes.
+ */
+
+export type AdminDeps = {
+  userManager: UserManager
+  siteManager: SiteManager
+  feedManager: FeedManager
+  postManager: PostManager
+  inviteManager: InviteManager
+}
+
+export class AdminError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message)
+  }
+}
+
+const LOOPBACK_ADDRESSES = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1'])
+
+export function isLoopbackAddress(address: string | undefined): boolean {
+  return address !== undefined && LOOPBACK_ADDRESSES.has(address)
+}
+
+/**
+ * Defense in depth: the server already binds to 127.0.0.1, this rejects anything else that could
+ * still get through (a changed bind address, a misconfigured proxy). Checks the raw TCP peer, not
+ * `req.ip`, because the latter honours X-Forwarded-For.
+ */
+export function loopbackOnly(logger: Logger) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const address = req.socket.remoteAddress
+    if (!isLoopbackAddress(address)) {
+      logger.warn('Rejected admin request from a non-loopback address', { address, url: req.url })
+      res.status(403).json({ result: 'error', code: 'forbidden', message: 'Admin API is loopback-only' })
+      return
+    }
+    next()
+  }
+}
+
+type AdminParams = Record<string, unknown>
+
+type AdminRoute = {
+  method: 'GET' | 'POST'
+  path: string
+  description: string
+  schema: Joi.ObjectSchema
+  handler: (params: AdminParams) => Promise<unknown>
+}
+
+const userRef = Joi.object({
+  userId: Joi.number().integer().positive(),
+  username: Joi.string(),
+}).xor('userId', 'username')
+
+const noParams = Joi.object({})
+
+/**
+ * A username is resolved through the user cache first (then the DB), on purpose: the typical
+ * reason to evict by name is that the cache still holds a name the DB no longer has.
+ */
+async function resolveUserId(userManager: UserManager, params: AdminParams): Promise<number> {
+  if (typeof params.userId === 'number') {
+    return params.userId
+  }
+  const username = String(params.username)
+  const user = await userManager.getByUsername(username)
+  if (!user) {
+    throw new AdminError(404, 'not-found', `User "${username}" is neither cached nor in the DB`)
+  }
+  return user.id
+}
+
+export function buildAdminRoutes(deps: AdminDeps): AdminRoute[] {
+  const { userManager, siteManager, feedManager, postManager, inviteManager } = deps
+  return [
+    {
+      method: 'GET',
+      path: '/cache/stats',
+      description: 'Sizes of every in-process cache.',
+      schema: noParams,
+      handler: async () => ({
+        users: userManager.userCacheStats(),
+        sites: siteManager.cacheStats(),
+        feedSubscriptions: feedManager.userSubscriptionsCacheStats(),
+        contentCounters: postManager.contentNumberCacheStats(),
+        invitesAvailability: inviteManager.invitesAvailabilityCacheStats(),
+        sessions: sessionMemoryStats(),
+      }),
+    },
+    {
+      method: 'GET',
+      path: '/cache/users/inspect',
+      description:
+        'Cached user entries next to the DB row (userId or username). ' +
+        '`drift` is true when a cached username differs from the DB, `cache.consistent` is false when a username key is orphaned.',
+      schema: userRef,
+      handler: async (params) => {
+        const userId = await resolveUserId(userManager, params)
+        const cache = userManager.inspectUserCache(userId)
+        const db = await userManager.getUserInfoFromDb(userId)
+        const dbUsername = db ? db.username : undefined
+        const drift =
+          (cache.byId !== undefined && cache.byId.username !== dbUsername) ||
+          cache.usernameKeys.some((username) => username !== dbUsername)
+        return { userId, cache, db, drift }
+      },
+    },
+    {
+      method: 'POST',
+      path: '/cache/users/evict',
+      description:
+        'Evict one user (userId or username) from every in-process cache: identity by id and by any username key, ' +
+        'restrictions, last visit, feed subscriptions, content counters, invite availability. ' +
+        'A username is looked up in the cache first, so a stale name still works.',
+      schema: userRef,
+      handler: async (params) => {
+        const userId = await resolveUserId(userManager, params)
+        return {
+          userId,
+          user: userManager.evictUserCaches(userId),
+          feedSubscriptions: feedManager.clearUserSubscriptionsCache(userId),
+          contentCounters: postManager.clearContentNumberCache(userId),
+          invitesAvailability: inviteManager.clearInvitesAvailabilityCache(userId),
+        }
+      },
+    },
+    {
+      method: 'POST',
+      path: '/cache/users/evict-all',
+      description:
+        'Drop every in-process user cache. The username suggestions trie is kept, rebuild it separately. ' +
+        'Returns the sizes that were dropped.',
+      schema: noParams,
+      handler: async () => ({
+        user: userManager.clearAllCaches(),
+        feedSubscriptions: feedManager.clearUserSubscriptionsCache(),
+        contentCounters: postManager.clearContentNumberCache(),
+        invitesAvailability: inviteManager.clearInvitesAvailabilityCache(),
+      }),
+    },
+    {
+      method: 'POST',
+      path: '/cache/usernames/rebuild',
+      description:
+        'Rebuild the username suggestions trie (@mention autocomplete) from the DB. ' +
+        'The trie only grows on registration, so renames and deletions need this.',
+      schema: noParams,
+      handler: async () => ({ usernames: await userManager.rebuildUsernameSuggestions() }),
+    },
+    {
+      method: 'POST',
+      path: '/cache/karma/evict',
+      description:
+        'Delete the Redis karma caches of one user (userId or username): active_karma_votes, trial_progress, ' +
+        'remove_votes_when_karma_is_low, is_user_active. With asVoter=true also the active_karma_votes and ' +
+        'trial_progress of everyone the user has karma-voted (those are keyed by voter username). ' +
+        'karma_penalty is state, never touched.',
+      schema: userRef.keys({ asVoter: Joi.boolean().default(false) }),
+      handler: async (params) => {
+        const userId = await resolveUserId(userManager, params)
+        return { userId, deleted: await userManager.evictKarmaCaches(userId, params.asVoter === true) }
+      },
+    },
+    {
+      method: 'POST',
+      path: '/cache/karma/evict-all',
+      description:
+        'Delete every Redis karma cache key, same families as /cache/karma/evict. Returns counts per pattern.',
+      schema: noParams,
+      handler: async () => ({ deleted: await userManager.evictAllKarmaCaches() }),
+    },
+    {
+      method: 'POST',
+      path: '/cache/sites/evict',
+      description: 'Evict one site from the in-process site cache (siteId or site subdomain).',
+      schema: Joi.object({
+        siteId: Joi.number().integer().positive(),
+        site: Joi.string(),
+      }).xor('siteId', 'site'),
+      handler: async (params) => ({
+        removed: siteManager.clearCache({ siteId: params.siteId as number, site: params.site as string }),
+      }),
+    },
+    {
+      method: 'POST',
+      path: '/cache/sites/evict-all',
+      description: 'Drop the whole in-process site cache.',
+      schema: noParams,
+      handler: async () => ({ removed: siteManager.clearCache() }),
+    },
+    {
+      method: 'POST',
+      path: '/cache/sessions/evict',
+      description:
+        'Drop in-memory session entries for a user (userId) or one session (sessionId). ' +
+        'The sessions table is not touched: delete rows there first when the goal is a forced logout, ' +
+        'the process keeps honouring cached sessions until they are evicted here.',
+      schema: Joi.object({
+        userId: Joi.number().integer().positive(),
+        sessionId: Joi.string(),
+      }).xor('userId', 'sessionId'),
+      handler: async (params) =>
+        typeof params.sessionId === 'string'
+          ? { removed: evictSessionFromMemory(params.sessionId) ? 1 : 0 }
+          : { removed: evictSessionsFromMemory(params.userId as number) },
+    },
+  ]
+}
+
+export function createAdminApp(deps: AdminDeps, logger: Logger): express.Express {
+  const routes = buildAdminRoutes(deps)
+  const app = express()
+  app.disable('x-powered-by')
+  app.use(loopbackOnly(logger))
+  app.use(express.json())
+
+  app.get('/', (req, res) => {
+    res.json({
+      result: 'success',
+      payload: { routes: routes.map(({ method, path, description }) => ({ method, path, description })) },
+    })
+  })
+
+  for (const route of routes) {
+    const handle = async (req: Request, res: Response) => {
+      const raw = route.method === 'GET' ? req.query : req.body
+      const { error, value } = route.schema.validate(raw || {}, { convert: true })
+      if (error) {
+        res.status(400).json({ result: 'error', code: 'invalid-params', message: error.message })
+        return
+      }
+      const params = value as AdminParams
+      try {
+        const payload = await route.handler(params)
+        logger.info(`${route.method} ${route.path}`, { params, payload })
+        res.json({ result: 'success', payload })
+      } catch (err) {
+        if (err instanceof AdminError) {
+          logger.warn(`${route.method} ${route.path}: ${err.message}`, { params })
+          res.status(err.status).json({ result: 'error', code: err.code, message: err.message })
+          return
+        }
+        logger.error(`${route.method} ${route.path} failed`, { params, error: err })
+        res.status(500).json({
+          result: 'error',
+          code: 'error',
+          message: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+    if (route.method === 'GET') {
+      app.get(route.path, handle)
+    } else {
+      app.post(route.path, handle)
+    }
+  }
+
+  app.all('*', (req, res) => {
+    res.status(404).json({ result: 'error', code: '404', message: 'Unknown admin endpoint, GET / lists them' })
+  })
+
+  // malformed JSON bodies end up here
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+    res.status(400).json({ result: 'error', code: 'bad-request', message: err.message })
+  })
+
+  return app
+}
+
+/**
+ * Starts the admin server on 127.0.0.1:port. A failure to bind is logged and swallowed: the
+ * public API must not go down because an auxiliary port is busy.
+ */
+export function startAdminServer(deps: AdminDeps, port: number, logger: Logger): Promise<http.Server | undefined> {
+  return new Promise((resolve) => {
+    const server = http.createServer(createAdminApp(deps, logger))
+    server.once('error', (error) => {
+      logger.error('Could not start the admin server, continuing without it', { error })
+      resolve(undefined)
+    })
+    server.listen(port, '127.0.0.1', () => {
+      logger.info(`Admin server is listening on 127.0.0.1:${port} (loopback only)`)
+      resolve(server)
+    })
+  })
+}

--- a/backend/src/api/UserController.ts
+++ b/backend/src/api/UserController.ts
@@ -151,7 +151,6 @@ export default class UserController {
       oauth('читать инфо о карме пользователя'),
       (req, res) => this.karma(req, res),
     )
-    this.router.post('/user/clearCache', validate(profileSchema), (req, res) => this.clearCache(req, res))
     this.router.post(
       '/user/restrictions',
       sharedReadRateLimiter,
@@ -476,27 +475,6 @@ export default class UserController {
       })
     } catch (error) {
       this.logger.error('Could not get user restrictions', { username, error })
-      return response.error('error', `Could not get restrictions for user ${username}`, 500)
-    }
-  }
-
-  async clearCache(request: APIRequest<UserProfileRequest>, response: APIResponse<void>) {
-    if (!request.session.data.userId) {
-      return response.authRequired()
-    }
-    const { username } = request.body
-
-    try {
-      const profile = await this.userManager.getByUsername(username)
-
-      if (!profile) {
-        return response.error(ERROR_CODES.NOT_FOUND, 'User not found', 404)
-      }
-
-      this.userManager.clearCache(profile.id)
-      this.userManager.clearUserRestrictionsCache(profile.id)
-    } catch (error) {
-      this.logger.error('Something went wrong', { username, error })
       return response.error('error', `Could not get restrictions for user ${username}`, 500)
     }
   }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,6 +9,7 @@ import helmet from 'helmet'
 import jsonStringify from 'safe-stable-stringify'
 import winston from 'winston'
 
+import { startAdminServer } from './admin/AdminServer'
 import { apiMiddleware } from './api/ApiMiddleware'
 import AuthController from './api/AuthController'
 import FeedController from './api/FeedController'
@@ -336,6 +337,14 @@ app.all('*', (req, res) => {
         reject(error)
       })
   })
+
+  if (config.adminPort > 0) {
+    await startAdminServer(
+      { userManager, siteManager, feedManager, postManager, inviteManager },
+      config.adminPort,
+      logger.child({ service: 'ADMIN' }),
+    )
+  }
 })()
   .then(() => {
     logger.info('Backend ready')

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,5 +1,7 @@
 type Config = {
   port: number
+  /** loopback-only admin server (see admin/AdminServer.ts), 0 disables it */
+  adminPort: number
   logLevel: string
   mysql: MysqlConfig
   redis: RedisConfig
@@ -65,6 +67,7 @@ export type OAuthConfig = {
 
 export const config: Config = {
   port: parseInt(process.env.SERVER_PORT) || 5001,
+  adminPort: process.env.ADMIN_PORT === undefined ? 5002 : parseInt(process.env.ADMIN_PORT) || 0,
   logLevel: process.env.LOG_LEVEL || 'info',
   mysql: {
     host: process.env.MYSQL_HOST || 'mysql',

--- a/backend/src/db/repositories/VoteRepository.ts
+++ b/backend/src/db/repositories/VoteRepository.ts
@@ -24,6 +24,15 @@ export default class VoteRepository {
     this.db = db
   }
 
+  /** Ids of every user this voter has a karma vote on (any value, including 0). */
+  async getKarmaVoteTargetIds(voterId: number): Promise<number[]> {
+    const rows = await this.db.fetchAll<{ user_id: number }>(
+      'select user_id from user_karma where voter_id = :voter_id',
+      { voter_id: voterId },
+    )
+    return rows.map((row) => row.user_id)
+  }
+
   async getUserVote(userId: number, byUserId: number): Promise<number> {
     const voteResult = await this.db.fetchOne<{ vote: number }>(
       'select vote from user_karma where user_id=:user_id and voter_id=:voter_id',

--- a/backend/src/managers/FeedManager.ts
+++ b/backend/src/managers/FeedManager.ts
@@ -68,6 +68,20 @@ export default class FeedManager {
     this.logger = logger
   }
 
+  /** Drops the cached site subscriptions of one user, or of everyone when no user is given. */
+  public clearUserSubscriptionsCache(userId?: number): number {
+    if (userId === undefined) {
+      const removed = this.userSubscriptionsCache.size
+      this.userSubscriptionsCache.clear()
+      return removed
+    }
+    return this.userSubscriptionsCache.delete(userId) ? 1 : 0
+  }
+
+  public userSubscriptionsCacheStats(): number {
+    return this.userSubscriptionsCache.size
+  }
+
   private offsetPostTs(ts: Date): number {
     if (!this.minDate) {
       return 0

--- a/backend/src/managers/InviteManager.ts
+++ b/backend/src/managers/InviteManager.ts
@@ -28,6 +28,20 @@ export default class InviteManager {
     this.parser = parser
   }
 
+  /** Drops the cached invite availability of one user, or of everyone when no user is given. */
+  public clearInvitesAvailabilityCache(userId?: number): number {
+    if (userId === undefined) {
+      const removed = this.invitesAvailabilityCache.size
+      this.invitesAvailabilityCache.clear()
+      return removed
+    }
+    return this.invitesAvailabilityCache.delete(userId) ? 1 : 0
+  }
+
+  public invitesAvailabilityCacheStats(): number {
+    return this.invitesAvailabilityCache.size
+  }
+
   async get(code: string): Promise<InviteRawWithIssuer | undefined> {
     return await this.inviteRepository.getInviteWithIssuer(code)
   }

--- a/backend/src/managers/PostManager.ts
+++ b/backend/src/managers/PostManager.ts
@@ -53,6 +53,30 @@ export default class PostManager {
     this.parser = parser
   }
 
+  /** Drops the cached post/comment counters of one user, or of everyone when no user is given. */
+  public clearContentNumberCache(userId?: number): { posts: number; comments: number } {
+    if (userId === undefined) {
+      const removed = this.contentNumberCacheStats()
+      this.numberOfPostsCache = {}
+      this.numberOfCommentsCache = {}
+      return removed
+    }
+    const removed = {
+      posts: userId in this.numberOfPostsCache ? 1 : 0,
+      comments: userId in this.numberOfCommentsCache ? 1 : 0,
+    }
+    delete this.numberOfPostsCache[userId]
+    delete this.numberOfCommentsCache[userId]
+    return removed
+  }
+
+  public contentNumberCacheStats(): { posts: number; comments: number } {
+    return {
+      posts: Object.keys(this.numberOfPostsCache).length,
+      comments: Object.keys(this.numberOfCommentsCache).length,
+    }
+  }
+
   async getPost(postId: number, forUserId: number, format: ContentFormat): Promise<PostInfo | undefined> {
     const [rawPost] = await this.postRepository.getPostsWithUserData([postId], forUserId)
     return (await this.feedManager.convertRawPosts(forUserId, [rawPost], format))[0]

--- a/backend/src/managers/SiteManager.ts
+++ b/backend/src/managers/SiteManager.ts
@@ -14,6 +14,37 @@ export default class SiteManager {
     this.userManager = userManager
   }
 
+  /**
+   * Evicts one site (by id or subdomain) or, without a target, every cached site.
+   * Returns the number of cache entries removed (a site is held under its name and its id).
+   */
+  public clearCache(target?: { siteId?: number; site?: string }): number {
+    if (!target || (target.siteId === undefined && target.site === undefined)) {
+      const removed = Object.keys(this.cache).length + Object.keys(this.cacheId).length
+      this.cache = {}
+      this.cacheId = {}
+      return removed
+    }
+    let removed = 0
+    for (const [name, site] of Object.entries(this.cache)) {
+      if (name === target.site || (site !== undefined && site.id === target.siteId)) {
+        delete this.cache[name]
+        removed++
+      }
+    }
+    for (const [id, site] of Object.entries(this.cacheId)) {
+      if (Number(id) === target.siteId || (site !== undefined && site.site === target.site)) {
+        delete this.cacheId[Number(id)]
+        removed++
+      }
+    }
+    return removed
+  }
+
+  public cacheStats(): { byName: number; byId: number } {
+    return { byName: Object.keys(this.cache).length, byId: Object.keys(this.cacheId).length }
+  }
+
   async getSiteByName(siteName: string): Promise<SiteInfo | undefined> {
     let site = this.cache[siteName]
     if (site !== undefined) {

--- a/backend/src/managers/UserCache.ts
+++ b/backend/src/managers/UserCache.ts
@@ -4,6 +4,34 @@ import UserRepository from '../db/repositories/UserRepository'
 import { UserRaw } from '../db/types/UserRaw'
 import { UserInfo, UserStats } from './types/UserInfo'
 
+export type UserCacheEviction = {
+  byId: boolean
+  /** every username key that pointed at the user, including ones left behind by a rename */
+  usernameKeys: string[]
+  publicKey: boolean
+  parent: boolean
+  stats: boolean
+}
+
+export type UserCacheStats = {
+  byId: number
+  byUsername: number
+  parents: number
+  publicKeys: number
+  stats: number
+  usernameSuggestions: number
+}
+
+export type UserCacheInspection = {
+  byId: UserInfo | undefined
+  usernameKeys: string[]
+  /** false when a username key points at a different object than the id entry (an orphan) */
+  consistent: boolean
+  publicKeyCached: boolean
+  parentCached: boolean
+  statsCached: boolean
+}
+
 export class UserCache {
   private userRepository: UserRepository
   /**
@@ -17,29 +45,38 @@ export class UserCache {
   private cacheUsername: Record<string, UserInfo> = {}
   private cachedUserParents: Record<number, number | undefined | false> = {}
   private cachedPublicKeys: Record<number, string | undefined> = {}
-  private usernamesSuggestionsCache = new TrieSearch('k', { min: 1 })
+  private usernamesSuggestionsCache = UserCache.createSuggestionsTrie()
+  private usernamesSuggestionsCount = 0
   private userStatsCache = new Map<number, UserStats>()
 
   constructor(userRepository: UserRepository) {
     this.userRepository = userRepository
     ;(async () => {
-      await this.createUsernamesSuggestionsCache()
+      await this.rebuildUsernameSuggestions()
     })()
   }
 
-  private async createUsernamesSuggestionsCache() {
+  private static createSuggestionsTrie() {
+    return new TrieSearch('k', { min: 1 })
+  }
+
+  /**
+   * Rebuilds the username suggestions trie from the DB and swaps it in atomically.
+   * The trie only ever grows (on registration), so renames and deletions need this.
+   * Returns the number of usernames loaded.
+   */
+  public async rebuildUsernameSuggestions(): Promise<number> {
+    const trie = UserCache.createSuggestionsTrie()
     const usersCount = await this.userRepository.getUserCount()
+    let count = 0
     for (let i = 0; i < usersCount; i += 1000) {
       const usernames = await this.userRepository.getUsernames(i)
-      const entries = []
-      usernames.map((user) => {
-        entries.push({
-          k: user.username.toLowerCase(),
-          v: user.username,
-        })
-      })
-      this.usernamesSuggestionsCache.addAll(entries)
+      trie.addAll(usernames.map((user) => ({ k: user.username.toLowerCase(), v: user.username })))
+      count += usernames.length
     }
+    this.usernamesSuggestionsCache = trie
+    this.usernamesSuggestionsCount = count
+    return count
   }
 
   private initialize() {
@@ -104,14 +141,67 @@ export class UserCache {
     return users
   }
 
-  public clearCache(userId: number) {
-    const cacheEntry = this.cacheId[userId]
-    if (!cacheEntry) {
-      return
-    }
+  /**
+   * Evicts everything cached for the user. Username keys are matched by the cached id rather than
+   * by the name of the current id entry, so keys left behind by a rename are removed as well.
+   */
+  public clearCache(userId: number): UserCacheEviction {
+    const byId = userId in this.cacheId
     delete this.cacheId[userId]
-    delete this.cacheUsername[cacheEntry.username]
+
+    const usernameKeys: string[] = []
+    for (const [username, user] of Object.entries(this.cacheUsername)) {
+      if (user.id === userId) {
+        usernameKeys.push(username)
+        delete this.cacheUsername[username]
+      }
+    }
+
+    const publicKey = userId in this.cachedPublicKeys
     delete this.cachedPublicKeys[userId]
+    const parent = userId in this.cachedUserParents
+    delete this.cachedUserParents[userId]
+    const stats = this.userStatsCache.delete(userId)
+
+    return { byId, usernameKeys, publicKey, parent, stats }
+  }
+
+  /** Drops every cached user. The username suggestions trie is kept. Returns the sizes that were dropped. */
+  public clearAll(): UserCacheStats {
+    const stats = this.stats()
+    this.cacheId = {}
+    this.cacheUsername = {}
+    this.cachedUserParents = {}
+    this.cachedPublicKeys = {}
+    this.userStatsCache.clear()
+    return stats
+  }
+
+  public stats(): UserCacheStats {
+    return {
+      byId: Object.keys(this.cacheId).length,
+      byUsername: Object.keys(this.cacheUsername).length,
+      parents: Object.keys(this.cachedUserParents).length,
+      publicKeys: Object.keys(this.cachedPublicKeys).length,
+      stats: this.userStatsCache.size,
+      usernameSuggestions: this.usernamesSuggestionsCount,
+    }
+  }
+
+  public inspect(userId: number): UserCacheInspection {
+    const byId = this.cacheId[userId]
+    const usernameKeys = Object.entries(this.cacheUsername)
+      .filter(([, user]) => user.id === userId)
+      .map(([username]) => username)
+    const consistent = usernameKeys.every((username) => this.cacheUsername[username] === byId)
+    return {
+      byId,
+      usernameKeys,
+      consistent,
+      publicKeyCached: userId in this.cachedPublicKeys,
+      parentCached: userId in this.cachedUserParents,
+      statsCached: this.userStatsCache.has(userId),
+    }
   }
 
   private cache(user: UserInfo) {
@@ -183,6 +273,7 @@ export class UserCache {
   }
 
   addUsernameSuggestion(username) {
+    this.usernamesSuggestionsCount++
     return this.usernamesSuggestionsCache.add({ k: username.toLowerCase(), v: username })
   }
 

--- a/backend/src/managers/UserCache.ts
+++ b/backend/src/managers/UserCache.ts
@@ -43,6 +43,8 @@ export class UserCache {
   private initializedState: Promise<void> | boolean = false
   private cacheId: Record<number, UserInfo> = {}
   private cacheUsername: Record<string, UserInfo> = {}
+  /** reverse index of cacheUsername: every key that has pointed at a user id, so eviction stays O(1) */
+  private usernameKeysById = new Map<number, Set<string>>()
   private cachedUserParents: Record<number, number | undefined | false> = {}
   private cachedPublicKeys: Record<number, string | undefined> = {}
   private usernamesSuggestionsCache = UserCache.createSuggestionsTrie()
@@ -150,11 +152,16 @@ export class UserCache {
     delete this.cacheId[userId]
 
     const usernameKeys: string[] = []
-    for (const [username, user] of Object.entries(this.cacheUsername)) {
-      if (user.id === userId) {
-        usernameKeys.push(username)
-        delete this.cacheUsername[username]
+    const keys = this.usernameKeysById.get(userId)
+    if (keys) {
+      for (const username of keys) {
+        // a key can have been taken over by another user since (rename collisions); leave those alone
+        if (this.cacheUsername[username] !== undefined && this.cacheUsername[username].id === userId) {
+          usernameKeys.push(username)
+          delete this.cacheUsername[username]
+        }
       }
+      this.usernameKeysById.delete(userId)
     }
 
     const publicKey = userId in this.cachedPublicKeys
@@ -171,6 +178,7 @@ export class UserCache {
     const stats = this.stats()
     this.cacheId = {}
     this.cacheUsername = {}
+    this.usernameKeysById.clear()
     this.cachedUserParents = {}
     this.cachedPublicKeys = {}
     this.userStatsCache.clear()
@@ -190,9 +198,12 @@ export class UserCache {
 
   public inspect(userId: number): UserCacheInspection {
     const byId = this.cacheId[userId]
-    const usernameKeys = Object.entries(this.cacheUsername)
-      .filter(([, user]) => user.id === userId)
-      .map(([username]) => username)
+    const keys = this.usernameKeysById.get(userId)
+    const usernameKeys = keys
+      ? Array.from(keys).filter(
+          (username) => this.cacheUsername[username] !== undefined && this.cacheUsername[username].id === userId,
+        )
+      : []
     const consistent = usernameKeys.every((username) => this.cacheUsername[username] === byId)
     return {
       byId,
@@ -207,6 +218,12 @@ export class UserCache {
   private cache(user: UserInfo) {
     this.cacheId[user.id] = user
     this.cacheUsername[user.username] = user
+    let keys = this.usernameKeysById.get(user.id)
+    if (!keys) {
+      keys = new Set()
+      this.usernameKeysById.set(user.id, keys)
+    }
+    keys.add(user.username)
   }
 
   public async getByUsername(username: string): Promise<UserInfo | undefined> {

--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -181,8 +181,10 @@ export default class UserManager {
 
   /**
    * Deletes the Redis caches derived from karma votes and activity for one user. With asVoter, also
-   * the vote caches of everyone this user has karma-voted: those are keyed by voter username and go
-   * stale on a rename. karma_penalty_* is state set by hand, never a cache, and is left alone.
+   * `active_karma_votes_<targetId>` of everyone this user has karma-voted: that value is a
+   * `Record<voterUsername, vote>`, so it goes stale when the voter is renamed. `trial_progress_*`
+   * of those targets is a plain number derived from the votes and is left alone.
+   * karma_penalty_* is state set by hand, never a cache, and is never touched.
    * Returns the keys that actually existed.
    */
   public async evictKarmaCaches(userId: number, asVoter = false): Promise<string[]> {
@@ -194,7 +196,7 @@ export default class UserManager {
     ]
     if (asVoter) {
       for (const targetId of await this.voteRepository.getKarmaVoteTargetIds(userId)) {
-        keys.push(`active_karma_votes_${targetId}`, `trial_progress_${targetId}`)
+        keys.push(`active_karma_votes_${targetId}`)
       }
     }
     const deleted: string[] = []

--- a/backend/src/managers/UserManager.ts
+++ b/backend/src/managers/UserManager.ts
@@ -18,7 +18,7 @@ import TheParser from '../parser/TheParser'
 import { sendResetPasswordEmail } from '../utils/Mailer'
 import NotificationManager from './NotificationManager'
 import { UserGender, UserInfo, UserRatingBySubsite, UserRestrictions, UserStats } from './types/UserInfo'
-import { UserCache } from './UserCache'
+import { UserCache, UserCacheEviction, UserCacheInspection, UserCacheStats } from './UserCache'
 
 const USER_RESTRICTIONS = {
   MIN_KARMA: -1000,
@@ -122,6 +122,106 @@ export default class UserManager {
 
   public clearUserRestrictionsCache(userId: number) {
     this.userRestrictionsCache.delete(userId)
+  }
+
+  /** Evicts one user from every in-memory cache this manager owns: identity, restrictions, last visit. */
+  public evictUserCaches(userId: number): UserCacheEviction & { restrictions: boolean; lastVisit: boolean } {
+    const identity = this.userCache.clearCache(userId)
+    const restrictions = this.userRestrictionsCache.delete(userId)
+    const lastVisit = userId in this.cacheLastVisit
+    delete this.cacheLastVisit[userId]
+    return { ...identity, restrictions, lastVisit }
+  }
+
+  /** Drops every in-memory user cache. The username suggestions trie is kept, see rebuildUsernameSuggestions. */
+  public clearAllCaches(): UserCacheStats & { restrictions: number; lastVisit: number } {
+    const identity = this.userCache.clearAll()
+    const restrictions = this.userRestrictionsCache.size
+    this.userRestrictionsCache.clear()
+    const lastVisit = Object.keys(this.cacheLastVisit).length
+    this.cacheLastVisit = {}
+    this.cachedNumActiveUsersThatCanVote.lastUpdateTs = 0
+    return { ...identity, restrictions, lastVisit }
+  }
+
+  public userCacheStats(): UserCacheStats & { restrictions: number; lastVisit: number } {
+    return {
+      ...this.userCache.stats(),
+      restrictions: this.userRestrictionsCache.size,
+      lastVisit: Object.keys(this.cacheLastVisit).length,
+    }
+  }
+
+  public inspectUserCache(
+    userId: number,
+  ): UserCacheInspection & { restrictionsCached: boolean; lastVisitCached: boolean } {
+    return {
+      ...this.userCache.inspect(userId),
+      restrictionsCached: this.userRestrictionsCache.has(userId),
+      lastVisitCached: userId in this.cacheLastVisit,
+    }
+  }
+
+  /** Reads the user straight from the DB, bypassing every cache. */
+  public async getUserInfoFromDb(userId: number): Promise<UserInfo | undefined> {
+    const raw = await this.userRepository.getUserById(userId)
+    return raw ? this.userCache.mapUserRaw(raw) : undefined
+  }
+
+  public rebuildUsernameSuggestions(): Promise<number> {
+    return this.userCache.rebuildUsernameSuggestions()
+  }
+
+  static readonly KARMA_CACHE_KEY_PATTERNS = [
+    'active_karma_votes_*',
+    'trial_progress_*',
+    'remove_votes_when_karma_is_low_*',
+    'is_user_active_*',
+  ]
+
+  /**
+   * Deletes the Redis caches derived from karma votes and activity for one user. With asVoter, also
+   * the vote caches of everyone this user has karma-voted: those are keyed by voter username and go
+   * stale on a rename. karma_penalty_* is state set by hand, never a cache, and is left alone.
+   * Returns the keys that actually existed.
+   */
+  public async evictKarmaCaches(userId: number, asVoter = false): Promise<string[]> {
+    const keys = [
+      `active_karma_votes_${userId}`,
+      `trial_progress_${userId}`,
+      `remove_votes_when_karma_is_low_${userId}`,
+      `is_user_active_${userId}`,
+    ]
+    if (asVoter) {
+      for (const targetId of await this.voteRepository.getKarmaVoteTargetIds(userId)) {
+        keys.push(`active_karma_votes_${targetId}`, `trial_progress_${targetId}`)
+      }
+    }
+    const deleted: string[] = []
+    for (const key of keys) {
+      if (await this.redis.del(key)) {
+        deleted.push(key)
+      }
+    }
+    return deleted
+  }
+
+  /** Deletes every key of the karma cache families (KARMA_CACHE_KEY_PATTERNS). Returns counts per pattern. */
+  public async evictAllKarmaCaches(): Promise<Record<string, number>> {
+    const deleted: Record<string, number> = {}
+    for (const pattern of UserManager.KARMA_CACHE_KEY_PATTERNS) {
+      let count = 0
+      let cursor = 0
+      do {
+        const reply = await this.redis.scan(cursor, { MATCH: pattern, COUNT: 200 })
+        cursor = reply.cursor
+        if (reply.keys.length) {
+          count += await this.redis.del(reply.keys)
+        }
+      } while (cursor !== 0)
+      deleted[pattern] = count
+    }
+    return deleted
   }
 
   async getByUsername(username: string): Promise<UserInfo | undefined> {

--- a/backend/src/session/Session.ts
+++ b/backend/src/session/Session.ts
@@ -208,6 +208,13 @@ export default class Session {
   async store() {
     if (!this.id) return
 
+    if (this.data.userId) {
+      // The login path is init() -> data.userId = ... -> store(); restore() only indexes sessions it
+      // re-reads from the DB. Index here too, so per-user eviction and destroyAllForCurrentUser()
+      // see sessions created since the last restart.
+      addToUserSessions(this.data.userId, this.id)
+    }
+
     const data = {
       userId: this.data.userId,
     }

--- a/backend/src/session/Session.ts
+++ b/backend/src/session/Session.ts
@@ -25,6 +25,9 @@ function deleteFromUserSessions(userId: number, sessionId: string) {
   const userSessions = sessionsByUser.get(userId)
   if (userSessions) {
     userSessions.delete(sessionId)
+    if (userSessions.size === 0) {
+      sessionsByUser.delete(userId)
+    }
   }
 }
 

--- a/backend/src/session/Session.ts
+++ b/backend/src/session/Session.ts
@@ -28,6 +28,43 @@ function deleteFromUserSessions(userId: number, sessionId: string) {
   }
 }
 
+/**
+ * Drops the in-memory copies of a user's sessions. Rows in the `sessions` table are left alone:
+ * pair this with a DB delete to force a logout. The process keeps honouring cached sessions
+ * until they are evicted here, so a DB-only cleanup is not enough.
+ */
+export function evictSessionsFromMemory(userId: number): number {
+  const userSessions = sessionsByUser.get(userId)
+  if (!userSessions) {
+    return 0
+  }
+  let evicted = 0
+  for (const sessionId of userSessions) {
+    if (sessionStorage[sessionId]) {
+      delete sessionStorage[sessionId]
+      evicted++
+    }
+  }
+  sessionsByUser.delete(userId)
+  return evicted
+}
+
+export function evictSessionFromMemory(sessionId: string): boolean {
+  const cached = sessionStorage[sessionId]
+  if (!cached) {
+    return false
+  }
+  delete sessionStorage[sessionId]
+  if (cached.data.userId) {
+    deleteFromUserSessions(cached.data.userId, sessionId)
+  }
+  return true
+}
+
+export function sessionMemoryStats(): { sessions: number; users: number } {
+  return { sessions: Object.keys(sessionStorage).length, users: sessionsByUser.size }
+}
+
 export default class Session {
   private request: Request
   private response: Response

--- a/backend/test/admin/AdminServer.test.ts
+++ b/backend/test/admin/AdminServer.test.ts
@@ -1,0 +1,207 @@
+import http from 'http'
+import { AddressInfo } from 'net'
+
+import { NextFunction, Request, Response } from 'express'
+import winston from 'winston'
+
+import { AdminDeps, createAdminApp, isLoopbackAddress, loopbackOnly } from '../../src/admin/AdminServer'
+
+const logger = winston.createLogger({ silent: true })
+
+function makeDeps() {
+  const deps = {
+    userManager: {
+      getByUsername: jest.fn(async (username: string) => (username === 'Dobrokot' ? { id: 1625 } : undefined)),
+      userCacheStats: jest.fn(() => ({ byId: 3, byUsername: 4 })),
+      inspectUserCache: jest.fn(() => ({
+        byId: { id: 1625, username: 'Stervo' },
+        usernameKeys: ['Dobrokot', 'Stervo'],
+        consistent: false,
+      })),
+      getUserInfoFromDb: jest.fn(async () => ({ id: 1625, username: 'Stervo' })),
+      evictUserCaches: jest.fn(() => ({
+        byId: true,
+        usernameKeys: ['Dobrokot'],
+        restrictions: false,
+        lastVisit: true,
+      })),
+      clearAllCaches: jest.fn(() => ({ byId: 3 })),
+      rebuildUsernameSuggestions: jest.fn(async () => 2222),
+      evictKarmaCaches: jest.fn(async () => ['active_karma_votes_1625']),
+      evictAllKarmaCaches: jest.fn(async () => ({ 'active_karma_votes_*': 2 })),
+    },
+    siteManager: { clearCache: jest.fn(() => 2), cacheStats: jest.fn(() => ({ byName: 1, byId: 1 })) },
+    feedManager: { clearUserSubscriptionsCache: jest.fn(() => 1), userSubscriptionsCacheStats: jest.fn(() => 5) },
+    postManager: {
+      clearContentNumberCache: jest.fn(() => ({ posts: 1, comments: 0 })),
+      contentNumberCacheStats: jest.fn(() => ({ posts: 2, comments: 2 })),
+    },
+    inviteManager: { clearInvitesAvailabilityCache: jest.fn(() => 0), invitesAvailabilityCacheStats: jest.fn(() => 0) },
+  }
+  return deps
+}
+
+type Reply = { status: number; body: { result: string; payload?: any; code?: string; message?: string } }
+
+function request(port: number, method: string, path: string, body?: unknown): Promise<Reply> {
+  return new Promise((resolve, reject) => {
+    const data = body === undefined ? undefined : JSON.stringify(body)
+    const req = http.request(
+      { host: '127.0.0.1', port, method, path, headers: data ? { 'Content-Type': 'application/json' } : {} },
+      (res) => {
+        let raw = ''
+        res.on('data', (chunk) => (raw += chunk))
+        res.on('end', () => resolve({ status: res.statusCode, body: JSON.parse(raw) }))
+      },
+    )
+    req.on('error', reject)
+    if (data) {
+      req.write(data)
+    }
+    req.end()
+  })
+}
+
+describe('admin server', () => {
+  let server: http.Server
+  let port: number
+  let deps: ReturnType<typeof makeDeps>
+
+  beforeEach(async () => {
+    deps = makeDeps()
+    server = http.createServer(createAdminApp(deps as unknown as AdminDeps, logger))
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    port = (server.address() as AddressInfo).port
+  })
+
+  afterEach(async () => {
+    await new Promise((resolve) => server.close(resolve))
+  })
+
+  test('GET / lists every route', async () => {
+    const reply = await request(port, 'GET', '/')
+    expect(reply.status).toBe(200)
+    const paths = reply.body.payload.routes.map((route) => `${route.method} ${route.path}`)
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        'GET /cache/stats',
+        'GET /cache/users/inspect',
+        'POST /cache/users/evict',
+        'POST /cache/usernames/rebuild',
+        'POST /cache/karma/evict',
+        'POST /cache/sessions/evict',
+      ]),
+    )
+  })
+
+  test('evicting by username resolves through the cache and fans out to every per-user cache', async () => {
+    const reply = await request(port, 'POST', '/cache/users/evict', { username: 'Dobrokot' })
+    expect(reply.status).toBe(200)
+    expect(reply.body.payload).toEqual({
+      userId: 1625,
+      user: { byId: true, usernameKeys: ['Dobrokot'], restrictions: false, lastVisit: true },
+      feedSubscriptions: 1,
+      contentCounters: { posts: 1, comments: 0 },
+      invitesAvailability: 0,
+    })
+    expect(deps.userManager.evictUserCaches).toHaveBeenCalledWith(1625)
+    expect(deps.feedManager.clearUserSubscriptionsCache).toHaveBeenCalledWith(1625)
+    expect(deps.postManager.clearContentNumberCache).toHaveBeenCalledWith(1625)
+    expect(deps.inviteManager.clearInvitesAvailabilityCache).toHaveBeenCalledWith(1625)
+  })
+
+  test('an unknown username is a 404, missing params are a 400', async () => {
+    expect((await request(port, 'POST', '/cache/users/evict', { username: 'nobody' })).status).toBe(404)
+    expect((await request(port, 'POST', '/cache/users/evict', {})).status).toBe(400)
+    expect((await request(port, 'POST', '/cache/users/evict', { userId: 1, username: 'x' })).status).toBe(400)
+    expect(deps.userManager.evictUserCaches).not.toHaveBeenCalled()
+  })
+
+  test('inspect reports drift between the cache and the DB', async () => {
+    const reply = await request(port, 'GET', '/cache/users/inspect?userId=1625')
+    expect(reply.status).toBe(200)
+    expect(reply.body.payload.drift).toBe(true)
+    expect(reply.body.payload.cache.consistent).toBe(false)
+    expect(deps.userManager.getUserInfoFromDb).toHaveBeenCalledWith(1625)
+  })
+
+  test('karma eviction passes asVoter through and defaults it to false', async () => {
+    await request(port, 'POST', '/cache/karma/evict', { userId: 7, asVoter: true })
+    expect(deps.userManager.evictKarmaCaches).toHaveBeenLastCalledWith(7, true)
+    await request(port, 'POST', '/cache/karma/evict', { userId: 7 })
+    expect(deps.userManager.evictKarmaCaches).toHaveBeenLastCalledWith(7, false)
+  })
+
+  test('trie rebuild and site eviction return their counts', async () => {
+    expect((await request(port, 'POST', '/cache/usernames/rebuild')).body.payload).toEqual({ usernames: 2222 })
+    expect((await request(port, 'POST', '/cache/sites/evict', { site: 'main' })).body.payload).toEqual({ removed: 2 })
+    expect(deps.siteManager.clearCache).toHaveBeenCalledWith({ siteId: undefined, site: 'main' })
+    expect((await request(port, 'POST', '/cache/sites/evict-all')).body.payload).toEqual({ removed: 2 })
+    expect(deps.siteManager.clearCache).toHaveBeenLastCalledWith()
+  })
+
+  test('stats aggregates every cache', async () => {
+    const reply = await request(port, 'GET', '/cache/stats')
+    expect(reply.body.payload).toMatchObject({
+      users: { byId: 3 },
+      sites: { byName: 1 },
+      feedSubscriptions: 5,
+      contentCounters: { posts: 2 },
+      sessions: { sessions: expect.any(Number) },
+    })
+  })
+
+  test('unknown endpoints and malformed JSON get JSON errors', async () => {
+    expect((await request(port, 'POST', '/cache/nope')).status).toBe(404)
+    const bad = await new Promise<number>((resolve, reject) => {
+      const req = http.request(
+        {
+          host: '127.0.0.1',
+          port,
+          method: 'POST',
+          path: '/cache/users/evict',
+          headers: { 'Content-Type': 'application/json' },
+        },
+        (res) => {
+          res.resume()
+          res.on('end', () => resolve(res.statusCode))
+        },
+      )
+      req.on('error', reject)
+      req.end('{not json')
+    })
+    expect(bad).toBe(400)
+  })
+})
+
+describe('loopback guard', () => {
+  test('recognises loopback peers only', () => {
+    expect(isLoopbackAddress('127.0.0.1')).toBe(true)
+    expect(isLoopbackAddress('::1')).toBe(true)
+    expect(isLoopbackAddress('::ffff:127.0.0.1')).toBe(true)
+    expect(isLoopbackAddress('172.18.0.5')).toBe(false)
+    expect(isLoopbackAddress(undefined)).toBe(false)
+  })
+
+  test('rejects a non-loopback peer with 403 and never calls next', () => {
+    const middleware = loopbackOnly(logger)
+    const json = jest.fn()
+    const status = jest.fn(() => ({ json }))
+    const next = jest.fn()
+    middleware(
+      { socket: { remoteAddress: '172.18.0.5' }, url: '/cache/stats' } as unknown as Request,
+      { status } as unknown as Response,
+      next as NextFunction,
+    )
+    expect(status).toHaveBeenCalledWith(403)
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ code: 'forbidden' }))
+    expect(next).not.toHaveBeenCalled()
+
+    middleware(
+      { socket: { remoteAddress: '::1' }, url: '/' } as unknown as Request,
+      { status } as unknown as Response,
+      next,
+    )
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+})

--- a/backend/test/admin/AdminServer.test.ts
+++ b/backend/test/admin/AdminServer.test.ts
@@ -205,3 +205,24 @@ describe('loopback guard', () => {
     expect(next).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('admin server logging', () => {
+  test('session ids are masked in the log line but used in full', async () => {
+    const spy = { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+    const server = http.createServer(
+      createAdminApp(makeDeps() as unknown as AdminDeps, spy as unknown as winston.Logger),
+    )
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const port = (server.address() as AddressInfo).port
+    try {
+      const reply = await request(port, 'POST', '/cache/sessions/evict', { sessionId: 'abcdef0123456789abcdef' })
+      expect(reply.status).toBe(200)
+      expect(spy.info).toHaveBeenCalledWith(
+        'POST /cache/sessions/evict',
+        expect.objectContaining({ params: { sessionId: 'abcdef…' } }),
+      )
+    } finally {
+      await new Promise((resolve) => server.close(resolve))
+    }
+  })
+})

--- a/backend/test/managers/UserCache.test.ts
+++ b/backend/test/managers/UserCache.test.ts
@@ -41,6 +41,23 @@ describe('UserCache eviction', () => {
     expect(cache.stats()).toMatchObject({ byId: 0, byUsername: 0 })
   })
 
+  test('clearCache leaves a username key alone once another user owns it', async () => {
+    const repository = makeRepository([])
+    const cache = new UserCache(repository as unknown as UserRepository)
+    repository.getUserByUsername.mockResolvedValueOnce(raw(1, 'Taken'))
+    await cache.getByUsername('Taken')
+    // user 1 gave the name up and user 2 took it; a lookup of user 2 now caches it under the same key
+    repository.getUserById.mockResolvedValueOnce(raw(2, 'Taken'))
+    await cache.getById(2)
+
+    expect(cache.inspect(1).usernameKeys).toEqual([])
+    expect(cache.inspect(2).usernameKeys).toEqual(['Taken'])
+    expect(cache.clearCache(1).usernameKeys).toEqual([])
+    await expect(cache.getByUsername('Taken')).resolves.toMatchObject({ id: 2 })
+    expect(cache.clearCache(2).usernameKeys).toEqual(['Taken'])
+    expect(cache.stats()).toMatchObject({ byId: 0, byUsername: 0 })
+  })
+
   test('clearAll drops everything and reports what was there', async () => {
     const repository = makeRepository([])
     const cache = new UserCache(repository as unknown as UserRepository)

--- a/backend/test/managers/UserCache.test.ts
+++ b/backend/test/managers/UserCache.test.ts
@@ -1,0 +1,79 @@
+import UserRepository from '../../src/db/repositories/UserRepository'
+import { UserRaw } from '../../src/db/types/UserRaw'
+import { UserCache } from '../../src/managers/UserCache'
+
+function raw(userId: number, username: string): UserRaw {
+  return { user_id: userId, username, gender: 0, karma: 0, name: username, ontrial: 0 } as unknown as UserRaw
+}
+
+function makeRepository(usernames: string[]) {
+  return {
+    getUserCount: jest.fn(async () => usernames.length),
+    getUsernames: jest.fn(async () => usernames.map((username) => ({ username }))),
+    getLastActiveUsers: jest.fn(async () => []),
+    getUserById: jest.fn(),
+    getUserByUsername: jest.fn(),
+    getUsersByIds: jest.fn(async () => []),
+  }
+}
+
+describe('UserCache eviction', () => {
+  test('clearCache removes username keys orphaned by a rename', async () => {
+    const repository = makeRepository(['Dobrokot'])
+    const cache = new UserCache(repository as unknown as UserRepository)
+
+    repository.getUserByUsername.mockResolvedValueOnce(raw(1625, 'Dobrokot'))
+    await cache.getByUsername('Dobrokot')
+    // the DB row is renamed; a lookup by the new name replaces the id entry but leaves the old key behind
+    repository.getUserByUsername.mockResolvedValueOnce(raw(1625, 'Stervo'))
+    await cache.getByUsername('Stervo')
+
+    const before = cache.inspect(1625)
+    expect(before.usernameKeys.sort()).toEqual(['Dobrokot', 'Stervo'])
+    expect(before.consistent).toBe(false)
+
+    const eviction = cache.clearCache(1625)
+    expect(eviction.byId).toBe(true)
+    expect(eviction.usernameKeys.sort()).toEqual(['Dobrokot', 'Stervo'])
+
+    repository.getUserByUsername.mockResolvedValueOnce(undefined)
+    await expect(cache.getByUsername('Dobrokot')).resolves.toBeUndefined()
+    expect(cache.stats()).toMatchObject({ byId: 0, byUsername: 0 })
+  })
+
+  test('clearAll drops everything and reports what was there', async () => {
+    const repository = makeRepository([])
+    const cache = new UserCache(repository as unknown as UserRepository)
+    repository.getUserByUsername.mockResolvedValueOnce(raw(1, 'a')).mockResolvedValueOnce(raw(2, 'b'))
+    await cache.getByUsername('a')
+    await cache.getByUsername('b')
+    cache.cacheUserStats(1, { notifications: 0, watch: { posts: 0, comments: 0 } } as never)
+
+    expect(cache.clearAll()).toMatchObject({ byId: 2, byUsername: 2, stats: 1 })
+    expect(cache.stats()).toMatchObject({ byId: 0, byUsername: 0, stats: 0 })
+  })
+})
+
+describe('UserCache username suggestions', () => {
+  test('rebuild replaces the trie instead of growing it', async () => {
+    const repository = makeRepository(['Dobrokot', 'Aivean'])
+    const cache = new UserCache(repository as unknown as UserRepository)
+    await expect(cache.rebuildUsernameSuggestions()).resolves.toBe(2)
+    expect(cache.getUsernameSuggestion('dob').map((entry) => entry.v)).toEqual(['Dobrokot'])
+
+    repository.getUsernames.mockResolvedValue([{ username: 'Stervo' }, { username: 'Aivean' }])
+    await expect(cache.rebuildUsernameSuggestions()).resolves.toBe(2)
+    expect(cache.getUsernameSuggestion('dob')).toEqual([])
+    expect(cache.getUsernameSuggestion('ste').map((entry) => entry.v)).toEqual(['Stervo'])
+    expect(cache.stats().usernameSuggestions).toBe(2)
+  })
+
+  test('registration keeps adding to the current trie', async () => {
+    const repository = makeRepository([])
+    const cache = new UserCache(repository as unknown as UserRepository)
+    await cache.rebuildUsernameSuggestions()
+    cache.addUsernameSuggestion('Newcomer')
+    expect(cache.getUsernameSuggestion('new').map((entry) => entry.v)).toEqual(['Newcomer'])
+    expect(cache.stats().usernameSuggestions).toBe(1)
+  })
+})

--- a/backend/test/session/SessionMemory.test.ts
+++ b/backend/test/session/SessionMemory.test.ts
@@ -41,7 +41,6 @@ describe('in-memory session eviction', () => {
     expect(sessionMemoryStats()).toMatchObject({ sessions: 1, users: 1 })
     expect(evictSessionsFromMemory(6)).toBe(1)
   })
-})
 
   test('sessions created through the login path are indexed and evictable by user id', async () => {
     const db = { fetchOne: jest.fn(), query: jest.fn().mockResolvedValue(undefined) }

--- a/backend/test/session/SessionMemory.test.ts
+++ b/backend/test/session/SessionMemory.test.ts
@@ -42,3 +42,23 @@ describe('in-memory session eviction', () => {
     expect(evictSessionsFromMemory(6)).toBe(1)
   })
 })
+
+  test('sessions created through the login path are indexed and evictable by user id', async () => {
+    const db = { fetchOne: jest.fn(), query: jest.fn().mockResolvedValue(undefined) }
+    const request = { header: () => undefined } as unknown as Request
+    const response = { setHeader: jest.fn() } as unknown as Response
+    const session = new Session(db as unknown as DB, logger, request, response)
+    const sessionId = await session.init()
+    session.data.userId = 7
+    await session.store()
+    expect(db.query).toHaveBeenCalledTimes(1)
+
+    expect(sessionMemoryStats()).toMatchObject({ sessions: 1, users: 1 })
+    db.fetchOne.mockResolvedValue(undefined)
+    expect((await restore(db, sessionId)).data.userId).toBe(7)
+
+    expect(evictSessionsFromMemory(7)).toBe(1)
+    expect((await restore(db, sessionId)).data.userId).toBeFalsy()
+    expect(sessionMemoryStats()).toMatchObject({ sessions: 0, users: 0 })
+  })
+})

--- a/backend/test/session/SessionMemory.test.ts
+++ b/backend/test/session/SessionMemory.test.ts
@@ -1,0 +1,44 @@
+import { Request, Response } from 'express'
+import winston from 'winston'
+
+import DB from '../../src/db/DB'
+import Session, { evictSessionFromMemory, evictSessionsFromMemory, sessionMemoryStats } from '../../src/session/Session'
+
+const logger = winston.createLogger({ silent: true })
+
+function restore(db: { fetchOne: jest.Mock }, sessionId: string) {
+  const request = { header: () => sessionId } as unknown as Request
+  const response = { setHeader: jest.fn() } as unknown as Response
+  const session = new Session(db as unknown as DB, logger, request, response)
+  return session.restore().then(() => session)
+}
+
+describe('in-memory session eviction', () => {
+  test('a session evicted from memory is re-read from the DB', async () => {
+    const db = { fetchOne: jest.fn().mockResolvedValue({ data: JSON.stringify({ userId: 5 }), used: new Date() }) }
+
+    expect((await restore(db, 'sess-a')).data.userId).toBe(5)
+    expect(sessionMemoryStats()).toMatchObject({ sessions: 1, users: 1 })
+
+    // the DB row is gone, but the process still serves the cached session
+    db.fetchOne.mockResolvedValue(undefined)
+    expect((await restore(db, 'sess-a')).data.userId).toBe(5)
+
+    expect(evictSessionsFromMemory(5)).toBe(1)
+    expect(evictSessionsFromMemory(5)).toBe(0)
+    expect((await restore(db, 'sess-a')).data.userId).toBeFalsy()
+    expect(sessionMemoryStats()).toMatchObject({ sessions: 0, users: 0 })
+  })
+
+  test('a single session can be evicted by id', async () => {
+    const db = { fetchOne: jest.fn().mockResolvedValue({ data: JSON.stringify({ userId: 6 }), used: new Date() }) }
+    await restore(db, 'sess-b')
+    await restore(db, 'sess-c')
+    expect(sessionMemoryStats()).toMatchObject({ sessions: 2, users: 1 })
+
+    expect(evictSessionFromMemory('sess-b')).toBe(true)
+    expect(evictSessionFromMemory('sess-b')).toBe(false)
+    expect(sessionMemoryStats()).toMatchObject({ sessions: 1, users: 1 })
+    expect(evictSessionsFromMemory(6)).toBe(1)
+  })
+})

--- a/backend/test/session/SessionMemory.test.ts
+++ b/backend/test/session/SessionMemory.test.ts
@@ -39,7 +39,10 @@ describe('in-memory session eviction', () => {
     expect(evictSessionFromMemory('sess-b')).toBe(true)
     expect(evictSessionFromMemory('sess-b')).toBe(false)
     expect(sessionMemoryStats()).toMatchObject({ sessions: 1, users: 1 })
-    expect(evictSessionsFromMemory(6)).toBe(1)
+    expect(evictSessionFromMemory('sess-c')).toBe(true)
+    // the last session of a user takes the index entry with it, so `users` does not over-count
+    expect(sessionMemoryStats()).toMatchObject({ sessions: 0, users: 0 })
+    expect(evictSessionsFromMemory(6)).toBe(0)
   })
 
   test('sessions created through the login path are indexed and evictable by user id', async () => {

--- a/docs/admin-server.md
+++ b/docs/admin-server.md
@@ -1,0 +1,81 @@
+# Admin cache server
+
+The backend runs a second, loopback-only HTTP server for operational cache work that cannot
+be done safely from outside the process. Source: `backend/src/admin/AdminServer.ts`.
+
+## Security model
+
+- Binds to `127.0.0.1:${ADMIN_PORT}` (default `5002`, `ADMIN_PORT=0` disables it) inside the
+  backend container. It is not published by Docker and not proxied by Caddy.
+- Reaching it therefore requires `docker exec` on the box, i.e. root access. There are no
+  credentials to configure or leak.
+- Defense in depth: a middleware rejects any request whose raw TCP peer is not a loopback
+  address (`req.socket.remoteAddress`, never `req.ip`, which honours `X-Forwarded-For`).
+- A failure to bind the admin port is logged and ignored; the public API keeps starting.
+
+## Usage
+
+```bash
+# list the routes with their descriptions
+sudo docker exec orbitar-backend-1 curl -s localhost:5002/
+
+# evict a user from every in-process cache, by id or by (possibly stale) username
+sudo docker exec orbitar-backend-1 curl -s -X POST localhost:5002/cache/users/evict \
+  -H 'Content-Type: application/json' -d '{"username":"OldName"}'
+
+# compare what the process has cached with the DB row
+sudo docker exec orbitar-backend-1 curl -s 'localhost:5002/cache/users/inspect?userId=1625'
+```
+
+Responses use the public API envelope: `{"result":"success","payload":{...}}` or
+`{"result":"error","code":"...","message":"..."}`. Every call is logged under the `ADMIN`
+service with its parameters and result.
+
+## Routes
+
+| Method | Path | Parameters | What it touches |
+| --- | --- | --- | --- |
+| GET | `/cache/stats` | | sizes of every in-process cache |
+| GET | `/cache/users/inspect` | `userId` or `username` | cached user entries next to the DB row; `drift` flags a username mismatch, `cache.consistent=false` flags an orphaned username key |
+| POST | `/cache/users/evict` | `userId` or `username` | identity (by id and by every username key pointing at it), restrictions, last visit, feed subscriptions, content counters, invite availability |
+| POST | `/cache/users/evict-all` | | all of the above for every user; the username trie is kept |
+| POST | `/cache/usernames/rebuild` | | the `@mention` autocomplete trie, reloaded from the DB and swapped atomically |
+| POST | `/cache/karma/evict` | `userId` or `username`, `asVoter` (default `false`) | Redis `active_karma_votes_<id>`, `trial_progress_<id>`, `remove_votes_when_karma_is_low_<id>`, `is_user_active_<id>`; with `asVoter` also the `active_karma_votes`/`trial_progress` of everyone the user has karma-voted |
+| POST | `/cache/karma/evict-all` | | every key of those four families, via SCAN |
+| POST | `/cache/sites/evict` | `siteId` or `site` | in-process site cache, by id and by subdomain |
+| POST | `/cache/sites/evict-all` | | the whole site cache |
+| POST | `/cache/sessions/evict` | `userId` or `sessionId` | in-memory session entries only |
+
+`username` is resolved through the user cache first and the DB second, on purpose: the usual
+reason to evict by name is that the cache still holds a name the DB no longer has.
+
+`karma_penalty_<id>` is state set by hand, not a cache, and no route touches it.
+
+## Scope rule
+
+Routes are building blocks over a single cache each, never workflows. Anything that is already
+easy with SQL or `redis-cli` stays out: data changes, re-rendering content (reset
+`parser_version` on the row and the next read re-parses it), deleting Redis keys you can name.
+The server exists only for state that lives in process memory, or that cannot be targeted
+safely from outside because it is keyed by something other than the user id.
+
+## Example: renaming a user
+
+The steps stay manual; the server just makes each cache reachable.
+
+1. `UPDATE users SET username = 'New' WHERE user_id = <id> AND username = 'Old';`
+2. `POST /cache/users/evict {"userId": <id>}` — do this **before** touching Redis. Recomputing a
+   Redis karma cache looks voters up by name, and if that happens while the process still holds
+   the old identity it leaves an orphaned old-name key behind.
+3. `POST /cache/karma/evict {"userId": <id>, "asVoter": true}` — the vote caches are keyed by
+   voter username.
+4. `POST /cache/usernames/rebuild` — the autocomplete trie only ever grows on registration.
+5. `GET /cache/users/inspect?userId=<id>` — expect `drift: false` and `cache.consistent: true`.
+
+Sessions key on the user id and survive the rename. Mentions and secret-mail envelopes inside
+stored content embed the old name; whether to rewrite those is a separate, content-level decision.
+
+## Forcing a logout
+
+Deleting rows from `sessions` is not enough: the process keeps serving the cached copy until it
+is evicted. Delete the rows, then `POST /cache/sessions/evict {"userId": <id>}`.

--- a/docs/admin-server.md
+++ b/docs/admin-server.md
@@ -40,7 +40,7 @@ service with its parameters and result.
 | POST | `/cache/users/evict` | `userId` or `username` | identity (by id and by every username key pointing at it), restrictions, last visit, feed subscriptions, content counters, invite availability |
 | POST | `/cache/users/evict-all` | | all of the above for every user; the username trie is kept |
 | POST | `/cache/usernames/rebuild` | | the `@mention` autocomplete trie, reloaded from the DB and swapped atomically |
-| POST | `/cache/karma/evict` | `userId` or `username`, `asVoter` (default `false`) | Redis `active_karma_votes_<id>`, `trial_progress_<id>`, `remove_votes_when_karma_is_low_<id>`, `is_user_active_<id>`; with `asVoter` also the `active_karma_votes`/`trial_progress` of everyone the user has karma-voted |
+| POST | `/cache/karma/evict` | `userId` or `username`, `asVoter` (default `false`) | Redis `active_karma_votes_<id>`, `trial_progress_<id>`, `remove_votes_when_karma_is_low_<id>`, `is_user_active_<id>`; with `asVoter` also `active_karma_votes_<targetId>` of everyone the user has karma-voted (its value is a map keyed by voter username, so it goes stale when the voter is renamed) |
 | POST | `/cache/karma/evict-all` | | every key of those four families, via SCAN |
 | POST | `/cache/sites/evict` | `siteId` or `site` | in-process site cache, by id and by subdomain |
 | POST | `/cache/sites/evict-all` | | the whole site cache |
@@ -67,8 +67,8 @@ The steps stay manual; the server just makes each cache reachable.
 2. `POST /cache/users/evict {"userId": <id>}` — do this **before** touching Redis. Recomputing a
    Redis karma cache looks voters up by name, and if that happens while the process still holds
    the old identity it leaves an orphaned old-name key behind.
-3. `POST /cache/karma/evict {"userId": <id>, "asVoter": true}` — the vote caches are keyed by
-   voter username.
+3. `POST /cache/karma/evict {"userId": <id>, "asVoter": true}` — `active_karma_votes_<targetId>`
+   holds a map keyed by voter username, so every target the user has voted on carries the old name.
 4. `POST /cache/usernames/rebuild` — the autocomplete trie only ever grows on registration.
 5. `GET /cache/users/inspect?userId=<id>` — expect `drift: false` and `cache.consistent: true`.
 


### PR DESCRIPTION
## Summary

- Adds a **loopback-only admin HTTP server** on `127.0.0.1:${ADMIN_PORT}` (default `5002`, `0` disables) inside the backend container. It is not published by Docker and not proxied by Caddy, so reaching it requires `docker exec` on the box. No credentials; a middleware additionally rejects any non-loopback TCP peer (checks `req.socket.remoteAddress`, not `req.ip`).
- Routes are **building blocks over single caches**, never workflows. Anything already easy with SQL or `redis-cli` (data edits, re-parsing via `parser_version`) stays out. `GET /` lists them:
  - `GET /cache/stats`, `GET /cache/users/inspect?userId=|username=` (cache vs DB, `drift` flag)
  - `POST /cache/users/evict {userId|username}`, `/cache/users/evict-all`
  - `POST /cache/usernames/rebuild` (the `@mention` autocomplete trie only grows on registration)
  - `POST /cache/karma/evict {userId|username, asVoter?}`, `/cache/karma/evict-all` (Redis `active_karma_votes_*`, `trial_progress_*`, `remove_votes_when_karma_is_low_*`, `is_user_active_*`; `karma_penalty_*` is state and is never touched)
  - `POST /cache/sites/evict {siteId|site}`, `/cache/sites/evict-all`
  - `POST /cache/sessions/evict {userId|sessionId}` (in-memory only; the `sessions` table is untouched)
- Fixes `UserCache.clearCache` to remove **every username key pointing at the id**, not only the current name. This is the orphan that survived the 2026-09-04 username rename on prod. Adds `clearAll`, `stats`, `inspect`, and an atomic trie rebuild.
- Adds per-cache clear/stats methods on `SiteManager`, `FeedManager`, `PostManager`, `InviteManager`, and in-memory session eviction helpers in `session/Session.ts`.
- **Removes the public `POST /user/clearCache`**: any logged-in user could call it, and it never sent a response (the connection hung until the client timed out). Nothing in the frontend used it.
- Docs: `docs/admin-server.md` (security model, route table, scope rule, rename and forced-logout recipes), linked from `AGENTS.md`.

## Usage

```bash
sudo docker exec orbitar-backend-1 curl -s localhost:5002/
sudo docker exec orbitar-backend-1 curl -s -X POST localhost:5002/cache/users/evict \
  -H 'Content-Type: application/json' -d '{"username":"OldName"}'
```

## Test plan

- [x] `backend`: `tsc --noEmit` clean, `eslint` 0 errors, `jest` 22 suites / 393 tests passing (16 new: admin routes and guard, `UserCache` orphan eviction and trie rebuild, session memory eviction)
- [x] staging (2026-09-04): deploy logs `Admin server is listening on 127.0.0.1:5002`; `GET /` lists the routes
- [x] staging security: host `127.0.0.1:5002` refused (port not published), sibling container `backend:5002` refused (loopback bind), public `stage-api.orbitar.space/cache/*` returns the app's 404
- [x] staging orphan reproduction: rename user 1625 in the DB, look the new name up via the public API, `inspect` shows both username keys with `consistent:false, drift:true`; `evict {username:<stale>}` removes both; the stale name then 404s on the public API; `usernames/rebuild` flips the autocomplete; name restored
- [x] staging karma: `/user/karma` populates `active_karma_votes_*`/`trial_progress_*`/`is_user_active_*`; `karma/evict` deletes the user's keys, `asVoter:true` also deletes the voted target's key, `evict-all` leaves the four families at zero
- [x] staging sessions: a session whose DB row was deleted keeps working until `sessions/evict` by `sessionId` or `userId`, after which the public API answers `auth-required`
- [x] staging errors: 400 for missing/both/typed params, 404 for unknown user and route, 400 for malformed JSON, all as JSON; `ADMIN` log lines carry params and payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrDw6xRn4hdvMeksK6oNDJ
